### PR TITLE
Adding reference integration build

### DIFF
--- a/.github/workflows/reference-integration.yml
+++ b/.github/workflows/reference-integration.yml
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Reference Integration Build
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+
+    jobs:
+      integration:
+        uses: eclipse-score/reference_integration/.github/workflows/module-integration-build.yml@main
+        with:
+          known_good: |
+            { "modules": [] }
+          config: x86_64-linux


### PR DESCRIPTION
- Adding workflow to run the reference integration build.
- Needed for https://github.com/eclipse-score/lifecycle/issues/36