### PR TITLE
Mb add mocks for unit testing

### DIFF
--- a/src/lifecycle_client_lib/BUILD
+++ b/src/lifecycle_client_lib/BUILD
@@ -152,6 +152,60 @@ cc_library(
     ]
 ]
 
+cc_library(
+    name = "applicationcontext_mock",
+    testonly = True,
+    srcs = [
+        "test/ut/mocks/applicationcontextmock.cpp",
+    ],
+    hdrs = [
+        "include/applicationcontext.h",
+        "test/ut/mocks/applicationcontextmock.h",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "@googletest//:gtest",
+        "@score_baselibs//score/memory:string_literal",
+        "@score_baselibs//score/os/utils:signal",
+    ],
+)
+
+cc_library(
+    name = "application_mock",
+    testonly = True,
+    srcs = [
+        "src/application.cpp",
+    ],
+    hdrs = [
+        "include/application.h",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":applicationcontext_mock",
+        "@score_baselibs//score/os/utils:signal",
+    ],
+)
+
+cc_library(
+    name = "lifecycle_mock",
+    testonly = True,
+    srcs = [
+        "test/ut/mocks/lifecyclemanagermock.cpp",
+    ],
+    hdrs = [
+        "include/lifecyclemanager.h",
+        "test/ut/mocks/lifecyclemanagermock.h",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":application_mock",
+        # "//platform/aas/lib/os/utils/mocklib:signal_mock",
+        "@score_baselibs//score/os/utils/mocklib:signal_mock",
+        "@googletest//:gtest",
+        "@score_baselibs//score/os/utils:signal",
+    ],
+)
+
 filegroup(
     name = "all_sources",
     srcs = glob([

--- a/src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.cpp
+++ b/src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.cpp
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.h"
+#include "src/lifecycle_client_lib/include/applicationcontext.h"
+
+#include <functional>
+
+namespace
+{
+
+auto& GetConstructorCallback() noexcept
+{
+    static std::function<void(const std::int32_t argc, const score::StringLiteral argv[])> constructor_callback{};
+    return constructor_callback;
+}
+
+auto& GetGetArgumentsCallback() noexcept
+{
+    static std::function<const std::vector<std::string>&()> get_arguments_callback{};
+    return get_arguments_callback;
+}
+
+auto& GetGetArgumentCallback() noexcept
+{
+    static std::function<const std::string(const std::string_view)> get_argument_callback{};
+    return get_argument_callback;
+}
+
+}  // namespace
+
+score::mw::lifecycle::ApplicationContextMock::ApplicationContextMock()
+{
+    GetConstructorCallback() = [this](const std::int32_t argc, const score::StringLiteral argv[]) {
+        ctor(argc, argv);
+    };
+    GetGetArgumentsCallback() = [this]() -> decltype(auto) {
+        return get_arguments();
+    };
+    GetGetArgumentCallback() = [this](const std::string_view flag) -> decltype(auto) {
+        return get_argument(flag);
+    };
+}
+
+score::mw::lifecycle::ApplicationContextMock::~ApplicationContextMock()
+{
+    GetConstructorCallback() = nullptr;
+    GetGetArgumentsCallback() = nullptr;
+    GetGetArgumentCallback() = nullptr;
+}
+
+score::mw::lifecycle::ApplicationContext::ApplicationContext(const std::int32_t argc, const score::StringLiteral argv[])
+{
+    auto& constructor_callback = GetConstructorCallback();
+    constructor_callback(argc, argv);
+}
+
+const std::vector<std::string>& score::mw::lifecycle::ApplicationContext::get_arguments() const noexcept
+{
+    auto& get_arguments_callback = GetGetArgumentsCallback();
+    return get_arguments_callback();
+}
+
+std::string score::mw::lifecycle::ApplicationContext::get_argument(const std::string_view flag) const noexcept
+{
+    auto& get_argument_callback = GetGetArgumentCallback();
+    return get_argument_callback(flag);
+}

--- a/src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.h
+++ b/src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.h
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#ifndef SCORE_MW_LIFECYCLE_MOCKS_APPLICATIONCONTEXTMOCK_H_
+#define SCORE_MW_LIFECYCLE_MOCKS_APPLICATIONCONTEXTMOCK_H_
+
+#include "score/memory/string_literal.h"
+
+#include <gmock/gmock.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace score
+{
+namespace mw
+{
+namespace lifecycle
+{
+
+class ApplicationContextMock
+{
+  public:
+    ApplicationContextMock();
+    ~ApplicationContextMock();
+
+    MOCK_METHOD(const std::vector<std::string>&, get_arguments, (), ());
+    MOCK_METHOD(void, ctor, (const std::int32_t argc, const score::StringLiteral argv[]), ());
+    MOCK_METHOD(std::string, get_argument, (const std::string_view flag), ());
+};
+
+}  // namespace lifecycle
+}  // namespace mw
+}  // namespace score
+
+#endif  // SCORE_MW_LIFECYCLE_MOCKS_APPLICATIONCONTEXTMOCK_H_

--- a/src/lifecycle_client_lib/test/ut/mocks/lifecyclemanagermock.cpp
+++ b/src/lifecycle_client_lib/test/ut/mocks/lifecyclemanagermock.cpp
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "src/lifecycle_client_lib/test/ut/mocks/lifecyclemanagermock.h"
+#include "src/lifecycle_client_lib/include/lifecyclemanager.h"
+
+#include <functional>
+
+namespace
+{
+
+auto& GetConstructorCallback() noexcept
+{
+    static std::function<void()> constructor_callback{};
+    return constructor_callback;
+}
+
+auto& GetDestructorCallback() noexcept
+{
+    static std::function<void()> destructor_callback{};
+    return destructor_callback;
+}
+
+auto& GetRunCallback() noexcept
+{
+    static std::function<std::int32_t(score::mw::lifecycle::Application & app,
+                                      const score::mw::lifecycle::ApplicationContext& context)>
+        run_callback;
+    return run_callback;
+}
+
+}  // namespace
+
+score::mw::lifecycle::LifeCycleManagerMock::LifeCycleManagerMock()
+{
+    GetConstructorCallback() = [this] {
+        ctor();
+    };
+    GetDestructorCallback() = [this] {
+        dtor();
+    };
+    ResetCallbackForRunMethod();
+}
+
+score::mw::lifecycle::LifeCycleManagerMock::~LifeCycleManagerMock()
+{
+    GetConstructorCallback() = nullptr;
+    GetDestructorCallback() = nullptr;
+    GetRunCallback() = nullptr;
+}
+
+void score::mw::lifecycle::LifeCycleManagerMock::SetCallbackForRunMethod(
+    std::function<std::int32_t(score::mw::lifecycle::Application& app, const score::mw::lifecycle::ApplicationContext& context)> callback)
+{
+    GetRunCallback() = std::move(callback);
+}
+
+void score::mw::lifecycle::LifeCycleManagerMock::ResetCallbackForRunMethod()
+{
+    GetRunCallback() = [this](score::mw::lifecycle::Application& app,
+                              const score::mw::lifecycle::ApplicationContext& context) {
+        return run(app, context);
+    };
+}
+
+score::mw::lifecycle::LifeCycleManager::LifeCycleManager(std::unique_ptr<score::os::Signal>) noexcept
+{
+    auto& constructor_callback = GetConstructorCallback();
+    constructor_callback();
+}
+
+score::mw::lifecycle::LifeCycleManager::~LifeCycleManager() noexcept
+{
+    auto& destructor_callback = GetDestructorCallback();
+    destructor_callback();
+}
+
+std::int32_t score::mw::lifecycle::LifeCycleManager::run(score::mw::lifecycle::Application& app,
+                                                         const score::mw::lifecycle::ApplicationContext& context)
+{
+    report_running();
+    auto& run_callback = GetRunCallback();
+    const auto result = run_callback(app, context);
+    report_shutdown();
+    return result;
+}

--- a/src/lifecycle_client_lib/test/ut/mocks/lifecyclemanagermock.h
+++ b/src/lifecycle_client_lib/test/ut/mocks/lifecyclemanagermock.h
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#ifndef SCORE_MW_LIFECYCLE_MOCKS_LIFECYCLEMANAGERMOCK_H_
+#define SCORE_MW_LIFECYCLE_MOCKS_LIFECYCLEMANAGERMOCK_H_
+
+#include "score/os/utils/mocklib/signalmock.h"
+#include "score/os/utils/signal.h"
+#include "src/lifecycle_client_lib/include/application.h"
+#include "src/lifecycle_client_lib/test/ut/mocks/applicationcontextmock.h"
+
+#include <gmock/gmock.h>
+
+#include <functional>
+
+namespace score
+{
+namespace mw
+{
+namespace lifecycle
+{
+
+class LifeCycleManagerMock
+{
+  public:
+    LifeCycleManagerMock();
+    ~LifeCycleManagerMock();
+
+    void SetCallbackForRunMethod(
+        std::function<std::int32_t(score::mw::lifecycle::Application& app, const score::mw::lifecycle::ApplicationContext& context)> callback);
+    void ResetCallbackForRunMethod();
+
+    MOCK_METHOD(std::int32_t, run, (score::mw::lifecycle::Application & app, const score::mw::lifecycle::ApplicationContext& context), ());
+    MOCK_METHOD(void, ctor, (), ());
+    MOCK_METHOD(void, dtor, (), ());
+};
+
+}  // namespace lifecycle
+}  // namespace mw
+}  // namespace score
+
+#endif  // SCORE_MW_LIFECYCLE_MOCKS_LIFECYCLEMANAGERMOCK_H_


### PR DESCRIPTION
This PR adds mocks for the lifecycle_client_api to allow unit testing for applications using it. 