### PR TITLE
Fixing reference integraion builds

### DIFF
--- a/externals/ipc_dropin/BUILD
+++ b/externals/ipc_dropin/BUILD
@@ -2,7 +2,7 @@ cc_library(
     name = "ipc_dropin_internal",
     hdrs = glob(["include/ipc_dropin/*.hpp"]),
     includes = ["include"],
-    strip_include_prefix = "include",
+    # strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )
 

--- a/externals/ipc_dropin/BUILD
+++ b/externals/ipc_dropin/BUILD
@@ -2,7 +2,6 @@ cc_library(
     name = "ipc_dropin_internal",
     hdrs = glob(["include/ipc_dropin/*.hpp"]),
     includes = ["include"],
-    # strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )
 

--- a/src/launch_manager_daemon/process_state_client_lib/BUILD
+++ b/src/launch_manager_daemon/process_state_client_lib/BUILD
@@ -57,7 +57,6 @@ cc_library(
         "//src/launch_manager_daemon/common:identifier_hash",
         "//src/launch_manager_daemon/common:lifecycle_error",
         "//src/launch_manager_daemon/common:log",
-        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
     ],
 )

--- a/src/launch_manager_daemon/process_state_client_lib/include/score/lcm/posixprocess.hpp
+++ b/src/launch_manager_daemon/process_state_client_lib/include/score/lcm/posixprocess.hpp
@@ -15,6 +15,7 @@
 #ifndef POSIXPROCESS_HPP_INCLUDED
 #define POSIXPROCESS_HPP_INCLUDED
 
+#include <cstdint>
 #include <ctime>  // for definition of "timespec"
 #include <score/lcm/identifier_hash.hpp>
 
@@ -23,7 +24,7 @@ namespace score {
 namespace lcm {
 
 /// @brief Represents the state of a modelled process.
-enum class ProcessState : std::uint_least8_t {
+enum class ProcessState : std::uint8_t {
     kIdle = 0,         ///< process in idle state.
     kStarting = 1,     ///< process in starting state.
     kRunning = 2,      ///< process in running state.


### PR DESCRIPTION
Fixing builds with the reference integration repo

- This is in preparation for using the [reference integration workflow](https://github.com/eclipse-score/reference_integration/blob/main/.github/workflows/reusable_integration-build.yml)
    - Note: This needs to be done in multiple PRs as when the build works another PR is needed in reference integration repo