### PR TITLE
Add missing virtual destructor

### DIFF
--- a/src/launch_manager_daemon/src/process_group_manager/ihealth_monitor_thread.hpp
+++ b/src/launch_manager_daemon/src/process_group_manager/ihealth_monitor_thread.hpp
@@ -25,6 +25,8 @@ class IHealthMonitorThread {
  public:
     virtual bool start() = 0;
     virtual void stop() = 0;
+
+    virtual ~IHealthMonitorThread() = default;
 };
 }
 }


### PR DESCRIPTION
Some shared memory was not removed during normal shutdown due to a missing virtual destructor.