### PR TITLE
repo: rework fix for `logging` build issues

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,7 +22,6 @@ build --credential_helper=*.qnx.com=%workspace%/scripts/internal/qnx_creds.py
 
 # Common test flags for all platforms
 test --test_output=errors
-test --@score_logging//score/mw/log/flags:KRemote_Logging=False
 test --@score_baselibs//score/json:base_library=nlohmann
 test --cxxopt=-Wno-deprecated-declarations
 
@@ -36,6 +35,7 @@ build:toolchain_common --incompatible_strict_action_env
 build:toolchain_common --host_platform=@score_bazel_platforms//:x86_64-linux
 ## Ferrocene must be common compiler for HOST. To ensure metadata compatibility for proc macro crate
 build:toolchain_common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
+build:stub --@score_baselibs//score/mw/log/flags:KRemote_Logging=False
 build:stub --@score_logging//score/mw/log/flags:KRemote_Logging=False
 build:stub --@score_baselibs//score/json:base_library=nlohmann
 

--- a/examples/cpp_lifecycle_app/BUILD
+++ b/examples/cpp_lifecycle_app/BUILD
@@ -26,5 +26,6 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//src/lifecycle_client_lib",
+        "@score_logging//score/mw/log",
     ],
 )

--- a/src/control_client_lib/BUILD
+++ b/src/control_client_lib/BUILD
@@ -32,6 +32,6 @@ cc_library(
         "//src/launch_manager_daemon/common:log",
         "//src/launch_manager_daemon/common:osal",
         "@score_baselibs//score/concurrency/future",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )

--- a/src/launch_manager_daemon/BUILD
+++ b/src/launch_manager_daemon/BUILD
@@ -52,8 +52,8 @@ cc_binary_with_common_opts(
         "//src/launch_manager_daemon/health_monitor_lib:health_monitor",
         "//src/launch_manager_daemon/process_state_client_lib:process_state_client",
         "@flatbuffers",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -84,7 +84,7 @@ cc_library(
         "//src/launch_manager_daemon/common:log",
         "//src/launch_manager_daemon/health_monitor_lib:health_monitor",
         "@flatbuffers",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
     ],
 )

--- a/src/launch_manager_daemon/health_monitor_lib/BUILD
+++ b/src/launch_manager_daemon/health_monitor_lib/BUILD
@@ -48,7 +48,7 @@ cc_library_with_common_opts(
     ],
     visibility = ["//src:__pkg__"],
     deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -68,7 +68,7 @@ cc_library_with_common_opts(
     visibility = ["//src:__pkg__"],
     deps = [
         "//src/launch_manager_daemon/process_state_client_lib:process_state_client",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -118,7 +118,7 @@ cc_library_with_common_opts(
         "src/score/lcm/saf/logging",
     ],
     deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -138,7 +138,7 @@ cc_library_with_common_opts(
     deps = [
         ":config",
         "//src/launch_manager_daemon/recovery_client_lib:recovery_client",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -305,7 +305,7 @@ cc_library_with_common_opts(
         ":supervision",
         ":timers",
         "@flatbuffers//:flatc",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/src/launch_manager_daemon/lifecycle_client_lib/BUILD
+++ b/src/launch_manager_daemon/lifecycle_client_lib/BUILD
@@ -37,7 +37,7 @@ cc_library(
         "//src/launch_manager_daemon/common:lifecycle_error",
         "//src/launch_manager_daemon/common:log",
         "//src/launch_manager_daemon/common:osal",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )

--- a/src/launch_manager_daemon/process_state_client_lib/BUILD
+++ b/src/launch_manager_daemon/process_state_client_lib/BUILD
@@ -31,8 +31,8 @@ cc_library(
         "//src/launch_manager_daemon/common:identifier_hash",
         "//src/launch_manager_daemon/common:lifecycle_error",
         "//src/launch_manager_daemon/common:log",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/src/lifecycle_client_lib/BUILD
+++ b/src/lifecycle_client_lib/BUILD
@@ -47,9 +47,9 @@ cc_library(
         "//src/launch_manager_daemon/lifecycle_client_lib:lifecycle_client",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory:string_literal",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os:stdlib",
         "@score_baselibs//score/os/utils:signal",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -65,9 +65,9 @@ cc_library(
     tags = ["FUSA"],
     deps = [
         "@score_baselibs//score/memory:string_literal",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os:stdlib",
         "@score_baselibs//score/os/utils:signal",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -117,9 +117,9 @@ cc_library(
     deps = [
         ":application",
         "//src/launch_manager_daemon/lifecycle_client_lib:lifecycle_client",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os:stdlib",
         "@score_baselibs//score/os/utils:signal",
-        "@score_logging//score/mw/log",
     ],
 )
 


### PR DESCRIPTION
- Use `logging` where applicable.
- Revert previous (partially invalid) change.
- Fix configuration in `.bazelrc`.