### PR TITLE
hmon: global fixes to HMON

### DIFF
--- a/src/health_monitoring_lib/cpp/include/score/hm/common.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/common.h
@@ -44,7 +44,7 @@ class RustDroppable
     /// Marks object as no longer managed by C++ side, releasing handle to be passed to Rust side for dropping
     std::optional<FFIHandle> drop_by_rust()
     {
-        return static_cast<T*>(this)->__drop_by_rust_impl();
+        return static_cast<T*>(this)->_drop_by_rust_impl();
     }
 };
 

--- a/src/health_monitoring_lib/cpp/include/score/hm/deadline/deadline_monitor.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/deadline/deadline_monitor.h
@@ -51,7 +51,7 @@ class DeadlineMonitorBuilder final : public internal::RustDroppable<DeadlineMoni
     DeadlineMonitorBuilder add_deadline(const DeadlineTag& deadline_tag, const TimeRange& range) &&;
 
   protected:
-    std::optional<internal::FFIHandle> __drop_by_rust_impl()
+    std::optional<internal::FFIHandle> _drop_by_rust_impl()
     {
         return monitor_builder_handler_.drop_by_rust();
     }

--- a/src/health_monitoring_lib/rust/deadline/ffi.rs
+++ b/src/health_monitoring_lib/rust/deadline/ffi.rs
@@ -40,7 +40,7 @@ impl DeadlineMonitorCpp {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_monitor_builder_create(deadline_monitor_builder_handle_out: *mut FFIHandle) -> FFICode {
     if deadline_monitor_builder_handle_out.is_null() {
         return FFICode::NullParameter;
@@ -54,7 +54,7 @@ pub extern "C" fn deadline_monitor_builder_create(deadline_monitor_builder_handl
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_monitor_builder_destroy(deadline_monitor_builder_handle: FFIHandle) -> FFICode {
     if deadline_monitor_builder_handle.is_null() {
         return FFICode::NullParameter;
@@ -70,7 +70,7 @@ pub extern "C" fn deadline_monitor_builder_destroy(deadline_monitor_builder_hand
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_monitor_builder_add_deadline(
     deadline_monitor_builder_handle: FFIHandle,
     deadline_tag: *const DeadlineTag,
@@ -108,7 +108,7 @@ pub extern "C" fn deadline_monitor_builder_add_deadline(
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_monitor_get_deadline(
     deadline_monitor_handle: FFIHandle,
     deadline_tag: *const DeadlineTag,
@@ -141,7 +141,7 @@ pub extern "C" fn deadline_monitor_get_deadline(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_monitor_destroy(deadline_monitor_handle: FFIHandle) -> FFICode {
     if deadline_monitor_handle.is_null() {
         return FFICode::NullParameter;
@@ -157,7 +157,7 @@ pub extern "C" fn deadline_monitor_destroy(deadline_monitor_handle: FFIHandle) -
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_start(deadline_handle: FFIHandle) -> FFICode {
     if deadline_handle.is_null() {
         return FFICode::NullParameter;
@@ -176,7 +176,7 @@ pub extern "C" fn deadline_start(deadline_handle: FFIHandle) -> FFICode {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_stop(deadline_handle: FFIHandle) -> FFICode {
     if deadline_handle.is_null() {
         return FFICode::NullParameter;
@@ -193,7 +193,7 @@ pub extern "C" fn deadline_stop(deadline_handle: FFIHandle) -> FFICode {
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn deadline_destroy(deadline_handle: FFIHandle) -> FFICode {
     if deadline_handle.is_null() {
         return FFICode::NullParameter;

--- a/src/health_monitoring_lib/rust/ffi.rs
+++ b/src/health_monitoring_lib/rust/ffi.rs
@@ -73,7 +73,7 @@ impl<T: DerefMut> DerefMut for FFIBorrowed<T> {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_builder_create(health_monitor_builder_handle_out: *mut FFIHandle) -> FFICode {
     if health_monitor_builder_handle_out.is_null() {
         return FFICode::NullParameter;
@@ -87,7 +87,7 @@ pub extern "C" fn health_monitor_builder_create(health_monitor_builder_handle_ou
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_builder_destroy(health_monitor_builder_handle: FFIHandle) -> FFICode {
     if health_monitor_builder_handle.is_null() {
         return FFICode::NullParameter;
@@ -104,7 +104,7 @@ pub extern "C" fn health_monitor_builder_destroy(health_monitor_builder_handle: 
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_builder_build(
     health_monitor_builder_handle: FFIHandle,
     supervisor_cycle_ms: u32,
@@ -137,7 +137,7 @@ pub extern "C" fn health_monitor_builder_build(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_builder_add_deadline_monitor(
     health_monitor_builder_handle: FFIHandle,
     monitor_tag: *const MonitorTag,
@@ -171,7 +171,7 @@ pub extern "C" fn health_monitor_builder_add_deadline_monitor(
     FFICode::Success
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_get_deadline_monitor(
     health_monitor_handle: FFIHandle,
     monitor_tag: *const MonitorTag,
@@ -202,7 +202,7 @@ pub extern "C" fn health_monitor_get_deadline_monitor(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_start(health_monitor_handle: FFIHandle) -> FFICode {
     if health_monitor_handle.is_null() {
         return FFICode::NullParameter;
@@ -221,7 +221,7 @@ pub extern "C" fn health_monitor_start(health_monitor_handle: FFIHandle) -> FFIC
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_destroy(health_monitor_handle: FFIHandle) -> FFICode {
     if health_monitor_handle.is_null() {
         return FFICode::NullParameter;

--- a/src/health_monitoring_lib/rust/tag.rs
+++ b/src/health_monitoring_lib/rust/tag.rs
@@ -23,6 +23,15 @@ struct Tag {
     length: usize,
 }
 
+impl Tag {
+    const fn new(value: &str) -> Self {
+        Self {
+            data: value.as_ptr(),
+            length: value.len(),
+        }
+    }
+}
+
 unsafe impl Send for Tag {}
 unsafe impl Sync for Tag {}
 
@@ -86,6 +95,12 @@ impl From<&str> for Tag {
 #[repr(C)]
 pub struct MonitorTag(Tag);
 
+impl MonitorTag {
+    pub const fn new(value: &str) -> Self {
+        MonitorTag(Tag::new(value))
+    }
+}
+
 impl fmt::Debug for MonitorTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // SAFETY: the underlying data was created from a valid `&str`.
@@ -120,6 +135,12 @@ impl From<&str> for MonitorTag {
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 #[repr(C)]
 pub struct DeadlineTag(Tag);
+
+impl DeadlineTag {
+    pub const fn new(value: &str) -> Self {
+        DeadlineTag(Tag::new(value))
+    }
+}
 
 impl fmt::Debug for DeadlineTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -231,6 +252,13 @@ mod tests {
     }
 
     #[test]
+    fn tag_new() {
+        const EXAMPLE_STR: &str = "EXAMPLE";
+        const TAG: Tag = Tag::new(EXAMPLE_STR);
+        compare_tag(TAG, EXAMPLE_STR);
+    }
+
+    #[test]
     fn tag_debug() {
         let example_str = "EXAMPLE";
         let tag = Tag::from(example_str.to_string());
@@ -313,6 +341,13 @@ mod tests {
     }
 
     #[test]
+    fn monitor_tag_new() {
+        const EXAMPLE_STR: &str = "EXAMPLE";
+        const TAG: MonitorTag = MonitorTag::new(EXAMPLE_STR);
+        compare_tag(TAG.0, EXAMPLE_STR);
+    }
+
+    #[test]
     fn monitor_tag_debug() {
         let example_str = "EXAMPLE";
         let tag = MonitorTag::from(example_str.to_string());
@@ -340,6 +375,13 @@ mod tests {
         let example_str = "EXAMPLE";
         let tag = MonitorTag::from(example_str);
         compare_tag(tag.0, example_str);
+    }
+
+    #[test]
+    fn deadline_tag_new() {
+        const EXAMPLE_STR: &str = "EXAMPLE";
+        const TAG: DeadlineTag = DeadlineTag::new(EXAMPLE_STR);
+        compare_tag(TAG.0, EXAMPLE_STR);
     }
 
     #[test]


### PR DESCRIPTION
- Rename `__drop_by_rust_impl` to `_drop_by_rust_impl`.
  - Double underscore is reserved in C++.
- Rename `#[no_mangle]` to `#[unsafe(no_mangle)]`.
- Add const constructors for tags.