### PR TITLE
lifecycle: Add exception handling for CPU affinity

### DIFF
--- a/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
+++ b/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
@@ -80,7 +80,8 @@ const char* kEnvVarDefaultValue = "/opt/internal/launch_manager/etc/ecu-cfg";  /
 
 const uint32_t ConfigurationManager::kDefaultProcessExecutionError = 1U;
 uint32_t ConfigurationManager::kDefaultProcessorAffinityMask() {
-    return (1U << osal::getNumCores()) - 1U;
+    uint32_t core = osal::getNumCores();
+    return (1U << (core > 31 ? 31 : core)) - 1U;
 }
 const int32_t ConfigurationManager::kDefaultSchedulingPolicy = SCHED_OTHER;
 const int32_t ConfigurationManager::kDefaultRealtimeSchedulingPriority = 99;


### PR DESCRIPTION
When there are 32 CPU cores, an issue arises where the process cannot be executed, and when there are more than 32 cores, a problem occurs where fewer cores than expected are used. To resolve this issue, exception handling is added to set the maximum number of cores using the uint32_t type when there are more than 32 cores.