### PR TITLE
 Log real names instead of hashes in IdentifierHash class in Launch Manager

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Refresh compile_commands.json",
+            "type": "shell",
+            "isBackground": true,
+            "command": "bazel run @hedron_compile_commands//:refresh_all",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Refresh IntelliSense",
+            "dependsOn": [
+                "Refresh compile_commands.json"
+            ],
+            "command": "${command:clangd.restart}",
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This section contains information on how to build and use Lifecycle feature.
 * Build System: Bazel
 * Operating System: Linux (Ubuntu 22.04+)
 * Dependencies: S-Core Baselibs, Google Flatbuffers, libacl1-dev
-* Dependencies of demo applications: Docker, Python (3.12)
+* Dependencies of example applications: Docker, Python (3.12)
 
 ## Building the project
 
@@ -122,7 +122,7 @@ TODO: Currently rust binaries are not compiling for QNX.
 
 ## Running Lifecycle feature and example applications
 
-The ``demo`` folder contains a demo setup running in a docker container, consisting of a set of example applications and corresponding configuration. As per configuration, Launch Manager will start Health Monitor and a set of configured applications. For more information see [demo/README.md](demo/README.md) file.
+The ``examples`` folder contains a demo setup running in a docker container, consisting of a set of example applications and corresponding configuration. As per configuration, Launch Manager will start Health Monitor and a set of configured applications. For more information see [examples/README.md](examples/README.md) file.
 
 ## Configuration
 
@@ -444,7 +444,7 @@ Sample configuration of Health Monitor daemon:
 }
 ```
 
-Full configuration for example applications can be found in ``demo/config`` folder.
+Full configuration for example applications can be found in ``examples/config`` folder.
 
 # Architecture
 

--- a/examples/control_application/control_daemon.cpp
+++ b/examples/control_application/control_daemon.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     }
 
     score::lcm::ControlClient client([](const score::lcm::ExecutionErrorEvent& event) {
-        std::cerr << "Undefined state callback invoked for process group id: " << event.processGroup.data() << std::endl;
+        std::cerr << "Undefined state callback invoked for process group id: " << event.processGroup << std::endl;
     });
 
     score::safecpp::Scope<> scope{};

--- a/src/launch_manager_daemon/BUILD
+++ b/src/launch_manager_daemon/BUILD
@@ -12,6 +12,8 @@
 # *******************************************************************************
 load("//config:common_cc.bzl", "cc_binary_with_common_opts", "cc_library_with_common_opts")
 
+package(default_visibility = ["//tests:__subpackages__"])
+
 cc_library(
     name = "config",
     hdrs = ["config/lm_flatcfg_generated.h"],

--- a/src/launch_manager_daemon/common/src/identifier_hash.cpp
+++ b/src/launch_manager_daemon/common/src/identifier_hash.cpp
@@ -13,10 +13,13 @@
 
 #include <score/lcm/identifier_hash.hpp>
 #include <functional>
+#include <unordered_map>
 
-namespace score {
+namespace score
+{
 
-namespace lcm {
+namespace lcm
+{
 
 // Please note that a lot of the following info, would normally belong to identifier_hash.hpp file.
 // However, decision was made to publish identifier_hash.hpp alongside other headers.
@@ -55,45 +58,66 @@ namespace lcm {
 // One thing to note: hashing function is implementation specific.
 // So if this should work between different compilers, we may need to go for our own hash function.
 
-IdentifierHash::IdentifierHash(const std::string& id) {
+IdentifierHash::IdentifierHash(const std::string& id)
+{
     hash_id_ = std::hash<std::string>{}(id);
+    get_registry()[hash_id_] = id;
 }
 
-IdentifierHash::IdentifierHash(std::string_view id) {
+IdentifierHash::IdentifierHash(std::string_view id)
+{
     hash_id_ = std::hash<std::string_view>{}(id);
+    get_registry()[hash_id_] = id;
 }
 
-IdentifierHash::IdentifierHash(const char* id) {
-    hash_id_ =
-        std::hash<std::string_view>{}(id != nullptr ? std::string_view(id) : std::string_view(""));
+IdentifierHash::IdentifierHash(const char* id)
+{
+    const std::string_view sv = (id != nullptr) ? std::string_view(id) : std::string_view("");
+    hash_id_ = std::hash<std::string_view>{}(sv);
+    get_registry()[hash_id_] = sv;
 }
 
-bool IdentifierHash::operator==(const IdentifierHash& other) const {
+bool IdentifierHash::operator==(const IdentifierHash& other) const
+{
     return hash_id_ == other.hash_id_;
 }
 
-bool IdentifierHash::operator!=(const IdentifierHash& other) const {
+bool IdentifierHash::operator!=(const IdentifierHash& other) const
+{
     return !operator==(other);
 }
 
-bool IdentifierHash::operator==(const std::string_view& other) const {
+bool IdentifierHash::operator==(const std::string_view& other) const
+{
     return hash_id_ == (IdentifierHash{other}).hash_id_;
 }
 
-bool IdentifierHash::operator!=(const std::string_view& other) const {
+bool IdentifierHash::operator!=(const std::string_view& other) const
+{
     return !operator==(IdentifierHash{other});
 }
 
-bool IdentifierHash::operator<(const IdentifierHash& other) const {
+bool IdentifierHash::operator<(const IdentifierHash& other) const
+{
     return hash_id_ < other.hash_id_;
 }
 
-IdentifierHash::IdentifierHash() {
+IdentifierHash::IdentifierHash()
+{
     hash_id_ = std::hash<std::string_view>{}(std::string_view(""));
+    get_registry()[hash_id_] = "";
 }
 
-std::size_t IdentifierHash::data() const {
+std::size_t IdentifierHash::data() const
+{
     return hash_id_;
+}
+
+std::unordered_map<std::size_t, std::string>& IdentifierHash::get_registry()
+{
+    /// Static registry, which gets initialized per process.
+    static std::unordered_map<std::size_t, std::string> registry;
+    return registry;
 }
 
 }  // namespace lcm

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifexm/ProcessStateReader.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifexm/ProcessStateReader.cpp
@@ -79,8 +79,8 @@ bool ProcessStateReader::distributeChanges(const timers::NanoSecondType f_syncTi
             const auto changedPosixProcess{resultChangedProcess.value()};
             if (changedPosixProcess)
             {
-                logger_r.LogDebug() << "Process with Id" << changedPosixProcess->id.data() << "changed state PG"
-                                    << changedPosixProcess->processGroupStateId.data() << "PS"
+                logger_r.LogDebug() << "Process with Id" << changedPosixProcess->id << "changed state PG"
+                                    << changedPosixProcess->processGroupStateId << "PS"
                                     << static_cast<int>(changedPosixProcess->processStateId);
                 isPushPending = pushUpdateTill(*changedPosixProcess, f_syncTimestamp);
                 flagContinue = (!isPushPending);

--- a/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
+++ b/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
@@ -126,10 +126,10 @@ std::optional<const ProcessGroupStateID*> ConfigurationManager::getMainPGStartup
         if (pg_state) {
             result = &main_pg_startup_state_;
         } else {
-            LM_LOG_DEBUG() << "Process group state not found:" << main_pg_startup_state_.pg_state_name_.data();
+            LM_LOG_DEBUG() << "Process group state not found:" << main_pg_startup_state_.pg_state_name_;
         }
     } else {
-        LM_LOG_DEBUG() << "Process group not found:" << main_pg_startup_state_.pg_name_.data();
+        LM_LOG_DEBUG() << "Process group not found:" << main_pg_startup_state_.pg_name_;
     }
 
     return result;
@@ -154,8 +154,8 @@ std::optional<const std::vector<uint32_t>*> ConfigurationManager::getProcessInde
     if (state) {
         result = &state->process_indexes_;
     } else {
-        LM_LOG_DEBUG() << "Process group state '" << pg_state_id.pg_state_name_.data() << "' not found in group '"
-                       << pg_state_id.pg_name_.data() << "'.";
+        LM_LOG_DEBUG() << "Process group state '" << pg_state_id.pg_state_name_ << "' not found in group '"
+                       << pg_state_id.pg_name_ << "'.";
     }
 
     return result;
@@ -168,7 +168,7 @@ std::optional<const OsProcess*> ConfigurationManager::getOsProcessConfiguration(
     if (auto pg = getProcessGroupByNameAndIndex(pg_name, index)) {
         result = &(*pg)->processes_[index];
     } else {
-        LM_LOG_DEBUG() << "Unable to retrieve process configuration for process group" << pg_name.data()
+        LM_LOG_DEBUG() << "Unable to retrieve process configuration for process group" << pg_name
                        << "with index" << index;
     }
 
@@ -182,7 +182,7 @@ std::optional<const DependencyList*> ConfigurationManager::getOsProcessDependenc
     if (auto pg = getProcessGroupByNameAndIndex(pg_name, index)) {
         result = &(*pg)->processes_[index].dependencies_;
     } else {
-        LM_LOG_DEBUG() << "Unable to retrieve process dependencies for process group" << pg_name.data() << "with index"
+        LM_LOG_DEBUG() << "Unable to retrieve process dependencies for process group" << pg_name << "with index"
                        << index;
     }
 
@@ -304,7 +304,7 @@ bool ConfigurationManager::parseMachineConfigurations(const ModeGroup* node, con
         process_group_data.name_ = getStringViewFromFlatBuffer(node->identifier());
         process_group_data.sw_cluster_ = cluster;
         LM_LOG_DEBUG() << "FlatBufferParser::getModeGroupPgName:" << getStringFromFlatBuffer(node->identifier())
-                       << "( IdentifierHash:" << process_group_data.name_.data() << ")";
+                       << "( IdentifierHash:" << process_group_data.name_ << ")";
 
         if (process_group_data.name_ != score::lcm::IdentifierHash(std::string_view(""))) {
             // Add process group name to the PG name list
@@ -339,7 +339,7 @@ bool ConfigurationManager::parseModeGroups(const ModeGroup* node, ProcessGroup& 
                 pg_state.name_ = getStringViewFromFlatBuffer(flatbuffer_string);
                 LM_LOG_DEBUG() << "FlatBufferParser::getModeGroupPgStateName:"
                                << mode_declaration_node->identifier()->c_str()
-                               << "( IdentifierHash:" << pg_state.name_.data() << ")";
+                               << "( IdentifierHash:" << pg_state.name_ << ")";
                 process_group_data.states_.push_back(pg_state);
                 // Is this the "Off" state, i.e. does it end with "/Off" ?
                 auto str_len = string_name.length();
@@ -593,8 +593,8 @@ void ConfigurationManager::parseProcessGroup(
                 ProcessGroupStateID pg_info;
                 pg_info.pg_name_ = getStringViewFromFlatBuffer(process_pg_node->stateMachine_name());
                 pg_info.pg_state_name_ = getStringViewFromFlatBuffer(process_pg_node->stateName());
-                LM_LOG_DEBUG() << "ParseProcessProcessGroup: id:::pg_name_:" << pg_info.pg_name_.data()
-                               << ", pg_state_name_:" << pg_info.pg_state_name_.data();
+                LM_LOG_DEBUG() << "ParseProcessProcessGroup: id:::pg_name_:" << pg_info.pg_name_
+                               << ", pg_state_name_:" << pg_info.pg_state_name_;
 
                 // Assign OsProcess instance to the process group
                 AssignOsProcessInstanceToProcessGroup(pg_info, process_instance);
@@ -618,7 +618,7 @@ void ConfigurationManager::parseExecutionDependency(
                 dep.target_process_id_ = getStringViewFromFlatBuffer(process_dependency_node->targetProcess_identifier());
                 LM_LOG_DEBUG() << "ParseProcessExecutionDependency: target process path:"
                                 << getStringFromFlatBuffer(process_dependency_node->targetProcess_identifier())
-                                << "ID:" << dep.target_process_id_.data();
+                                << "ID:" << dep.target_process_id_;
                 process_instance.dependencies_.push_back(dep);
 
             }
@@ -715,10 +715,10 @@ void ConfigurationManager::AssignOsProcessInstanceToProcessGroup(const ProcessGr
                 state->process_indexes_.push_back(index_in_pg);
             }
         } else {
-            LM_LOG_WARN() << "Process group state not found:" << process_pg.pg_state_name_.data();
+            LM_LOG_WARN() << "Process group state not found:" << process_pg.pg_state_name_;
         }
     } else {
-        LM_LOG_WARN() << "Process group not found:", process_pg.pg_name_.data();
+        LM_LOG_WARN() << "Process group not found:" << process_pg.pg_name_;
     }
 }
 
@@ -827,10 +827,10 @@ osal::CommsType ConfigurationManager::isReportingProcess(const ExecutionStateRep
 
     if (reporting_behaviour == ExecutionStateReportingBehaviorEnum::ExecutionStateReportingBehaviorEnum_ReportsExecutionState) {
         reporting_status = osal::CommsType::kReporting;
-        LM_LOG_DEBUG() << "Process" << process_name.data() << "is Reporting execution state";
+        LM_LOG_DEBUG() << "Process" << process_name << "is Reporting execution state";
     } else {
         // ExecutionStateReportingBehaviorEnum::DoesNotReportExecutionState
-        LM_LOG_DEBUG() << "Process" << process_name.data() << "is NOT Reporting execution state";
+        LM_LOG_DEBUG() << "Process" << process_name << "is NOT Reporting execution state";
     }
 
     return reporting_status;
@@ -842,10 +842,10 @@ bool ConfigurationManager::isSelfTerminatingProcess(const TerminationBehaviorEnu
 
     if (termination_behavior == TerminationBehaviorEnum::TerminationBehaviorEnum_ProcessIsSelfTerminating) {
         termination_status = true;
-        LM_LOG_DEBUG() << "Process" << process_name.data() << "is Self terminating";
+        LM_LOG_DEBUG() << "Process" << process_name << "is Self terminating";
     } else {
         // TerminationBehaviorEnum::ProcessIsNotSelfTerminating
-        LM_LOG_DEBUG() << "Process" << process_name.data() << "is NOT Self terminating";
+        LM_LOG_DEBUG() << "Process" << process_name << "is NOT Self terminating";
     }
 
     return termination_status;
@@ -861,10 +861,10 @@ std::optional<const ProcessGroup*> ConfigurationManager::getProcessGroupByNameAn
         if (index < pg->processes_.size()) {
             result = pg;
         } else {
-            LM_LOG_DEBUG() << "Process index" << index << "is out of bounds in process group" << pg_name.data();
+            LM_LOG_DEBUG() << "Process index" << index << "is out of bounds in process group" << pg_name;
         }
     } else {
-        LM_LOG_DEBUG() << "Process group not found:" << pg_name.data();
+        LM_LOG_DEBUG() << "Process group not found:" << pg_name;
     }
 
     return result;

--- a/src/launch_manager_daemon/src/process_group_manager/graph.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/graph.cpp
@@ -62,7 +62,7 @@ void Graph::initProcessGroupNodes( IdentifierHash pg_name, uint32_t num_processe
     requested_state_.pg_state_name_ = off_state_;
     requested_state_.pg_name_ = pg_name;
 
-    LM_LOG_DEBUG() << "Process group index" << index << "(with name" << pg_name.data() << ") has" << num_processes
+    LM_LOG_DEBUG() << "Process group index" << index << "(with name" << pg_name << ") has" << num_processes
                    << "processes";
 
     createProcessInfoNodes(num_processes);
@@ -84,7 +84,7 @@ inline void Graph::createProcessInfoNodes(uint32_t num_processes) {
 }
 
 inline void Graph::createSuccessorLists(IdentifierHash pg_name) {
-    LM_LOG_DEBUG() << "Creating successor lists for process group" << pg_name.data();
+    LM_LOG_DEBUG() << "Creating successor lists for process group" << pg_name;
 
     // Now create the successor lists for each process in this process group
     for (auto& node : nodes_) {
@@ -128,7 +128,7 @@ void Graph::setState(GraphState new_state) {
             if (state_.compare_exchange_strong(old_state, target_state)) {
                 LM_LOG_DEBUG() << "Graph::setState changes from" << toString(old_state) << "to"
                                << toString(target_state) << "for PG" << pg_index_ << "("
-                               << requested_state_.pg_name_.data() << ")";
+                               << requested_state_.pg_name_ << ")";
                 old_state = target_state;
 
                 if (new_state == GraphState::kSuccess) {
@@ -139,8 +139,8 @@ void Graph::setState(GraphState new_state) {
                     auto timeDiff =
                         std::chrono::duration_cast<std::chrono::milliseconds>(request_end_time - getRequestStartTime());
 
-                    LM_LOG_INFO() << "Completed the request for PG" << getProcessGroupName().data() << "to State"
-                                  << getProcessGroupState().data() << "in" << timeDiff.count() << "ms";
+                    LM_LOG_INFO() << "Completed the request for PG" << getProcessGroupName() << "to State"
+                                  << getProcessGroupState() << "in" << timeDiff.count() << "ms";
                 }
             }
         }
@@ -440,8 +440,8 @@ IdentifierHash Graph::setPendingState(IdentifierHash new_state) {
     pending_state_ = new_state;
 
     if (new_state != result_state) {
-        LM_LOG_DEBUG() << "Pending state for process group" << requested_state_.pg_name_.data() << "changed from"
-                       << result_state.data() << "to" << pending_state_.data();
+        LM_LOG_DEBUG() << "Pending state for process group" << requested_state_.pg_name_ << "changed from"
+                       << result_state << "to" << pending_state_;
     }
 
     return result_state;

--- a/src/launch_manager_daemon/src/process_group_manager/processgroupmanager.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processgroupmanager.cpp
@@ -363,8 +363,8 @@ bool ProcessGroupManager::sendResponse(ControlClientMessage msg) {
             LM_LOG_DEBUG() << "ProcessGroupManager::ControlClientHandler: Sending"
                            << scc->toString(msg.request_or_response_) << "("
                            << static_cast<int>(msg.request_or_response_) << ") re state"
-                           << msg.process_group_state_.pg_state_name_.data() << "of PG"
-                           << msg.process_group_state_.pg_name_.data();
+                           << msg.process_group_state_.pg_state_name_ << "of PG"
+                           << msg.process_group_state_.pg_name_;
             ret = scc->sendResponse(msg);
             if (!ret) {
                 ControlClientChannel::nudgeControlClientHandler();
@@ -395,8 +395,8 @@ inline void ProcessGroupManager::controlClientRequests(Graph& pg) {
                 LM_LOG_DEBUG() << "ProcessGroupManager::ControlClientHandler: got request"
                                << scc->toString(scc->request().request_or_response_) << "("
                                << static_cast<int>(scc->request().request_or_response_) << ") re state"
-                               << scc->request().process_group_state_.pg_state_name_.data() << "of PG"
-                               << scc->request().process_group_state_.pg_name_.data();
+                               << scc->request().process_group_state_.pg_state_name_ << "of PG"
+                               << scc->request().process_group_state_.pg_name_;
 
                 // Now process the request
                 switch (scc->request().request_or_response_) {
@@ -583,7 +583,7 @@ inline void ProcessGroupManager::processGroupHandler(Graph& pg) {
         if ((pgs.pg_state_name_ != IdentifierHash("")) &&
             ((pgs.pg_state_name_ != pg.getProcessGroupState()) || (GraphState::kUndefinedState == graph_state))) {
             pgs.pg_name_ = pg.getProcessGroupName();
-            LM_LOG_DEBUG() << "Start transition to" << pgs.pg_state_name_.data() << "for PG" << pgs.pg_name_.data();
+            LM_LOG_DEBUG() << "Start transition to" << pgs.pg_state_name_ << "for PG" << pgs.pg_name_;
 
             if (!pg.startTransition(pgs)) {
                 pg.setPendingEvent(ControlClientCode::kSetStateInvalidArguments);
@@ -607,7 +607,7 @@ inline void ProcessGroupManager::processGroupHandler(Graph& pg) {
             recovery_state.pg_state_name_ = configuration_manager_.getNameOfRecoveryState(recovery_state.pg_name_);
 
             LM_LOG_WARN() << "Problem discovered in PG"
-                          << recovery_state.pg_name_.data()
+                          << recovery_state.pg_name_
                           << "Activating Recovery state.";
 
             // no point checking errors here...

--- a/src/launch_manager_daemon/src/process_group_manager/processinfonode.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processinfonode.cpp
@@ -48,7 +48,7 @@ void ProcessInfoNode::initNode(Graph* graph, uint32_t index) {
                 LM_LOG_DEBUG() << "Process" << process_index_ << "has" << start_dependencies_ << "start dependencies";
             }
         } else {
-            LM_LOG_ERROR() << "No configuration for process" << process_index_ << "of process group" << pg.data();
+            LM_LOG_ERROR() << "No configuration for process" << process_index_ << "of process group" << pg;
         }
     }
 }
@@ -202,7 +202,7 @@ void ProcessInfoNode::unexpectedTermination() {
 }
 
 void ProcessInfoNode::terminated(int32_t process_status) {
-    LM_LOG_DEBUG() << "Child process" << process_index_ << "of" << graph_->getProcessGroupName().data() << "pid"
+    LM_LOG_DEBUG() << "Child process" << process_index_ << "of" << graph_->getProcessGroupName() << "pid"
                    << pid_ << "(" << config_->startup_config_.short_name_ << ") for node" << this
                    << "terminated with status" << process_status;
     status_ = process_status;
@@ -270,7 +270,7 @@ void ProcessInfoNode::startProcess() {
         }
         sync_.reset();
     } while ((status_ != 0) && (restart_counter_-- != 0U));
-    LM_LOG_DEBUG() << "startProcess for" << graph_->getProcessGroupName().data() << "process" << process_index_ << "("
+    LM_LOG_DEBUG() << "startProcess for" << graph_->getProcessGroupName() << "process" << process_index_ << "("
                    << config_->startup_config_.short_name_ << ") done";
 }
 
@@ -315,7 +315,7 @@ void ProcessInfoNode::handleProcessAlreadyTerminated(uint32_t execution_error_co
         // and to have exited with zero status
         LM_LOG_WARN() << "Got process termination before kRunning for pid" << pid_ << "("
                       << config_->startup_config_.short_name_ << ") process" << process_index_ << "of group"
-                      << graph_->getProcessGroupName().data();
+                      << graph_->getProcessGroupName();
         //This will cause the graph to fail, we must report to SM (unless we have restart attempts left)
         if (0U == restart_counter_) {
             graph_->abort(execution_error_code, ControlClientCode::kFailedUnexpectedTerminationOnEnter);
@@ -349,10 +349,10 @@ void ProcessInfoNode::handleProcessRunning(uint32_t execution_error_code) {
     if (osal::CommsType::kNoComms == config_->startup_config_.comms_type_) {
         LM_LOG_DEBUG() << "Considered kRunning for Non Reporting Process pid" << pid_ << "("
                        << config_->startup_config_.short_name_ << ") process" << process_index_ << "of group"
-                       << graph_->getProcessGroupName().data();
+                       << graph_->getProcessGroupName();
     } else {
         LM_LOG_DEBUG() << "Got kRunning for pid" << pid_ << "(" << config_->startup_config_.short_name_ << ") process"
-                       << process_index_ << "of group" << graph_->getProcessGroupName().data();
+                       << process_index_ << "of group" << graph_->getProcessGroupName();
     }
 
     // kRunning has already been reported (or assumed)
@@ -403,7 +403,7 @@ void ProcessInfoNode::terminateProcess() {
     if (!graph_->isStarting() || (0 == status_)) {
         queueTerminationSuccessorJobs();
     }
-    LM_LOG_DEBUG() << "terminateProcess for" << graph_->getProcessGroupName().data() << "process" << process_index_
+    LM_LOG_DEBUG() << "terminateProcess for" << graph_->getProcessGroupName() << "process" << process_index_
                    << "(" << config_->startup_config_.short_name_ << ") done";
 }
 
@@ -413,7 +413,7 @@ inline void ProcessInfoNode::handleTerminationProcess() {
     terminator_.init(0U, false);
     has_semaphore_.store(true);
     LM_LOG_DEBUG() << "Requesting termination of process" << process_index_ << "of"
-                   << graph_->getProcessGroupName().data() << "pid" << pid_ << "("
+                   << graph_->getProcessGroupName() << "pid" << pid_ << "("
                    << config_->startup_config_.short_name_ << ")";
 
     //handle request termination

--- a/tests/ut/identifier_hash_UT/BUILD
+++ b/tests/ut/identifier_hash_UT/BUILD
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "identifier_hash_UT",
+    srcs = ["identifier_hash_UT.cpp"],
+    visibility = ["//tests:__subpackages__"],
+    deps = [
+        "//src/launch_manager_daemon/common:identifier_hash",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/ut/identifier_hash_UT/identifier_hash_UT.cpp
+++ b/tests/ut/identifier_hash_UT/identifier_hash_UT.cpp
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include <gtest/gtest.h>
+#include <score/lcm/identifier_hash.hpp>
+#include <memory>
+#include <sstream>
+
+using namespace testing;
+using std::stringstream;
+
+using score::lcm::IdentifierHash;
+
+TEST(IdentifierHashTest, IdentifierHash_with_string_view_created)
+{
+    std::string_view idStrView = "ProcessGroup1/Startup";
+    IdentifierHash identifierHash(idStrView);
+    stringstream strStream;
+    strStream << identifierHash;
+    ASSERT_EQ(strStream.str(), idStrView);
+}
+
+TEST(IdentifierHashTest, IdentifierHash_with_string_created)
+{
+    std::string idStr = "ProcessGroup1/Startup";
+    IdentifierHash identifierHash(idStr);
+    stringstream strStream;
+    strStream << identifierHash;
+    ASSERT_EQ(strStream.str(), idStr);
+}
+
+TEST(IdentifierHashTest, IdentifierHash_default_created)
+{
+    IdentifierHash identifierHash;
+    stringstream strStream;
+    strStream << identifierHash;
+    ASSERT_EQ(strStream.str(), "");
+}
+
+TEST(IdentifierHashTest, IdentifierHash_invalid_hash_no_string_representation)
+{
+    std::string idStr = "MainFG";
+    IdentifierHash identifierHash(idStr);
+
+    // Clear registry to simulate missing entry
+    IdentifierHash::get_registry().clear();
+
+    stringstream strStream;
+    strStream << identifierHash;
+    ASSERT_TRUE(strStream.str().find("Unknown IdentifierHash") != std::string::npos);
+    ASSERT_TRUE(strStream.str().find(std::to_string(identifierHash.data())) != std::string::npos);
+}
+
+TEST(IdentifierHashTest, IdentifierHash_no_dangling_pointer_after_source_string_dies)
+{
+    std::unique_ptr<IdentifierHash> hash_ptr;
+    std::string_view idStrView = "this string will be destroyed";
+
+    {
+        std::string tmpIdStr = std::string(idStrView);
+        hash_ptr = std::make_unique<IdentifierHash>(tmpIdStr);  // Registry stores an owned copy
+        // Do not read the registry yet; ensure we read after the source string is destroyed.
+    }
+
+    stringstream strStream;
+    strStream << *(hash_ptr.get());
+
+    ASSERT_EQ(strStream.str(), idStrView);
+}


### PR DESCRIPTION
The `IdentifierHash` class is used to identify process group (states) in a memory efficient way. This is why it stores only a hash value of the string which is given at construction time. 

As it confusing to print hash values in log messages, a static map and a operator<< is introduced in the class which provides a easy way to print understandable strings for an IdentifierHash object, by still leaving the object as memory efficient as before.

Related to #57 