### PR TITLE
infra: disable `integration` job

### DIFF
--- a/.github/workflows/reference-integration.yml
+++ b/.github/workflows/reference-integration.yml
@@ -19,6 +19,8 @@ on:
     types: [checks_requested]
 jobs:
   integration:
+    # TODO: restore job once fixed. https://github.com/eclipse-score/lifecycle/issues/84
+    if: false
     uses: eclipse-score/reference_integration/.github/workflows/reusable_smoke-test.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
To be restored once fixed.

Related to #84