### PR TITLE
Using std::string_view for logging

### DIFF
--- a/src/launch_manager_daemon/common/include/score/lcm/internal/controlclientchannel.hpp
+++ b/src/launch_manager_daemon/common/include/score/lcm/internal/controlclientchannel.hpp
@@ -16,6 +16,7 @@
 #define CONTROL_CLIENT_CHANNEL_HPP_INCLUDED
 
 #include <atomic>
+#include <string_view>
 #include <score/lcm/internal/process_group_state_id.hpp>
 #include <score/lcm/internal/osal/osalipccomms.hpp>
 #include <condition_variable>
@@ -247,7 +248,7 @@ class ControlClientChannel final {
     /// @brief A utility function that converts codes to strings for logging purposes
     /// @param code The code to convert
     /// @return A string representing the code
-    const char* toString(ControlClientCode code);
+    std::string_view toString(ControlClientCode code);
 
    private:
 

--- a/src/launch_manager_daemon/common/include/score/lcm/internal/log.hpp
+++ b/src/launch_manager_daemon/common/include/score/lcm/internal/log.hpp
@@ -14,6 +14,8 @@
 #ifndef LCM_LOG_HPP_INCLUDED
 #define LCM_LOG_HPP_INCLUDED
 
+#include <cstring>
+
 // Compile time switch to use different logging subsystems.
 // Parts of LM code will be compiled into different binaries, think IPC between LifecycleClient and LM daemon.
 // In this situation, this code will need to inherit logging mechanism of the binary file.
@@ -270,9 +272,19 @@ inline Logger& _getLmLogger() noexcept
 
 }  // namespace score::lcm::internal
 
-// namespace internal
-
 #endif  // LC_LOG_SCORE_MW_LOG
+
+namespace score::lcm::internal
+{
+
+/// @brief Returns a string_view of the errno error message.
+/// @warning This method is not thread safe.
+inline std::string_view errno_message(const int err) noexcept(true)
+{
+    return std::string_view{std::strerror(err)};
+}
+
+}  // namespace score::lcm::internal
 
 // wrapper macros for Launch Manager
 #define LM_LOG_FATAL() (score::lcm::internal::_getLmLogger().LogFatal())

--- a/src/launch_manager_daemon/common/src/internal/controlclientchannel.cpp
+++ b/src/launch_manager_daemon/common/src/internal/controlclientchannel.cpp
@@ -134,7 +134,7 @@ ControlClientChannelP ControlClientChannel::initializeControlClientChannel(int f
 
     if (MAP_FAILED == channelMemory)
     {
-        LM_LOG_ERROR() << "mmap failed in initializeControlClientChannel:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "mmap failed in initializeControlClientChannel:" << errno_message(errno);
         return nullptr;
     }
 

--- a/src/launch_manager_daemon/common/src/internal/controlclientchannel.cpp
+++ b/src/launch_manager_daemon/common/src/internal/controlclientchannel.cpp
@@ -134,7 +134,7 @@ ControlClientChannelP ControlClientChannel::initializeControlClientChannel(int f
 
     if (MAP_FAILED == channelMemory)
     {
-        LM_LOG_ERROR() << "mmap failed in initializeControlClientChannel:" << std::strerror(errno);
+        LM_LOG_ERROR() << "mmap failed in initializeControlClientChannel:" << std::string_view{std::strerror(errno)};
         return nullptr;
     }
 
@@ -237,7 +237,7 @@ void ControlClientChannel::releaseParentMapping()
     ipc_parent_.reset();
 }
 
-const char* ControlClientChannel::toString(ControlClientCode code)
+std::string_view ControlClientChannel::toString(ControlClientCode code)
 {
     for (const auto& mapping : stateArray)
     {

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/factory/FlatCfgFactory.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/factory/FlatCfgFactory.cpp
@@ -185,7 +185,7 @@ bool FlatCfgFactory::createProcessStates(std::vector<ifexm::ProcessState>& f_pro
         {
             isSuccess = false;
             logger_r.LogError() << kLogPrefix
-                                << "Could not create Process States due to exception:" << f_exception_r.what();
+                                << "Could not create Process States due to exception:" << std::string_view{f_exception_r.what()};
         }
     }
     else
@@ -272,7 +272,7 @@ bool FlatCfgFactory::createMonitorIfIpcs(std::vector<ifappl::CheckpointIpcServer
         {
             isSuccess = false;
             logger_r.LogError() << kLogPrefix << "Could not create Monitor interface IPC due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
     else
@@ -332,7 +332,7 @@ bool FlatCfgFactory::createMonitorIf(std::vector<ifappl::MonitorIfDaemon>& f_int
         f_interfaces_r.clear();
         logger_r.LogError() << kLogPrefix
                             << "Could not create all necessary Monitor interfaces due to exception:"
-                            << f_exception_r.what();
+                            << std::string_view{f_exception_r.what()};
     }
 
     return isSuccess;
@@ -375,7 +375,7 @@ bool FlatCfgFactory::createSupervisionCheckpoints(std::vector<ifappl::Checkpoint
         {
             isSuccess = false;
             logger_r.LogError() << kLogPrefix << "Could not create supervision worker objects, due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
     else
@@ -477,7 +477,7 @@ bool FlatCfgFactory::createAliveSupervisions(std::vector<supervision::Alive>& f_
             logger_r.LogError() << kLogPrefix
                                 << "Could not create all necessary alive supervision "
                                    "worker objects, due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
 
@@ -541,7 +541,7 @@ bool FlatCfgFactory::createLocalSupervisions(std::vector<supervision::Local>& f_
         {
             isSuccess = false;
             logger_r.LogError() << kLogPrefix << "Could not create local supervision worker objects, due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
     else
@@ -649,7 +649,7 @@ bool FlatCfgFactory::createGlobalSupervisions(std::vector<supervision::Global>& 
         {
             isGlobalSupCfgSuccess = false;
             logger_r.LogError() << kLogPrefix << "Could not create all necessary global supervision due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
     else
@@ -702,7 +702,7 @@ bool FlatCfgFactory::createRecoveryNotifications(std::shared_ptr<score::lcm::IRe
             logger_r.LogError() << kLogPrefix
                                 << "Could not create all necessary recovery notifications "
                                    "due to exception:"
-                                << f_exception_r.what();
+                                << std::string_view{f_exception_r.what()};
         }
     }
 

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/factory/MachineConfigFactory.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/factory/MachineConfigFactory.cpp
@@ -13,6 +13,7 @@
 #include "score/lcm/saf/factory/MachineConfigFactory.hpp"
 
 #include <limits>
+#include <string_view>
 #include <fstream>
 #include "score/lcm/saf/timers/TimeConversion.hpp"
 #include "hmcore_flatcfg_generated.h"
@@ -191,8 +192,8 @@ void MachineConfigFactory::logConfiguration() noexcept(true)
     std::uint32_t wdgCount{1U};
     for (const auto& wdgConfig : watchdogConfigs)
     {
-        const char* const wdgMagicCloseBool{wdgConfig.needsMagicClose ? "true" : "false"};
-        const char* const wdgDeactivatedBool{wdgConfig.canBeDeactivated ? "true" : "false"};
+        const std::string_view wdgMagicCloseBool{wdgConfig.needsMagicClose ? "true" : "false"};
+        const std::string_view wdgDeactivatedBool{wdgConfig.canBeDeactivated ? "true" : "false"};
         logger_r.LogDebug() << kLogPrefix << "Watchdog" << wdgCount << "- device file:" << wdgConfig.fileName;
         logger_r.LogDebug() << kLogPrefix << "Watchdog" << wdgCount << "- max timeout:" << wdgConfig.timeoutMax << "ms";
         logger_r.LogDebug() << kLogPrefix << "Watchdog" << wdgCount << "- needs magic close:" << wdgMagicCloseBool;

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifappl/Checkpoint.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifappl/Checkpoint.cpp
@@ -67,9 +67,9 @@ bool Checkpoint::getDataLossEvent(void) const noexcept(true)
     return isDataLossEvent;
 }
 
-const char* Checkpoint::getConfigName(void) const noexcept(true)
+std::string_view Checkpoint::getConfigName(void) const noexcept(true)
 {
-    return k_configName.c_str();
+    return k_configName;
 }
 
 const ifexm::ProcessState* Checkpoint::getProcess(void) const noexcept(true)

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifappl/Checkpoint.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/ifappl/Checkpoint.hpp
@@ -15,6 +15,7 @@
 #define CHECKPOINT_HPP_INCLUDED
 
 #include <string>
+#include <string_view>
 
 #include <cstdint>
 
@@ -93,7 +94,7 @@ public:
 
     /// @brief Get the configuration name of the corresponding SupervisionCheckpoint
     /// @return     Name of the corresponding SupervisionCheckpoint (configuration element)
-    const char* getConfigName(void) const noexcept(true);
+    std::string_view getConfigName(void) const noexcept(true);
 
     /// @brief Return the process that is reporting this checkpoint
     /// @return process state

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Alive.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Alive.cpp
@@ -14,6 +14,7 @@
 #include "score/lcm/saf/supervision/Alive.hpp"
 
 #include <cassert>
+#include <string_view>
 
 #include "score/lcm/saf/common/Types.hpp"
 #include "score/lcm/saf/ifexm/ProcessState.hpp"
@@ -546,7 +547,7 @@ bool Alive::isMaxError(void) const noexcept(true)
 
 void Alive::logExpiredFailedStateDetails() const noexcept(true)
 {
-    const char* failedState{""};
+    std::string_view failedState{""};
     if (aliveStatus == Alive::EStatus::failed)
     {
         // failedSupervisionCycles == 1 if just switched to FAILED and > 1 if were already in FAILED before
@@ -559,11 +560,10 @@ void Alive::logExpiredFailedStateDetails() const noexcept(true)
 
     const bool minError{isMinError()};
     /* RULECHECKER_comment(0, 4, check_conditional_as_sub_expression, "Ternary operation is very simple", true_no_defect) */
-    const char* indication{((indicationCount != 1U) ? "indications" : "indication")};
     const std::uint64_t aliveIndicationMargin{minError ? k_minAliveIndications : k_maxAliveIndications};
-    const char* expectedComparison{minError ? ">=" : "<="};
+    const std::string_view expectedComparison{minError ? ">=" : "<="};
     logger_r.LogWarn() << "Alive Supervision (" << getConfigName() << ")" << failedState << ", due to"
-                       << indicationCount << "reported alive" << indication << "(expected" << expectedComparison
+                       << indicationCount << "reported alive indication(s) (expected" << expectedComparison
                        << aliveIndicationMargin << "). Failed supervision cycles:" << failedSupervisionCycles << "/"
                        << k_failedSupervisionCyclesTolerance;
 }

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ISupervision.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ISupervision.cpp
@@ -28,9 +28,9 @@ ISupervision::ISupervision(const char* const f_supervisionConfigName_p) : k_cfgN
     static_cast<void>(0);
 }
 
-const char* ISupervision::getConfigName(void) const
+std::string_view ISupervision::getConfigName(void) const noexcept
 {
-    return static_cast<const char*>(k_cfgName.c_str());
+    return k_cfgName;
 }
 
 }  // namespace supervision

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ISupervision.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ISupervision.hpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include "score/lcm/saf/timers/Timers_OsClock.hpp"
 
@@ -56,9 +57,8 @@ public:
     virtual void evaluate(const timers::NanoSecondType f_syncTimestamp) = 0;
 
     /// @brief Get the name of the configuration element for the corresponding supervision container
-    /// @return std::string   Constant string containing the name of the
-    ///                             corresponding supervision configuration container
-    const char* getConfigName(void) const;
+    /// @return std::string_view   View over the name of the corresponding supervision configuration container
+    std::string_view getConfigName(void) const noexcept;
 
 protected:
     /// @brief Default Move Constructor

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
@@ -14,6 +14,7 @@
 #include "score/lcm/saf/supervision/Local.hpp"
 
 #include <cassert>
+#include <string_view>
 
 #include "score/lcm/saf/logging/PhmLogger.hpp"
 #include "score/lcm/saf/timers/Timers_OsClock.hpp"
@@ -282,7 +283,7 @@ void Local::switchToOk(ICheckpointSupervision::EType f_type) noexcept
     pushResultToObservers();
 }
 
-void Local::switchToFailed(ICheckpointSupervision::EType f_type, const char* reason_p) noexcept
+void Local::switchToFailed(ICheckpointSupervision::EType f_type, std::string_view reason_p) noexcept
 {
     supervisionType = f_type;
     logger_r.LogWarn() << "Local Supervision (" << getConfigName() << ") switched to FAILED," << reason_p;
@@ -291,11 +292,11 @@ void Local::switchToFailed(ICheckpointSupervision::EType f_type, const char* rea
 }
 
 void Local::switchToExpired(ICheckpointSupervision::EType f_type,
-                            ifexm::ProcessCfg::ProcessExecutionError f_executionError, const char* reason_p) noexcept
+                            ifexm::ProcessCfg::ProcessExecutionError f_executionError, std::string_view reason_p) noexcept
 {
     supervisionType = f_type;
     processExecutionError = f_executionError;
-    if (nullptr == reason_p)
+    if (reason_p.empty())
     {
         if (ICheckpointSupervision::EType::aliveSupervision == f_type)
         {

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <map>
+#include <string_view>
 
 #include <cstdint>
 
@@ -174,7 +175,7 @@ PHM_PRIVATE:
     /// @brief Switch to state Failed
     /// @param [in] f_type      Type of Supervision
     /// @param [in] reason_p    Reason for switch to Failed
-    void switchToFailed(const ICheckpointSupervision::EType f_type, const char* reason_p) noexcept;
+    void switchToFailed(const ICheckpointSupervision::EType f_type, std::string_view reason_p) noexcept;
 
     /// @brief Switch to state Expired
     /// @details In case reason_p was given f_type will be ignored.
@@ -183,7 +184,7 @@ PHM_PRIVATE:
     /// @param [in] reason_p    [Optional] Other reason for switch to Expired
     void switchToExpired(ICheckpointSupervision::EType f_type,
                          ifexm::ProcessCfg::ProcessExecutionError f_executionError,
-                         const char* reason_p = nullptr) noexcept;
+                         std::string_view reason_p = {}) noexcept;
 
     /// @brief Check if ALL attached Supervisions are in status Deactivated
     bool isAllDeactivated() const noexcept;

--- a/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
+++ b/src/launch_manager_daemon/src/configuration_manager/configurationmanager.cpp
@@ -303,7 +303,7 @@ bool ConfigurationManager::parseMachineConfigurations(const ModeGroup* node, con
         ProcessGroup process_group_data;
         process_group_data.name_ = getStringViewFromFlatBuffer(node->identifier());
         process_group_data.sw_cluster_ = cluster;
-        LM_LOG_DEBUG() << "FlatBufferParser::getModeGroupPgName:" << getStringFromFlatBuffer(node->identifier())
+        LM_LOG_DEBUG() << "FlatBufferParser::getModeGroupPgName:" << std::string_view{getStringFromFlatBuffer(node->identifier())}
                        << "( IdentifierHash:" << process_group_data.name_.data() << ")";
 
         if (process_group_data.name_ != score::lcm::IdentifierHash(std::string_view(""))) {
@@ -338,7 +338,7 @@ bool ConfigurationManager::parseModeGroups(const ModeGroup* node, ProcessGroup& 
                 std::string string_name(flatbuffer_string->c_str(), flatbuffer_string->size());
                 pg_state.name_ = getStringViewFromFlatBuffer(flatbuffer_string);
                 LM_LOG_DEBUG() << "FlatBufferParser::getModeGroupPgStateName:"
-                               << mode_declaration_node->identifier()->c_str()
+                               << std::string_view{flatbuffer_string->c_str(), flatbuffer_string->size()}
                                << "( IdentifierHash:" << pg_state.name_.data() << ")";
                 process_group_data.states_.push_back(pg_state);
                 // Is this the "Off" state, i.e. does it end with "/Off" ?
@@ -395,7 +395,7 @@ static void setSchedulingParameters(const Process& node, const ProcessStartupCon
         } else if (strcasecmp("SCHED_OTHER", attribute->c_str()) == 0) {
             instance.startup_config_.scheduling_policy_ = SCHED_OTHER;
         } else {
-            LM_LOG_WARN() << "scheduling policy" << attribute->c_str() << "is not supported, using default";
+            LM_LOG_WARN() << "scheduling policy" << std::string_view{attribute->c_str(), attribute->size()} << "is not supported, using default";
         }
     }
     attribute = config.schedulingPriority();
@@ -617,7 +617,7 @@ void ConfigurationManager::parseExecutionDependency(
                 dep.process_state_ = getProcessState(state_name);
                 dep.target_process_id_ = getStringViewFromFlatBuffer(process_dependency_node->targetProcess_identifier());
                 LM_LOG_DEBUG() << "ParseProcessExecutionDependency: target process path:"
-                                << getStringFromFlatBuffer(process_dependency_node->targetProcess_identifier())
+                                << std::string_view{getStringFromFlatBuffer(process_dependency_node->targetProcess_identifier())}
                                 << "ID:" << dep.target_process_id_;
                 process_instance.dependencies_.push_back(dep);
 
@@ -761,7 +761,7 @@ bool ConfigurationManager::checkOrSetFlatConfigEnvVar(const std::string& name, c
     const char* value = getenv(name.c_str());
 
     if (value && strlen(value)) {
-        LM_LOG_DEBUG() << name.c_str() << "already set. Current value:" << value;
+        LM_LOG_DEBUG() << name << "already set. Current value:" << std::string_view{value};
         result = true;
     } else {
         if (setenv(name.c_str(), path.c_str(), overwrite_) == 0) {

--- a/src/launch_manager_daemon/src/process_group_manager/graph.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/graph.cpp
@@ -563,7 +563,7 @@ ControlClientMessage& Graph::getCancelMessage()
     return cancel_message_;
 }
 
-const char* Graph::toString(GraphState state)
+std::string_view Graph::toString(GraphState state)
 {
     switch (state)
     {

--- a/src/launch_manager_daemon/src/process_group_manager/graph.hpp
+++ b/src/launch_manager_daemon/src/process_group_manager/graph.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <atomic>
 #include <mutex>
+#include <string_view>
 #include <vector>
 
 #include <score/lcm/identifier_hash.hpp>
@@ -302,7 +303,7 @@ class Graph final {
     /// @brief A utility function that converts codes to strings for logging purposes
     /// @param state The state to convert
     /// @return A string representing the state
-    static const char* toString(GraphState state);
+    static std::string_view toString(GraphState state);
 
     /// @brief Sets the state transition request start time
     void setRequestStartTime();

--- a/src/launch_manager_daemon/src/process_group_manager/processinfonode.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processinfonode.cpp
@@ -305,7 +305,7 @@ void ProcessInfoNode::startProcess()
             if (osal::CommsType::kLaunchManager == config_->startup_config_.comms_type_)
             {
                 // Don't start launch manager, we're already running
-                LM_LOG_DEBUG() << "Found myself (" << config_->startup_config_.argv_[0U]
+                LM_LOG_DEBUG() << "Found myself (" << std::string_view{config_->startup_config_.argv_[0U]}
                                << ") in a process group to start, not starting, reporting kRunning";
                 pid_ = getpid();
                 static_cast<void>(setState(score::lcm::ProcessState::kRunning));  // Cannot fail by design
@@ -497,7 +497,7 @@ void ProcessInfoNode::terminateProcess()
     {
         if (osal::CommsType::kLaunchManager == config_->startup_config_.comms_type_)
         {
-            LM_LOG_DEBUG() << "Found myself (" << config_->startup_config_.argv_[0U]
+            LM_LOG_DEBUG() << "Found myself (" << std::string_view{config_->startup_config_.argv_[0U]}
                            << ") in a process group to terminate, not terminating, reporting kTerminated";
             static_cast<void>(setState(score::lcm::ProcessState::kTerminated));  // Cannot fail by design
         }

--- a/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
@@ -52,7 +52,8 @@ void applyLimitOrDie(const int resource, const rlimit& limit, const std::string_
 {
     if (::setrlimit(resource, &limit) == -1)
     {
-        LM_LOG_FATAL() << "[New process] Failed to set rlimit " << rlimit_name << " " << std::strerror(errno);
+        LM_LOG_FATAL() << "[New process] Failed to set rlimit " << rlimit_name << " "
+                       << score::lcm::internal::errno_message(errno);
         sysexit(EXIT_FAILURE);
     }
 }
@@ -148,7 +149,7 @@ void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig&
     if (-1 == chdir(dirname(strncpy(path_copy, config.executable_path_.c_str(), string_size))))
     {
         LM_LOG_ERROR() << "[New process] chdir(" << config.executable_path_
-                       << ") failed:" << std::string_view{std::strerror(errno)};
+                       << ") failed:" << score::lcm::internal::errno_message(errno);
         sysexit(EXIT_FAILURE);
     }
 }
@@ -280,7 +281,7 @@ inline bool IProcess::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
     if (fd < 0)
     {
         LM_LOG_ERROR() << "shm_open failed:" << config.executable_path_
-                       << "Unable to open shared memory object. Error:" << std::string_view{std::strerror(errno)};
+                       << "Unable to open shared memory object. Error:" << score::lcm::internal::errno_message(errno);
         comms_result = false;
     }
     else
@@ -292,7 +293,7 @@ inline bool IProcess::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
             comms_result = false;
             LM_LOG_ERROR() << "ftruncate failed:" << config.executable_path_
                            << "Unable to set size of shared memory file descriptor. Error:"
-                           << std::string_view{std::strerror(errno)};
+                           << score::lcm::internal::errno_message(errno);
         }
 
         if (config.comms_type_ == CommsType::kControlClient)
@@ -360,7 +361,7 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
     // setpgid will fail if called by a session lader (which LCMd is), so skip
     if (config.comms_type_ != osal::CommsType::kLaunchManager && 0 != setpgid(0, getpid()))
     {
-        LM_LOG_ERROR() << "setpgid() failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "setpgid() failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
     // Set scheduling policy with sched_setscheduler
@@ -384,21 +385,22 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
 
     if (-1 == sched_setscheduler(0, config.scheduling_policy_, &sch_param))
     {
-        LM_LOG_ERROR() << "sched_setscheduler() failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "sched_setscheduler() failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
 
     // Set core affinity using OS specific functionality in osal
     if (-1 == osal::setaffinity(config.cpu_mask_))
     {
-        LM_LOG_ERROR() << "setaffinity(" << config.cpu_mask_ << ") failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "setaffinity(" << config.cpu_mask_
+                       << ") failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
 
     // Set group ID
     if (-1 == setgid(config.gid_))
     {
-        LM_LOG_ERROR() << "setgid(" << config.gid_ << ") failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "setgid(" << config.gid_ << ") failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
     // Set supplementary group ids
@@ -408,14 +410,14 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
     if (supplementary_gids_number > 0 &&
         -1 == osal::setgroups(supplementary_gids_number, config.supplementary_gids_.data()))
     {
-        LM_LOG_ERROR() << "setgroups() failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "setgroups() failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
 
     // Set user ID
     if (-1 == setuid(config.uid_))
     {
-        LM_LOG_ERROR() << "setuid(" << config.uid_ << ") failed:" << std::string_view{std::strerror(errno)};
+        LM_LOG_ERROR() << "setuid(" << config.uid_ << ") failed:" << score::lcm::internal::errno_message(errno);
         retval = OsalReturnType::kFail;
     }
 
@@ -442,7 +444,7 @@ inline void IProcess::handleChildProcess(ChildProcessConfig& param)
     if (-1 == execve(param.config->argv_[0], const_cast<char* const*>(param.config->argv_.data()), param.config->envp_))
     {
         LM_LOG_ERROR() << "[New process] execve failed: Unable to execute the" << param.config->executable_path_
-                       << "app. Error:" << std::string_view{std::strerror(errno)};
+                       << "app. Error:" << score::lcm::internal::errno_message(errno);
         sysexit(EXIT_FAILURE);
     }
 }
@@ -462,7 +464,7 @@ OsalReturnType IProcess::requestTermination(ProcessID pid)
         else
         {
             LM_LOG_ERROR() << "SIGTERM failed: Unable to send SIGTERM to process ID" << pid
-                           << ". Error:" << std::string_view{std::strerror(errno)};
+                           << ". Error:" << score::lcm::internal::errno_message(errno);
         }
     }
     else
@@ -519,7 +521,7 @@ OsalReturnType IProcess::waitForTermination(osal::ProcessID& pid, int32_t& statu
     {
         /// exiting with pid == 0 is perfectly normal behaviour when all process groups are in the Off state.
         LM_LOG_DEBUG() << "wait failed: Unable to wait for any child process to terminate. Error:"
-                       << std::string_view{std::strerror(errno)};
+                       << score::lcm::internal::errno_message(errno);
     }
 
     return result;
@@ -561,7 +563,7 @@ OsalReturnType IProcess::waitForkRunning(IpcCommsP sync, std::chrono::millisecon
         else
         {
             LM_LOG_WARN() << "Skipping semaphore deinitialization - shared memory region appears invalid: "
-                          << std::string_view{std::strerror(errno)};
+                          << score::lcm::internal::errno_message(errno);
         }
     }
     else

--- a/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
@@ -102,7 +102,7 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
             if (-1 == fcntl(IpcCommsSync::sync_fd, F_SETFD, 0))
             {
                 LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
-                               << "failed:" << std::string_view(std::strerror(errno));
+                               << "failed:" << score::lcm::internal::errno_message(errno);
                 sysexit(EXIT_FAILURE);
             }
             close(IpcCommsSync::control_client_handler_nudge_fd);
@@ -111,13 +111,13 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
             if (-1 == fcntl(IpcCommsSync::sync_fd, F_SETFD, 0))
             {
                 LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
-                               << "failed:" << std::string_view(std::strerror(errno));
+                               << "failed:" << score::lcm::internal::errno_message(errno);
                 sysexit(EXIT_FAILURE);
             }
             if (-1 == fcntl(IpcCommsSync::control_client_handler_nudge_fd, F_SETFD, 0))
             {
                 LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
-                               << "failed:" << std::string_view(std::strerror(errno));
+                               << "failed:" << score::lcm::internal::errno_message(errno);
             }
             break;
         case CommsType::kLaunchManager:
@@ -174,7 +174,7 @@ void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
         if (score::lcm::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
         {
             LM_LOG_ERROR() << "[New process] changeSecurityPolicy(" << config.security_policy_
-                           << ") failed:" << std::string_view{strerror(errno)};
+                           << ") failed:" << score::lcm::internal::errno_message(errno);
             sysexit(EXIT_FAILURE);
         }
     }

--- a/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
+++ b/src/launch_manager_daemon/src/process_group_manager/processlauncher.cpp
@@ -11,6 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+#include <string_view>
+
 #include <fcntl.h>
 #include <grp.h>
 #include <libgen.h>
@@ -50,12 +52,10 @@ void applyLimitOrDie(const int resource, const rlimit& limit, const std::string_
 {
     if (::setrlimit(resource, &limit) == -1)
     {
-        LM_LOG_FATAL() << "[New process] Failed to set rlimit " << rlimit_name
-            << " " << std::strerror(errno);
+        LM_LOG_FATAL() << "[New process] Failed to set rlimit " << rlimit_name << " " << std::strerror(errno);
         sysexit(EXIT_FAILURE);
     }
 }
-
 
 /// @brief Sets the limit if given a non-zero value, otherwise skips.
 /// @warning This will sysexit if the set is not succesful.
@@ -66,14 +66,13 @@ void setLimit(const int resource, const std::size_t amount, const std::string_vi
         return;
     }
 
-    const struct rlimit limit {
+    const struct rlimit limit{
         .rlim_cur = amount,
         .rlim_max = amount,
     };
 
     applyLimitOrDie(resource, limit, rlimit_name);
 }
-
 
 void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
 {
@@ -101,7 +100,8 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
         case CommsType::kReporting:
             if (-1 == fcntl(IpcCommsSync::sync_fd, F_SETFD, 0))
             {
-                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__ << "failed:" << std::strerror(errno);
+                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
+                               << "failed:" << std::string_view(std::strerror(errno));
                 sysexit(EXIT_FAILURE);
             }
             close(IpcCommsSync::control_client_handler_nudge_fd);
@@ -109,12 +109,14 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
         case CommsType::kControlClient:
             if (-1 == fcntl(IpcCommsSync::sync_fd, F_SETFD, 0))
             {
-                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__ << "failed:" << std::strerror(errno);
+                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
+                               << "failed:" << std::string_view(std::strerror(errno));
                 sysexit(EXIT_FAILURE);
             }
             if (-1 == fcntl(IpcCommsSync::control_client_handler_nudge_fd, F_SETFD, 0))
             {
-                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__ << "failed:" << std::strerror(errno);
+                LM_LOG_ERROR() << "[New process] fcntl() at line" << __LINE__
+                               << "failed:" << std::string_view(std::strerror(errno));
             }
             break;
         case CommsType::kLaunchManager:
@@ -122,7 +124,7 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
             break;
         default:
             LM_LOG_ERROR() << "[New process] at line" << __LINE__ << "unknown CommsType"
-                            << static_cast<std::int32_t>(param.shared_block->comms_type_);
+                           << static_cast<std::int32_t>(param.shared_block->comms_type_);
             sysexit(EXIT_FAILURE);
             break;
     }
@@ -145,7 +147,8 @@ void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig&
 
     if (-1 == chdir(dirname(strncpy(path_copy, config.executable_path_.c_str(), string_size))))
     {
-        LM_LOG_ERROR() << "[New process] chdir(" << config.executable_path_ << ") failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "[New process] chdir(" << config.executable_path_
+                       << ") failed:" << std::string_view{std::strerror(errno)};
         sysexit(EXIT_FAILURE);
     }
 }
@@ -170,7 +173,7 @@ void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
         if (score::lcm::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
         {
             LM_LOG_ERROR() << "[New process] changeSecurityPolicy(" << config.security_policy_
-                           << ") failed:" << strerror(errno);
+                           << ") failed:" << std::string_view{strerror(errno)};
             sysexit(EXIT_FAILURE);
         }
     }
@@ -277,7 +280,7 @@ inline bool IProcess::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
     if (fd < 0)
     {
         LM_LOG_ERROR() << "shm_open failed:" << config.executable_path_
-                       << "Unable to open shared memory object. Error:" << std::strerror(errno);
+                       << "Unable to open shared memory object. Error:" << std::string_view{std::strerror(errno)};
         comms_result = false;
     }
     else
@@ -288,7 +291,8 @@ inline bool IProcess::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
         {
             comms_result = false;
             LM_LOG_ERROR() << "ftruncate failed:" << config.executable_path_
-                           << "Unable to set size of shared memory file descriptor. Error:" << std::strerror(errno);
+                           << "Unable to set size of shared memory file descriptor. Error:"
+                           << std::string_view{std::strerror(errno)};
         }
 
         if (config.comms_type_ == CommsType::kControlClient)
@@ -356,7 +360,7 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
     // setpgid will fail if called by a session lader (which LCMd is), so skip
     if (config.comms_type_ != osal::CommsType::kLaunchManager && 0 != setpgid(0, getpid()))
     {
-        LM_LOG_ERROR() << "setpgid() failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "setpgid() failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
     // Set scheduling policy with sched_setscheduler
@@ -380,21 +384,21 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
 
     if (-1 == sched_setscheduler(0, config.scheduling_policy_, &sch_param))
     {
-        LM_LOG_ERROR() << "sched_setscheduler() failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "sched_setscheduler() failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
 
     // Set core affinity using OS specific functionality in osal
     if (-1 == osal::setaffinity(config.cpu_mask_))
     {
-        LM_LOG_ERROR() << "setaffinity(" << config.cpu_mask_ << ") failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "setaffinity(" << config.cpu_mask_ << ") failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
 
     // Set group ID
     if (-1 == setgid(config.gid_))
     {
-        LM_LOG_ERROR() << "setgid(" << config.gid_ << ") failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "setgid(" << config.gid_ << ") failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
     // Set supplementary group ids
@@ -404,14 +408,14 @@ OsalReturnType IProcess::setSchedulingAndSecurity(const OsalConfig& config)
     if (supplementary_gids_number > 0 &&
         -1 == osal::setgroups(supplementary_gids_number, config.supplementary_gids_.data()))
     {
-        LM_LOG_ERROR() << "setgroups() failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "setgroups() failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
 
     // Set user ID
     if (-1 == setuid(config.uid_))
     {
-        LM_LOG_ERROR() << "setuid(" << config.uid_ << ") failed:" << std::strerror(errno);
+        LM_LOG_ERROR() << "setuid(" << config.uid_ << ") failed:" << std::string_view{std::strerror(errno)};
         retval = OsalReturnType::kFail;
     }
 
@@ -438,7 +442,7 @@ inline void IProcess::handleChildProcess(ChildProcessConfig& param)
     if (-1 == execve(param.config->argv_[0], const_cast<char* const*>(param.config->argv_.data()), param.config->envp_))
     {
         LM_LOG_ERROR() << "[New process] execve failed: Unable to execute the" << param.config->executable_path_
-                       << "app. Error:" << std::strerror(errno);
+                       << "app. Error:" << std::string_view{std::strerror(errno)};
         sysexit(EXIT_FAILURE);
     }
 }
@@ -458,7 +462,7 @@ OsalReturnType IProcess::requestTermination(ProcessID pid)
         else
         {
             LM_LOG_ERROR() << "SIGTERM failed: Unable to send SIGTERM to process ID" << pid
-                           << ". Error:" << std::strerror(errno);
+                           << ". Error:" << std::string_view{std::strerror(errno)};
         }
     }
     else
@@ -515,7 +519,7 @@ OsalReturnType IProcess::waitForTermination(osal::ProcessID& pid, int32_t& statu
     {
         /// exiting with pid == 0 is perfectly normal behaviour when all process groups are in the Off state.
         LM_LOG_DEBUG() << "wait failed: Unable to wait for any child process to terminate. Error:"
-                       << std::strerror(errno);
+                       << std::string_view{std::strerror(errno)};
     }
 
     return result;
@@ -557,7 +561,7 @@ OsalReturnType IProcess::waitForkRunning(IpcCommsP sync, std::chrono::millisecon
         else
         {
             LM_LOG_WARN() << "Skipping semaphore deinitialization - shared memory region appears invalid: "
-                          << std::strerror(errno);
+                          << std::string_view{std::strerror(errno)};
         }
     }
     else


### PR DESCRIPTION
Replacing char * to std::string_view to reduce logging warnings