### PR TITLE
Fix leftover shared memory when testing

### DIFF
--- a/externals/ipc_dropin/include/ipc_dropin/socket.hpp
+++ b/externals/ipc_dropin/include/ipc_dropin/socket.hpp
@@ -1,227 +1,236 @@
 #ifndef IPC_DROPIN_SOCKET_HPP_
 #define IPC_DROPIN_SOCKET_HPP_
 
-#include <sys/types.h>
-#include <string_view>
-#include <cstddef>
-#include <memory>
-#include <cstdio>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
+#include <cstddef>
+#include <cstdio>
+#include <memory>
 #include <string>
+#include <string_view>
 
 #include "ringbuffer.hpp"
 
 namespace ipc_dropin
 {
-    enum class ReturnCode
+enum class ReturnCode
+{
+    kOk,
+    kError,
+    kQueueEmpty,
+    kPermissionDenied,
+    kQueueStateCorrupt,
+};
+
+template <std::size_t ElementSize, std::size_t Capacity>
+class Socket
+{
+  public:
+    ReturnCode create(const char* name, mode_t mode)
     {
-        kOk,
-        kError,
-        kQueueEmpty,
-        kPermissionDenied,
-        kQueueStateCorrupt,
-    };
-
-    template <std::size_t ElementSize, std::size_t Capacity>
-    class Socket
-    {
-    public:
-        ReturnCode create(const char *name, mode_t mode)
+        name_ = name;
+        if (name_.size() > 0 && name_[0] != '/')
         {
-            name_ = name;
-            if(name_.size() > 0 && name_[0] != '/') {
-                name_ = "/" + name_;
-            }
-
-            fd_ = shm_open(name_.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, mode);
-            if (fd_ < 0)
-            {
-                if (errno == EACCES)
-                {
-                    return ReturnCode::kPermissionDenied;
-                }
-                return ReturnCode::kError;
-            }
-            const std::size_t bytes = sizeof(RingBuffer<Capacity, ElementSize>);
-            if (ftruncate(fd_, bytes) != 0)
-            {
-                cleanup();
-                if (errno == EACCES || errno == EPERM)
-                {
-                    return ReturnCode::kPermissionDenied;
-                }
-                return ReturnCode::kError;
-            }
-            void *ptr = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
-            if (ptr == MAP_FAILED)
-            {
-                cleanup();
-                if (errno == EACCES || errno == EPERM)
-                {
-                    return ReturnCode::kPermissionDenied;
-                }
-                return ReturnCode::kError;
-            }
-            buffer_ = static_cast<RingBuffer<Capacity, ElementSize> *>(ptr);
-            buffer_->initialize();
-            is_server_ = true;
-            return ReturnCode::kOk;
+            name_ = "/" + name_;
         }
 
-        ReturnCode connect(const char *name) noexcept
+        fd_ = shm_open(name_.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, mode);
+        if (fd_ < 0)
         {
-            name_ = name;
-            if(name_.size() > 0 && name_[0] != '/') {
-                name_ = "/" + name_;
-            }
-
-            fd_ = shm_open(name_.c_str(), O_RDWR | O_CLOEXEC, 0);
-            if (fd_ < 0)
+            if (errno == EACCES)
             {
-                if (errno == EACCES)
-                {
-                    return ReturnCode::kPermissionDenied;
-                }
-                return ReturnCode::kError;
-            }
-            const std::size_t bytes = sizeof(RingBuffer<Capacity, ElementSize>);
-            void *ptr = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
-            if (ptr == MAP_FAILED)
-            {
-                cleanup();
-                if (errno == EACCES || errno == EPERM)
-                {
-                    return ReturnCode::kPermissionDenied;
-                }
-                return ReturnCode::kError;
-            }
-            buffer_ = static_cast<RingBuffer<Capacity, ElementSize> *>(ptr);
-
-            if (!buffer_->isInitialized())
-            {
-                return ReturnCode::kError;
-            }
-            return ReturnCode::kOk;
-        }
-
-        void close() noexcept
-        {
-            if (buffer_)
-            {
-                munmap(static_cast<void *>(buffer_), sizeof(RingBuffer<Capacity, ElementSize>));
-                buffer_ = nullptr;
-            }
-            cleanup();
-            is_server_ = false;
-        }
-
-        std::string_view getName() const noexcept { return name_; }
-
-        bool getOverflowFlag(bool reset = false) noexcept
-        {
-            if (!buffer_)
-            {
-                return false;
-            }
-            return buffer_->getOverflowFlag(reset);
-        }
-
-        template <class Payload, typename... Args>
-        ReturnCode trySendEmplace(Args &&...args)
-        {
-            static_assert(std::is_trivially_copyable<Payload>::value, "Payload must be trivially copyable");
-            if (!buffer_)
-            {
-                return ReturnCode::kError;
-            }
-            if (sizeof(Payload) > ElementSize)
-            {
-                return ReturnCode::kError;
-            }
-            return buffer_->template tryEmplace<Payload>(std::forward<Args>(args)...) ? ReturnCode::kOk : ReturnCode::kError;
-        }
-
-        template <class Payload>
-        ReturnCode tryPeek(Payload *&elem)
-        {
-            if (!buffer_)
-            {
-                return ReturnCode::kError;
-            }
-            if (buffer_->empty())
-            {
-                return ReturnCode::kQueueEmpty;
-            }
-            if (buffer_->template tryPeek(elem))
-            {
-                return ReturnCode::kOk;
+                return ReturnCode::kPermissionDenied;
             }
             return ReturnCode::kError;
         }
-
-        ReturnCode tryPop()
+        const std::size_t bytes = sizeof(RingBuffer<Capacity, ElementSize>);
+        if (ftruncate(fd_, bytes) != 0)
         {
-            if (!buffer_)
+            cleanup();
+            if (errno == EACCES || errno == EPERM)
             {
-                return ReturnCode::kError;
+                return ReturnCode::kPermissionDenied;
             }
-            return buffer_->tryPop() ? ReturnCode::kOk : ReturnCode::kError;
+            return ReturnCode::kError;
+        }
+        void* ptr = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+        if (ptr == MAP_FAILED)
+        {
+            cleanup();
+            if (errno == EACCES || errno == EPERM)
+            {
+                return ReturnCode::kPermissionDenied;
+            }
+            return ReturnCode::kError;
+        }
+        buffer_ = static_cast<RingBuffer<Capacity, ElementSize>*>(ptr);
+        buffer_->initialize();
+        is_server_ = true;
+        return ReturnCode::kOk;
+    }
+
+    ReturnCode connect(const char* name) noexcept
+    {
+        name_ = name;
+        if (name_.size() > 0 && name_[0] != '/')
+        {
+            name_ = "/" + name_;
         }
 
-        template <class Payload>
-        ReturnCode tryReceive(Payload &elem)
+        fd_ = shm_open(name_.c_str(), O_RDWR | O_CLOEXEC, 0);
+        if (fd_ < 0)
         {
-            if (!buffer_)
+            if (errno == EACCES)
             {
-                return ReturnCode::kQueueStateCorrupt;
+                return ReturnCode::kPermissionDenied;
             }
-            if (buffer_->empty())
-            {
-                return ReturnCode::kQueueEmpty;
-            }
-            return buffer_->tryDequeue(elem) ? ReturnCode::kOk : ReturnCode::kError;
+            return ReturnCode::kError;
         }
-
-        template <class Payload>
-        ReturnCode trySend(Payload &elem)
+        const std::size_t bytes = sizeof(RingBuffer<Capacity, ElementSize>);
+        void* ptr = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+        if (ptr == MAP_FAILED)
         {
-            if (!buffer_)
+            cleanup();
+            if (errno == EACCES || errno == EPERM)
             {
-                return ReturnCode::kError;
+                return ReturnCode::kPermissionDenied;
             }
-            return buffer_->tryEnqueue(elem) ? ReturnCode::kOk : ReturnCode::kError;
+            return ReturnCode::kError;
         }
+        buffer_ = static_cast<RingBuffer<Capacity, ElementSize>*>(ptr);
 
-        Socket() = default;
-        ~Socket() noexcept { close(); }
-        Socket(const Socket &) = delete;
-        Socket &operator=(const Socket &) = delete;
-        Socket(Socket &&) noexcept = default;
-        Socket &operator=(Socket &&) noexcept = default;
-
-    private:
-        void cleanup() noexcept
+        if (!buffer_->isInitialized())
         {
-            if (fd_ >= 0)
-            {
-                ::close(fd_);
-                fd_ = -1;
-            }
-            if (is_server_ && !name_.empty())
-            {
-                shm_unlink(name_.c_str());
-            }
+            return ReturnCode::kError;
         }
+        return ReturnCode::kOk;
+    }
 
-        bool is_server_{false};
-        std::string name_;
-        int fd_{-1};
-        RingBuffer<Capacity, ElementSize> *buffer_{nullptr};
-    };
+    void close() noexcept
+    {
+        if (buffer_)
+        {
+            munmap(static_cast<void*>(buffer_), sizeof(RingBuffer<Capacity, ElementSize>));
+            buffer_ = nullptr;
+        }
+        cleanup();
+        is_server_ = false;
+    }
 
-}
+    std::string_view getName() const noexcept
+    {
+        return name_;
+    }
+
+    bool getOverflowFlag(bool reset = false) noexcept
+    {
+        if (!buffer_)
+        {
+            return false;
+        }
+        return buffer_->getOverflowFlag(reset);
+    }
+
+    template <class Payload, typename... Args>
+    ReturnCode trySendEmplace(Args&&... args)
+    {
+        static_assert(std::is_trivially_copyable<Payload>::value, "Payload must be trivially copyable");
+        if (!buffer_)
+        {
+            return ReturnCode::kError;
+        }
+        if (sizeof(Payload) > ElementSize)
+        {
+            return ReturnCode::kError;
+        }
+        return buffer_->template tryEmplace<Payload>(std::forward<Args>(args)...) ? ReturnCode::kOk
+                                                                                  : ReturnCode::kError;
+    }
+
+    template <class Payload>
+    ReturnCode tryPeek(Payload*& elem)
+    {
+        if (!buffer_)
+        {
+            return ReturnCode::kError;
+        }
+        if (buffer_->empty())
+        {
+            return ReturnCode::kQueueEmpty;
+        }
+        if (buffer_->template tryPeek(elem))
+        {
+            return ReturnCode::kOk;
+        }
+        return ReturnCode::kError;
+    }
+
+    ReturnCode tryPop()
+    {
+        if (!buffer_)
+        {
+            return ReturnCode::kError;
+        }
+        return buffer_->tryPop() ? ReturnCode::kOk : ReturnCode::kError;
+    }
+
+    template <class Payload>
+    ReturnCode tryReceive(Payload& elem)
+    {
+        if (!buffer_)
+        {
+            return ReturnCode::kQueueStateCorrupt;
+        }
+        if (buffer_->empty())
+        {
+            return ReturnCode::kQueueEmpty;
+        }
+        return buffer_->tryDequeue(elem) ? ReturnCode::kOk : ReturnCode::kError;
+    }
+
+    template <class Payload>
+    ReturnCode trySend(Payload& elem)
+    {
+        if (!buffer_)
+        {
+            return ReturnCode::kError;
+        }
+        return buffer_->tryEnqueue(elem) ? ReturnCode::kOk : ReturnCode::kError;
+    }
+
+    Socket() = default;
+    ~Socket() noexcept
+    {
+        close();
+    }
+    Socket(const Socket&) = delete;
+    Socket& operator=(const Socket&) = delete;
+    Socket(Socket&&) noexcept = default;
+    Socket& operator=(Socket&&) noexcept = default;
+
+  private:
+    void cleanup() noexcept
+    {
+        if (fd_ >= 0)
+        {
+            ::close(fd_);
+            fd_ = -1;
+        }
+        if (is_server_ && !name_.empty())
+        {
+            shm_unlink(name_.c_str());
+        }
+    }
+
+    bool is_server_{false};
+    std::string name_;
+    int fd_{-1};
+    RingBuffer<Capacity, ElementSize>* buffer_{nullptr};
+};
+
+}  // namespace ipc_dropin
 
 #endif

--- a/externals/ipc_dropin/include/ipc_dropin/socket.hpp
+++ b/externals/ipc_dropin/include/ipc_dropin/socket.hpp
@@ -37,6 +37,21 @@ class Socket
             name_ = "/" + name_;
         }
 
+        // shm_open will reopen shmem files if they already exist
+        // need to perform this check explicitly beforehand
+        if (exists(name_, mode))
+        {
+            // shm was likely not cleaned up from last run (e.g. due to a crash)
+            if (shm_unlink(name_.c_str()) != 0)
+            {
+                if (errno == EACCES)
+                {
+                    return ReturnCode::kPermissionDenied;
+                }
+                return ReturnCode::kError;
+            }
+        }
+
         fd_ = shm_open(name_.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, mode);
         if (fd_ < 0)
         {
@@ -46,6 +61,7 @@ class Socket
             }
             return ReturnCode::kError;
         }
+        owns_shared_memory_ = true;
         const std::size_t bytes = sizeof(RingBuffer<Capacity, ElementSize>);
         if (ftruncate(fd_, bytes) != 0)
         {
@@ -68,7 +84,6 @@ class Socket
         }
         buffer_ = static_cast<RingBuffer<Capacity, ElementSize>*>(ptr);
         buffer_->initialize();
-        is_server_ = true;
         return ReturnCode::kOk;
     }
 
@@ -117,7 +132,6 @@ class Socket
             buffer_ = nullptr;
         }
         cleanup();
-        is_server_ = false;
     }
 
     std::string_view getName() const noexcept
@@ -219,16 +233,33 @@ class Socket
             ::close(fd_);
             fd_ = -1;
         }
-        if (is_server_ && !name_.empty())
+        if (owns_shared_memory_ && !name_.empty())
         {
             shm_unlink(name_.c_str());
+            owns_shared_memory_ = false;
         }
     }
 
-    bool is_server_{false};
+    bool owns_shared_memory_{false};
     std::string name_;
     int fd_{-1};
     RingBuffer<Capacity, ElementSize>* buffer_{nullptr};
+
+    /// @brief Check if a shared memory file with given path already exists
+    /// @param [in] f_name The name of shared memory file
+    /// @param [in] f_mode The permission bits of shared memory file
+    /// @return True if shmem file already exists, else false
+    static bool exists(const std::string& f_name, mode_t f_mode) noexcept(false)
+    {
+        // Try opening the shmem without creating it to check if shmem files already exist
+        auto fd = shm_open(f_name.c_str(), O_RDONLY, f_mode);
+        if (fd >= 0)
+        {
+            ::close(fd);
+            return true;
+        }
+        return false;
+    }
 };
 
 }  // namespace ipc_dropin

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ipc/IpcServer.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ipc/IpcServer.hpp
@@ -88,20 +88,11 @@ public:
     IpcServer& operator=(const IpcServer&) = delete;
 
     /// @brief Create ipc channel (i.e. shared memory)
-    /// If a shared memory file with the same name already exists,
-    /// initialization fails.
     /// @param [in] f_ipcName_r The name of the ipc channel
     /// @param [in] f_mode The permission bits of the ipc channel
-    /// @return True if initialization of ipc channel successful, else false
+    /// @return kOk if initialization of ipc channel successful, else kPermissionDenied or kFailed
     EIpcInitResult init(const std::string& f_ipcName_r, mode_t f_mode = kOwnerReadWrite) noexcept(false)
     {
-        // pipc is not aborting if shmem files already exist
-        // need to perform this check explicitly beforehand
-        if (exists(f_ipcName_r, f_mode))
-        {
-            return EIpcInitResult::kFailed;
-        }
-
         ipc_dropin::ReturnCode result{socket->create(f_ipcName_r.c_str(), f_mode)};
         if (result == ipc_dropin::ReturnCode::kOk)
         {
@@ -214,24 +205,6 @@ public:
         }
 
         return exit_function(true);
-    }
-
-private:
-    /// @brief Check if a shared memory file with given path already exists
-    /// @param [in] f_name The name of shared memory file
-    /// @param [in] f_mode The permission bits of shared memory file
-    /// @return True if shmem file already exists, else false
-    static bool exists(const std::string& f_name, mode_t f_mode) noexcept(false)
-    {
-        const std::string name{"/" + f_name};
-        // Try opening the shmem without creating it to check if shmem files already exist
-        auto fd = shm_open(name.c_str(), O_RDONLY, f_mode);
-        if (fd >= 0)
-        {
-            close(fd);
-            return true;
-        }
-        return false;
     }
 };
 

--- a/tests/integration/smoke/smoke.py
+++ b/tests/integration/smoke/smoke.py
@@ -32,7 +32,7 @@ def test_smoke(target, setup_test, test_output_dir, remote_test_dir):
         binary_path=str(remote_test_dir / "launch_manager"),
         file_path=remote_test_dir.parent / "test_end",
         cwd=str(remote_test_dir),
-        timeout_s=60.0,
+        timeout_s=2.0,
     )
 
     download_xml_results(target, remote_test_dir, test_output_dir)

--- a/tests/utils/plugins/localhost.py
+++ b/tests/utils/plugins/localhost.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import logging
+import os
 import shutil
 import signal
 import subprocess
@@ -76,7 +77,10 @@ class LocalAsyncProcess(AsyncProcess):
 
     def stop(self) -> int:
         if self.is_running():
-            self._process.send_signal(signal.SIGTERM)
+            # Kill the entire process group so that children (e.g. the actual
+            # daemon binary launched under fakeroot) receive SIGTERM and can
+            # run their cleanup code before exiting.
+            os.killpg(os.getpgid(self._process.pid), signal.SIGTERM)
             for _ in range(5):
                 time.sleep(1)
                 if not self.is_running():
@@ -85,7 +89,7 @@ class LocalAsyncProcess(AsyncProcess):
                 logger.error(
                     f"Process [{self._process.pid}] did not terminate, sending SIGKILL"
                 )
-                self._process.send_signal(signal.SIGKILL)
+                os.killpg(os.getpgid(self._process.pid), signal.SIGKILL)
                 self._process.wait()
         self._output_thread.join()
         return self._process.returncode
@@ -130,6 +134,7 @@ class LocalTarget(Target):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=cwd,
+            start_new_session=True,  # Start under a new process group
         )
 
         def _async_log(proc: subprocess.Popen):

--- a/tests/utils/testing_utils/run_until_file_deployed.py
+++ b/tests/utils/testing_utils/run_until_file_deployed.py
@@ -59,10 +59,13 @@ def run_until_file_deployed(
 
         exit_code, _ = target.execute(f"test -f {file_path}")
         if exit_code == 0:
-            kill_cmd = f"kill -15 {proc.pid()}"
+            # Kill the entire process group so that children (e.g. the actual
+            # daemon binary launched under fakeroot) receive SIGTERM and can
+            # run their cleanup code before exiting.
+            kill_cmd = f"kill -15 -{proc.pid()}"
             res, _ = target.execute(kill_cmd)
             time.sleep(0.5)
-            assert proc.is_running() == False, "LCM still runing"
+            assert proc.is_running() == False, "LCM still running"
             assert res == 0, "Couldn't kill lcm"
             return proc
         logger.debug(f"Waiting for {file_path}")


### PR DESCRIPTION
The test framework was causing launch manager not to shut down correctly, fixed by terminating process groups rather than specific pids.

Additionally:
- Fix leftover memory in partial Socket::create() failure 
- Move memory name exists check inside socket.hpp
- Attempt to unlink existing memory if it is found