### PR TITLE
Align public API namespaces to score::mw::lifecycle and score::mw::health

### DIFF
--- a/examples/control_application/control_daemon.cpp
+++ b/examples/control_application/control_daemon.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);
 
-    score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
 
     ipc_dropin::Socket<static_cast<size_t>(sizeof(RunTargetInfo)), control_socket_capacity> sm_control_socket{};
     if (sm_control_socket.create(control_socket_path, 600) != ipc_dropin::ReturnCode::kOk) {
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    score::lcm::ControlClient client;
+    score::mw::lifecycle::ControlClient client;
 
     score::safecpp::Scope<> scope{};
     while (!exitRequested) {

--- a/examples/cpp_supervised_app/main.cpp
+++ b/examples/cpp_supervised_app/main.cpp
@@ -30,7 +30,7 @@
 #include <score/hm/health_monitor.h>
 #include <thread>
 
-using score::mw::health::Monitor;
+using score::mw::lifecycle::Monitor;
 
 /// @brief CLI configuration options for the demo_application process
 struct Config

--- a/examples/cpp_supervised_app/main.cpp
+++ b/examples/cpp_supervised_app/main.cpp
@@ -30,7 +30,7 @@
 #include <score/hm/health_monitor.h>
 #include <thread>
 
-using score::lcm::Monitor;
+using score::mw::health::Monitor;
 
 /// @brief CLI configuration options for the demo_application process
 struct Config
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
     score::mw::log::rust::StdoutLoggerBuilder builder;
     builder.Context("APP").LogLevel(score::mw::log::rust::LogLevel::Verbose).SetAsDefaultLogger();
 
-    using namespace score::hm;
+    using namespace score::mw::health;
 
     auto builder_mon =
         deadline::DeadlineMonitorBuilder()
@@ -149,7 +149,7 @@ int main(int argc, char** argv)
 
         hm.start();
 
-        score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
 
         auto deadline_mon = std::move(*deadline_monitor_res);
 

--- a/src/control_client_lib/include/score/lcm/control_client.h
+++ b/src/control_client_lib/include/score/lcm/control_client.h
@@ -20,9 +20,7 @@
 #include <memory>
 #include "score/lcm/exec_error_domain.h"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 class ControlClientImpl;
 
@@ -67,16 +65,16 @@ class ControlClient final {
     ///
     /// @param[in] runTargetName name of the Run Target that should be activated. Launch Manager will deactivate the currently active Run Target and activate Run Target identified by this parameter.
     /// @returns void if activation requested is successful, otherwise it returns ExecErrorDomain error.
-    /// @error score::lcm::ExecErrc::kCancelled if activation requested was cancelled by a newer request
-    /// @error score::lcm::ExecErrc::kFailed if activation requested failed
-    /// @error score::lcm::ExecErrc::kFailedUnexpectedTerminationOnExit if Unexpected Termination of a Process assigned to the previously active Run Target happened.
-    /// @error score::lcm::ExecErrc::kFailedUnexpectedTerminationOnEnter if Unexpected Termination of a Process assigned the requested Run Target happened.
-    /// @error score::lcm::ExecErrc::kInvalidArguments if argument passed doesn't appear to be valid (e.g. after a software update, given Run Target doesn't exist anymore)
-    /// @error score::lcm::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
-    /// @error score::lcm::ExecErrc::kAlreadyInState if the requested Run Target is already active
-    /// @error score::lcm::ExecErrc::kInTransitionToSameState if there is already an ongoing request to activate requested Run Target
-    /// @error score::lcm::ExecErrc::kInvalidTransition if activation of the requested Run Target is prohibited (e.g. Off Run Target)
-    /// @error score::lcm::ExecErrc::kGeneralError if any other error occurs.
+    /// @error score::mw::lifecycle::ExecErrc::kCancelled if activation requested was cancelled by a newer request
+    /// @error score::mw::lifecycle::ExecErrc::kFailed if activation requested failed
+    /// @error score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnExit if Unexpected Termination of a Process assigned to the previously active Run Target happened.
+    /// @error score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnEnter if Unexpected Termination of a Process assigned the requested Run Target happened.
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidArguments if argument passed doesn't appear to be valid (e.g. after a software update, given Run Target doesn't exist anymore)
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
+    /// @error score::mw::lifecycle::ExecErrc::kAlreadyInState if the requested Run Target is already active
+    /// @error score::mw::lifecycle::ExecErrc::kInTransitionToSameState if there is already an ongoing request to activate requested Run Target
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidTransition if activation of the requested Run Target is prohibited (e.g. Off Run Target)
+    /// @error score::mw::lifecycle::ExecErrc::kGeneralError if any other error occurs.
     ///
     /// @threadsafety{thread-safe}
     ///
@@ -87,8 +85,6 @@ class ControlClient final {
     std::unique_ptr<ControlClientImpl> control_client_impl_;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // CONTROL_CLIENT_H_

--- a/src/control_client_lib/src/control_client.cpp
+++ b/src/control_client_lib/src/control_client.cpp
@@ -19,12 +19,10 @@
 #include <score/lcm/identifier_hash.hpp>
 #include "control_client_impl.hpp"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 // coverity[exn_spec_violation:FALSE] SetError cannot raise an exception in this instance
-inline score::concurrency::InterruptibleFuture<void> GetErrorFuture(score::lcm::ExecErrc errType) noexcept {
+inline score::concurrency::InterruptibleFuture<void> GetErrorFuture(ExecErrc errType) noexcept {
     score::concurrency::InterruptiblePromise<void> tmp_{};
     tmp_.SetError(errType);
     return tmp_.GetInterruptibleFuture().value();
@@ -57,8 +55,8 @@ score::concurrency::InterruptibleFuture<void> ControlClient::ActivateRunTarget(s
 
     if( control_client_impl_ != nullptr )
     {
-        static IdentifierHash pg_name{"MainPG"};
-        IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
+        static score::lcm::IdentifierHash pg_name{"MainPG"};
+        score::lcm::IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
         retVal_ = control_client_impl_->SetState(pg_name, pg_state);
     }
     else
@@ -69,6 +67,4 @@ score::concurrency::InterruptibleFuture<void> ControlClient::ActivateRunTarget(s
     return retVal_;
 }
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/src/control_client_lib/src/control_client_impl.cpp
+++ b/src/control_client_lib/src/control_client_impl.cpp
@@ -31,31 +31,29 @@
 // setting the mapping for both ControlClientCode and ExecErrc codes for error handling
 // This approach is used to avoid using switch-case statements
 // RULECHECKER_comment(1, 2, check_static_object_dynamic_initialization, "Map doesn't rely on any other static so this is fine", false)
-static std::map<score::lcm::internal::ControlClientCode, score::lcm::ExecErrc> scErrorMap =
+static std::map<score::lcm::internal::ControlClientCode, score::mw::lifecycle::ExecErrc> scErrorMap =
 {
     { score::lcm::internal::ControlClientCode::kSetStateInvalidArguments,
-      score::lcm::ExecErrc::kInvalidArguments },
+      score::mw::lifecycle::ExecErrc::kInvalidArguments },
     { score::lcm::internal::ControlClientCode::kSetStateCancelled,
-      score::lcm::ExecErrc::kCancelled },
+      score::mw::lifecycle::ExecErrc::kCancelled },
     { score::lcm::internal::ControlClientCode::kSetStateFailed,
-      score::lcm::ExecErrc::kFailed },
+      score::mw::lifecycle::ExecErrc::kFailed },
     { score::lcm::internal::ControlClientCode::kSetStateAlreadyInState,
-      score::lcm::ExecErrc::kAlreadyInState },
+      score::mw::lifecycle::ExecErrc::kAlreadyInState },
     { score::lcm::internal::ControlClientCode::kSetStateTransitionToSameState,
-      score::lcm::ExecErrc::kInTransitionToSameState },
+      score::mw::lifecycle::ExecErrc::kInTransitionToSameState },
     { score::lcm::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter,
-      score::lcm::ExecErrc::kFailedUnexpectedTerminationOnEnter }
+      score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnEnter }
 };
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 bool ControlClientImpl::instance_created_{false};
 std::mutex ControlClientImpl::instance_creation_mutex_{};
 
 // coverity[exn_spec_violation:FALSE] SetError cannot raise an exception in this instance
-inline score::concurrency::InterruptibleFuture<void> GetErrorFuture(score::lcm::ExecErrc errType) noexcept
+inline score::concurrency::InterruptibleFuture<void> GetErrorFuture(score::mw::lifecycle::ExecErrc errType) noexcept
 {
     score::concurrency::InterruptiblePromise<void> tmp_ {};
     tmp_.SetError( errType );
@@ -81,9 +79,9 @@ ControlClientImpl::ControlClientImpl(std::function<void(const score::lcm::Execut
         }
 
     struct stat stats;
-    const auto fstat_ret = fstat(internal::osal::IpcCommsSync::sync_fd, &stats);
+    const auto fstat_ret = fstat(score::lcm::internal::osal::IpcCommsSync::sync_fd, &stats);
     // Check size we have access of to avoid a crash if fd is not pointing to correct data
-    const auto needed_size = sizeof(internal::osal::IpcCommsSync) + sizeof(internal::ControlClientChannel);
+    const auto needed_size = sizeof(score::lcm::internal::osal::IpcCommsSync) + sizeof(score::lcm::internal::ControlClientChannel);
     if (fstat_ret == -1 || stats.st_size != static_cast<off_t>(needed_size)) {
         LM_LOG_ERROR() << "Control client channel at sync_fd is not valid!";
         instance_created_ = false;
@@ -156,7 +154,7 @@ void ControlClientImpl::run() {
                                                            initial_machine_state_transition_request_ ) )
                                                      {
                                                          control_client_requests_[i].promise_.SetError(
-                                                             score::lcm::ExecErrc::kFailed );
+                                                             score::mw::lifecycle::ExecErrc::kFailed );
                                                          control_client_requests_[i].
                                                          initial_machine_state_transition_request_ = false;
                                                          control_client_requests_[i].in_use_
@@ -301,7 +299,7 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
     return retVal_;
 }
 
-score::concurrency::InterruptibleFuture<void> ControlClientImpl::SetState(const IdentifierHash& pg_name, const IdentifierHash& pg_state) noexcept {
+score::concurrency::InterruptibleFuture<void> ControlClientImpl::SetState(const score::lcm::IdentifierHash& pg_name, const score::lcm::IdentifierHash& pg_state) noexcept {
     score::concurrency::InterruptibleFuture<void> retVal_{};
 
     if (nullptr != ipc_channel_) {
@@ -344,7 +342,7 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::GetInitialMachi
 score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionError(
     const score::lcm::IdentifierHash& processGroup) noexcept {
     // default error (just in case)
-    score::Result<score::lcm::ExecutionErrorEvent> retVal_ {score::MakeUnexpected(score::lcm::ExecErrc::kCommunicationError)};
+    score::Result<score::lcm::ExecutionErrorEvent> retVal_ {score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
 
     if (nullptr != ipc_channel_) {
         if (score::lcm::internal::osal::OsalReturnType::kSuccess ==
@@ -365,7 +363,7 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
                 // GetExecutionError
                 case score::lcm::internal::ControlClientCode::kExecutionErrorInvalidArguments:
                 case score::lcm::internal::ControlClientCode::kExecutionErrorRequestFailed:
-                    retVal_ = score::MakeUnexpected( score::lcm::ExecErrc::kFailed );
+                    retVal_ = score::MakeUnexpected( score::mw::lifecycle::ExecErrc::kFailed );
                     break;
 
                 case score::lcm::internal::ControlClientCode::kExecutionErrorRequestSuccess: {
@@ -377,7 +375,7 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
                 default:
                     LM_LOG_WARN() << "ControlClient error. GetExecutionError unexpected response from Launch Manager:"
                                 << static_cast<int>( msg.request_or_response_ );
-                    retVal_ = score::MakeUnexpected(score::lcm::ExecErrc::kFailed );
+                    retVal_ = score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kFailed );
                     break;
             }
 
@@ -391,6 +389,4 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
     return retVal_;
 }
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/src/control_client_lib/src/control_client_impl.hpp
+++ b/src/control_client_lib/src/control_client_impl.hpp
@@ -26,9 +26,7 @@
 #include <score/lcm/internal/controlclientchannel.hpp>
 #include "execution_error_event.h"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 /// @brief Data structure used to manage active, i.e. still not completed, requests from ControlClient.
 /// Most of the ControlClient methods are asynchronous. This means that when an API call returns,
@@ -94,27 +92,27 @@ class ControlClientImpl final {
     /// @param[in] pg_state representing meta-model definition of a state. Launch Manager will perform state transition from the current state to the state identified by this parameter.
     ///
     /// @returns void if requested transition is successful, otherwise it returns ExecErrorDomain error.
-    /// @error score::lcm::ExecErrc::kCancelled if transition to the requested Process Group state was cancelled by a newer request
-    /// @error score::lcm::ExecErrc::kFailed if transition to the requested Process Group state failed
-    /// @error score::lcm::ExecErrc::kFailedUnexpectedTerminationOnExit if Unexpected Termination in Process of previous Process Group State happened.
-    /// @error score::lcm::ExecErrc::kFailedUnexpectedTerminationOnEnter if Unexpected Termination in Process of target Process Group State happened.
-    /// @error score::lcm::ExecErrc::kInvalidArguments if arguments passed doesn't appear to be valid (e.g. after a software update, given processGroup doesn't exist anymore)
-    /// @error score::lcm::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
-    /// @error score::lcm::ExecErrc::kAlreadyInState if the ProcessGroup is already in the requested state
-    /// @error score::lcm::ExecErrc::kInTransitionToSameState if a transition to the requested state is already ongoing
-    /// @error score::lcm::ExecErrc::kInvalidTransition if transition to the requested state is prohibited (e.g. Off state for MainPG)
-    /// @error score::lcm::ExecErrc::kGeneralError if any other error occurs.
-    score::concurrency::InterruptibleFuture<void> SetState(const IdentifierHash& pg_name, const IdentifierHash& pg_state) noexcept;
+    /// @error score::mw::lifecycle::ExecErrc::kCancelled if transition to the requested Process Group state was cancelled by a newer request
+    /// @error score::mw::lifecycle::ExecErrc::kFailed if transition to the requested Process Group state failed
+    /// @error score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnExit if Unexpected Termination in Process of previous Process Group State happened.
+    /// @error score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnEnter if Unexpected Termination in Process of target Process Group State happened.
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidArguments if arguments passed doesn't appear to be valid (e.g. after a software update, given processGroup doesn't exist anymore)
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
+    /// @error score::mw::lifecycle::ExecErrc::kAlreadyInState if the ProcessGroup is already in the requested state
+    /// @error score::mw::lifecycle::ExecErrc::kInTransitionToSameState if a transition to the requested state is already ongoing
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidTransition if transition to the requested state is prohibited (e.g. Off state for MainPG)
+    /// @error score::mw::lifecycle::ExecErrc::kGeneralError if any other error occurs.
+    score::concurrency::InterruptibleFuture<void> SetState(const score::lcm::IdentifierHash& pg_name, const score::lcm::IdentifierHash& pg_state) noexcept;
 
     /// @brief Method to retrieve result of Machine State initial transition to Startup state.
     ///
     /// Please note that this transition happens once per machine life cycle, thus result delivered by this method shall not change (unless machine is started again).
     ///
     /// @returns void if requested transition is successful, otherwise it returns ExecErrorDomain error.
-    /// @error score::lcm::ExecErrc::kCancelled if transition to the requested Process Group state was cancelled by a newer request
-    /// @error score::lcm::ExecErrc::kFailed if transition to the requested Process Group state failed
-    /// @error score::lcm::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
-    /// @error score::lcm::ExecErrc::kGeneralError if any other error occurs.
+    /// @error score::mw::lifecycle::ExecErrc::kCancelled if transition to the requested Process Group state was cancelled by a newer request
+    /// @error score::mw::lifecycle::ExecErrc::kFailed if transition to the requested Process Group state failed
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
+    /// @error score::mw::lifecycle::ExecErrc::kGeneralError if any other error occurs.
     score::concurrency::InterruptibleFuture<void> GetInitialMachineStateTransitionResult() noexcept;
 
     /// @brief Returns the execution error which changed the given Process Group to an Undefined Process Group State.
@@ -125,8 +123,8 @@ class ControlClientImpl final {
     /// @param[in] processGroup   For which Process Group the error should be retrieved.
     ///
     /// @returns The execution error which changed the given Process Group to an Undefined Process Group State.
-    /// @error score::lcm::ExecErrc::kFailed    Given Process Group is not in an Undefined Process Group State.
-    /// @error score::lcm::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
+    /// @error score::mw::lifecycle::ExecErrc::kFailed    Given Process Group is not in an Undefined Process Group State.
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch Manager (e.g. IPC link is down)
     score::Result<score::lcm::ExecutionErrorEvent> GetExecutionError(
         const score::lcm::IdentifierHash& processGroup) noexcept;
 
@@ -198,15 +196,13 @@ class ControlClientImpl final {
     ///
     /// @returns score::concurrency::InterruptibleFuture<void> when message is successfully sent to LCM. This future can be
     ///                                  used to retrieve LCM response at a later time.
-    /// @error score::lcm::ExecErrc::kFailed if the message could not be send to LCM
-    /// @error score::lcm::ExecErrc::kCommunicationError if we can't get access to the request_ link
+    /// @error score::mw::lifecycle::ExecErrc::kFailed if the message could not be send to LCM
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if we can't get access to the request_ link
     ///
     /// @threadsafety{thread-safe}
     score::concurrency::InterruptibleFuture<void> SendIpcMessage(score::lcm::internal::ControlClientMessage& msg) noexcept;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // CONTROL_CLIENT_IMPL_H_

--- a/src/health_monitoring_lib/cpp/common.cpp
+++ b/src/health_monitoring_lib/cpp/common.cpp
@@ -13,7 +13,7 @@
 #include <score/assert.hpp>
 #include <score/hm/common.h>
 
-namespace score::hm::internal
+namespace score::mw::health::internal
 {
 
 DroppableFFIHandle::DroppableFFIHandle(FFIHandle handle, DropFn drop_fn) : handle_(handle), drop_fn_(drop_fn) {}
@@ -80,4 +80,4 @@ DroppableFFIHandle::~DroppableFFIHandle()
     }
 }
 
-}  // namespace score::hm::internal
+}  // namespace score::mw::health::internal

--- a/src/health_monitoring_lib/cpp/deadline_monitor.cpp
+++ b/src/health_monitoring_lib/cpp/deadline_monitor.cpp
@@ -15,9 +15,9 @@
 namespace
 {
 extern "C" {
-using namespace score::hm;
-using namespace score::hm::internal;
-using namespace score::hm::deadline;
+using namespace score::mw::health;
+using namespace score::mw::health::internal;
+using namespace score::mw::health::deadline;
 
 // Functions below must match functions defined in `crate::deadline::ffi`.
 
@@ -48,7 +48,7 @@ FFIHandle deadline_monitor_builder_create_wrapper()
 
 // C++ wrapper for Rust library - the API implementation obeys the Rust API semantics and it's invariants
 
-namespace score::hm::deadline
+namespace score::mw::health::deadline
 {
 DeadlineMonitorBuilder::DeadlineMonitorBuilder()
     : monitor_builder_handler_{deadline_monitor_builder_create_wrapper(), &deadline_monitor_builder_destroy}
@@ -68,7 +68,7 @@ DeadlineMonitorBuilder DeadlineMonitorBuilder::add_deadline(const DeadlineTag& d
 
 DeadlineMonitor::DeadlineMonitor(FFIHandle handle) : monitor_handle_(handle, &deadline_monitor_destroy) {}
 
-score::cpp::expected<Deadline, score::hm::Error> DeadlineMonitor::get_deadline(const DeadlineTag& deadline_tag)
+score::cpp::expected<Deadline, score::mw::health::Error> DeadlineMonitor::get_deadline(const DeadlineTag& deadline_tag)
 {
     auto handle = monitor_handle_.as_rust_handle();
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION(handle.has_value());
@@ -80,7 +80,7 @@ score::cpp::expected<Deadline, score::hm::Error> DeadlineMonitor::get_deadline(c
         return score::cpp::unexpected(static_cast<Error>(result));
     }
 
-    return score::cpp::expected<Deadline, score::hm::Error>(Deadline{ret});
+    return score::cpp::expected<Deadline, score::mw::health::Error>(Deadline{ret});
 }
 
 Deadline::Deadline(FFIHandle handle) : deadline_handle_(handle, &deadline_destroy), has_handle_(false) {}
@@ -90,12 +90,12 @@ Deadline::~Deadline()
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION(!has_handle_);
 }
 
-score::cpp::expected<DeadlineHandle, score::hm::Error> Deadline::start()
+score::cpp::expected<DeadlineHandle, score::mw::health::Error> Deadline::start()
 {
     // Cannot start a deadline that is already started
     if (has_handle_)
     {
-        return score::cpp::unexpected(::score::hm::Error::WrongState);
+        return score::cpp::unexpected(::score::mw::health::Error::WrongState);
     }
 
     auto handle = deadline_handle_.as_rust_handle();
@@ -108,7 +108,7 @@ score::cpp::expected<DeadlineHandle, score::hm::Error> Deadline::start()
     }
 
     has_handle_ = true;
-    return score::cpp::expected<DeadlineHandle, score::hm::Error>(DeadlineHandle{*this});
+    return score::cpp::expected<DeadlineHandle, score::mw::health::Error>(DeadlineHandle{*this});
 }
 
 DeadlineHandle::DeadlineHandle(Deadline& deadline) : was_stopped_(false), deadline_(deadline) {}
@@ -146,4 +146,4 @@ DeadlineHandle::~DeadlineHandle()
     deadline_.value().get().has_handle_ = false;
 }
 
-}  // namespace score::hm::deadline
+}  // namespace score::mw::health::deadline

--- a/src/health_monitoring_lib/cpp/health_monitor.cpp
+++ b/src/health_monitoring_lib/cpp/health_monitor.cpp
@@ -15,11 +15,11 @@
 namespace
 {
 extern "C" {
-using namespace score::hm;
-using namespace score::hm::internal;
-using namespace score::hm::deadline;
-using namespace score::hm::heartbeat;
-using namespace score::hm::logic;
+using namespace score::mw::health;
+using namespace score::mw::health::internal;
+using namespace score::mw::health::deadline;
+using namespace score::mw::health::heartbeat;
+using namespace score::mw::health::logic;
 
 // Functions below must match functions defined in `crate::ffi`.
 
@@ -64,7 +64,7 @@ FFIHandle health_monitor_builder_create_wrapper()
 
 // C++ wrapper for Rust library - the API implementation obeys the Rust API semantics and it's invariants
 
-namespace score::hm
+namespace score::mw::health
 {
 
 HealthMonitorBuilder::HealthMonitorBuilder()
@@ -130,7 +130,7 @@ HealthMonitorBuilder HealthMonitorBuilder::with_supervisor_api_cycle(std::chrono
     return std::move(*this);
 }
 
-HealthMonitorBuilder HealthMonitorBuilder::thread_parameters(score::hm::ThreadParameters&& thread_parameters) &&
+HealthMonitorBuilder HealthMonitorBuilder::thread_parameters(score::mw::health::ThreadParameters&& thread_parameters) &&
 {
     thread_parameters_ = std::move(thread_parameters);
     return std::move(*this);
@@ -251,4 +251,4 @@ HealthMonitor& HealthMonitor::operator=(HealthMonitor&& other)
     return *this;
 }
 
-}  // namespace score::hm
+}  // namespace score::mw::health

--- a/src/health_monitoring_lib/cpp/heartbeat_monitor.cpp
+++ b/src/health_monitoring_lib/cpp/heartbeat_monitor.cpp
@@ -14,9 +14,9 @@
 
 namespace {
 extern "C" {
-using namespace score::hm;
-using namespace score::hm::internal;
-using namespace score::hm::heartbeat;
+using namespace score::mw::health;
+using namespace score::mw::health::internal;
+using namespace score::mw::health::heartbeat;
 
 FFICode heartbeat_monitor_builder_create(uint32_t range_min_ms, uint32_t range_max_ms, FFIHandle* heartbeat_monitor_builder_handle_out);
 FFICode heartbeat_monitor_builder_destroy(FFIHandle heartbeat_monitor_builder_handle);
@@ -34,7 +34,7 @@ FFIHandle heartbeat_monitor_builder_create_wrapper(uint32_t range_min_ms, uint32
 
 }
 
-namespace score::hm::heartbeat
+namespace score::mw::health::heartbeat
 {
 HeartbeatMonitorBuilder::HeartbeatMonitorBuilder(const TimeRange& range)
     : monitor_builder_handle_{heartbeat_monitor_builder_create_wrapper(range.min_ms(), range.max_ms()),
@@ -54,4 +54,4 @@ void HeartbeatMonitor::heartbeat()
     SCORE_LANGUAGE_FUTURECPP_ASSERT(heartbeat_monitor_heartbeat(monitor_handle.value()) == kSuccess);
 }
 
-}  // namespace score::hm::heartbeat
+}  // namespace score::mw::health::heartbeat

--- a/src/health_monitoring_lib/cpp/include/score/hm/common.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/common.h
@@ -17,7 +17,7 @@
 #include <chrono>
 #include <optional>
 
-namespace score::hm
+namespace score::mw::health
 {
 
 /// FFI internal helpers
@@ -113,6 +113,6 @@ class TimeRange
     const std::chrono::milliseconds max_ms_;
 };
 
-}  // namespace score::hm
+}  // namespace score::mw::health
 
 #endif  // SCORE_HM_COMMON_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/deadline/deadline_monitor.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/deadline/deadline_monitor.h
@@ -19,14 +19,14 @@
 #include <functional>
 #include <optional>
 
-namespace score::hm
+namespace score::mw::health
 {
 // Forward declaration
 class HealthMonitor;
 class HealthMonitorBuilder;
-}  // namespace score::hm
+}  // namespace score::mw::health
 
-namespace score::hm::deadline
+namespace score::mw::health::deadline
 {
 
 // Forward declaration
@@ -63,7 +63,7 @@ class DeadlineMonitorBuilder final : public internal::RustDroppable<DeadlineMoni
     friend class internal::RustDroppable<DeadlineMonitorBuilder>;
 
     // Allow HealthMonitorBuilder to access drop_by_rust implementation
-    friend class ::score::hm::HealthMonitorBuilder;
+    friend class ::score::mw::health::HealthMonitorBuilder;
 };
 
 class DeadlineMonitor final
@@ -76,13 +76,13 @@ class DeadlineMonitor final
     DeadlineMonitor(DeadlineMonitor&& other) noexcept = default;
     DeadlineMonitor& operator=(DeadlineMonitor&& other) noexcept = default;
 
-    ::score::cpp::expected<Deadline, score::hm::Error> get_deadline(const DeadlineTag& deadline_tag);
+    ::score::cpp::expected<Deadline, score::mw::health::Error> get_deadline(const DeadlineTag& deadline_tag);
 
   private:
     explicit DeadlineMonitor(internal::FFIHandle handle);
 
     // Allow only HealthMonitor to create DeadlineMonitor instances.
-    friend class score::hm::HealthMonitor;
+    friend class score::mw::health::HealthMonitor;
     internal::DroppableFFIHandle monitor_handle_;
 };
 
@@ -139,6 +139,6 @@ class DeadlineHandle final
     std::optional<std::reference_wrapper<Deadline>> deadline_;
 };
 
-}  // namespace score::hm::deadline
+}  // namespace score::mw::health::deadline
 
 #endif  // SCORE_HM_DEADLINE_DEADLINE_MONITOR_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/health_monitor.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/health_monitor.h
@@ -20,7 +20,7 @@
 #include <score/hm/tag.h>
 #include <score/hm/thread.h>
 
-namespace score::hm
+namespace score::mw::health
 {
 
 class HealthMonitor;
@@ -61,7 +61,7 @@ class HealthMonitorBuilder final
     HealthMonitorBuilder with_internal_processing_cycle(std::chrono::milliseconds cycle_duration) &&;
 
     /// Sets the monitoring thread parameters.
-    HealthMonitorBuilder thread_parameters(score::hm::ThreadParameters&& thread_parameters) &&;
+    HealthMonitorBuilder thread_parameters(score::mw::health::ThreadParameters&& thread_parameters) &&;
 
     /// Build a new `HealthMonitor` instance based on provided parameters.
     score::cpp::expected<HealthMonitor, Error> build() &&;
@@ -100,6 +100,6 @@ class HealthMonitor final
     internal::FFIHandle health_monitor_;
 };
 
-}  // namespace score::hm
+}  // namespace score::mw::health
 
 #endif  // SCORE_HM_HEALTH_MONITOR_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/heartbeat/heartbeat_monitor.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/heartbeat/heartbeat_monitor.h
@@ -16,14 +16,14 @@
 #include <score/expected.hpp>
 #include <score/hm/common.h>
 
-namespace score::hm
+namespace score::mw::health
 {
 // Forward declaration
 class HealthMonitor;
 class HealthMonitorBuilder;
-}  // namespace score::hm
+}  // namespace score::mw::health
 
-namespace score::hm::heartbeat
+namespace score::mw::health::heartbeat
 {
 // Forward declaration
 class HeartbeatMonitor;
@@ -56,7 +56,7 @@ class HeartbeatMonitorBuilder final : public internal::RustDroppable<HeartbeatMo
     friend class internal::RustDroppable<HeartbeatMonitorBuilder>;
 
     // Allow HealthMonitorBuilder to access drop_by_rust implementation
-    friend class ::score::hm::HealthMonitorBuilder;
+    friend class ::score::mw::health::HealthMonitorBuilder;
 };
 
 class HeartbeatMonitor final
@@ -75,10 +75,10 @@ class HeartbeatMonitor final
     explicit HeartbeatMonitor(internal::FFIHandle monitor_handle);
 
     // Only `HealthMonitor` is allowed to create `HeartbeatMonitor` instances.
-    friend class score::hm::HealthMonitor;
+    friend class score::mw::health::HealthMonitor;
     internal::DroppableFFIHandle monitor_handle_;
 };
 
-}  // namespace score::hm::heartbeat
+}  // namespace score::mw::health::heartbeat
 
 #endif  // SCORE_HM_HEARTBEAT_HEARTBEAT_MONITOR_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/logic/logic_monitor.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/logic/logic_monitor.h
@@ -18,14 +18,14 @@
 #include <score/expected.hpp>
 #include <vector>
 
-namespace score::hm
+namespace score::mw::health
 {
 // Forward declaration
 class HealthMonitor;
 class HealthMonitorBuilder;
-}  // namespace score::hm
+}  // namespace score::mw::health
 
-namespace score::hm::logic
+namespace score::mw::health::logic
 {
 
 class LogicMonitorBuilder final : public internal::RustDroppable<LogicMonitorBuilder>
@@ -59,7 +59,7 @@ class LogicMonitorBuilder final : public internal::RustDroppable<LogicMonitorBui
     friend class internal::RustDroppable<LogicMonitorBuilder>;
 
     // Allow HealthMonitorBuilder to access drop_by_rust implementation
-    friend class ::score::hm::HealthMonitorBuilder;
+    friend class ::score::mw::health::HealthMonitorBuilder;
 };
 
 class LogicMonitor final
@@ -82,10 +82,10 @@ class LogicMonitor final
     explicit LogicMonitor(internal::FFIHandle monitor_handle);
 
     // Only `HealthMonitor` is allowed to create `LogicMonitor` instances.
-    friend class score::hm::HealthMonitor;
+    friend class score::mw::health::HealthMonitor;
     internal::DroppableFFIHandle monitor_handle_;
 };
 
-}  // namespace score::hm::logic
+}  // namespace score::mw::health::logic
 
 #endif  // SCORE_HM_LOGIC_LOGIC_MONITOR_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/tag.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/tag.h
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <string_view>
 
-namespace score::hm
+namespace score::mw::health
 {
 
 /// Common string-based tag.
@@ -70,6 +70,6 @@ class StateTag : public Tag<StateTag>
     using Tag::Tag;
 };
 
-}  // namespace score::hm
+}  // namespace score::mw::health
 
 #endif  // SCORE_HM_TAG_H

--- a/src/health_monitoring_lib/cpp/include/score/hm/thread.h
+++ b/src/health_monitoring_lib/cpp/include/score/hm/thread.h
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::hm
+namespace score::mw::health
 {
 
 class HealthMonitorBuilder;
@@ -83,9 +83,9 @@ class ThreadParameters final : public internal::RustDroppable<ThreadParameters>
     friend class internal::RustDroppable<ThreadParameters>;
 
     // Allow `HealthMonitorBuilder` to access `drop_by_rust` implementation.
-    friend class score::hm::HealthMonitorBuilder;
+    friend class score::mw::health::HealthMonitorBuilder;
 };
 
-}  // namespace score::hm
+}  // namespace score::mw::health
 
 #endif  // SCORE_HM_THREAD_H

--- a/src/health_monitoring_lib/cpp/logic_monitor.cpp
+++ b/src/health_monitoring_lib/cpp/logic_monitor.cpp
@@ -16,9 +16,9 @@
 namespace
 {
 extern "C" {
-using namespace score::hm;
-using namespace score::hm::internal;
-using namespace score::hm::logic;
+using namespace score::mw::health;
+using namespace score::mw::health::internal;
+using namespace score::mw::health::logic;
 
 FFICode logic_monitor_builder_create(const StateTag* initial_state, FFIHandle* logic_monitor_builder_handle_out);
 FFICode logic_monitor_builder_destroy(FFIHandle logic_monitor_builder_handle);
@@ -40,7 +40,7 @@ FFIHandle logic_monitor_builder_create_wrapper(const StateTag& initial_state)
 }
 }  // namespace
 
-namespace score::hm::logic
+namespace score::mw::health::logic
 {
 LogicMonitorBuilder::LogicMonitorBuilder(const StateTag& initial_state)
     : monitor_builder_handle_{logic_monitor_builder_create_wrapper(initial_state), &logic_monitor_builder_destroy}
@@ -91,4 +91,4 @@ score::cpp::expected<StateTag, Error> LogicMonitor::state()
     return score::cpp::expected<StateTag, Error>(state_tag);
 }
 
-}  // namespace score::hm::logic
+}  // namespace score::mw::health::logic

--- a/src/health_monitoring_lib/cpp/tests/health_monitor_test.cpp
+++ b/src/health_monitoring_lib/cpp/tests/health_monitor_test.cpp
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace score::hm;
+using namespace score::mw::health;
 
 class HealthMonitorTest : public ::testing::Test
 {
@@ -121,7 +121,7 @@ TEST_F(HealthMonitorTest, TestName)
     {
         auto deadline_guard = deadline_res.value().start().value();
 
-        EXPECT_EQ(deadline_res.value().start().error(), ::score::hm::Error::WrongState);
+        EXPECT_EQ(deadline_res.value().start().error(), ::score::mw::health::Error::WrongState);
         deadline_guard.stop();
     }
 }

--- a/src/health_monitoring_lib/cpp/thread.cpp
+++ b/src/health_monitoring_lib/cpp/thread.cpp
@@ -18,8 +18,8 @@ namespace
 {
 extern "C" {
 
-using namespace score::hm;
-using namespace score::hm::internal;
+using namespace score::mw::health;
+using namespace score::mw::health::internal;
 
 // Functions below must match functions defined in `crate::thread_ffi`.
 
@@ -43,7 +43,7 @@ FFIHandle thread_parameters_create_wrapper()
 }
 }  // namespace
 
-namespace score::hm
+namespace score::mw::health
 {
 
 int32_t scheduler_policy_priority_min(SchedulerPolicy scheduler_policy)
@@ -120,4 +120,4 @@ ThreadParameters ThreadParameters::stack_size(size_t stack_size) &&
     return std::move(*this);
 }
 
-}  // namespace score::hm
+}  // namespace score::mw::health

--- a/src/launch_manager_daemon/common/include/score/lcm/exec_error_domain.h
+++ b/src/launch_manager_daemon/common/include/score/lcm/exec_error_domain.h
@@ -18,11 +18,8 @@
 
 #include "score/result/result.h"
 
-namespace score
+namespace score::mw::lifecycle
 {
-
-   namespace lcm
-   {
 
       enum class ExecErrc : score::result::ErrorCode
       {
@@ -88,8 +85,6 @@ namespace score
          ;
       }
 
-   } // namespace lcm
-
-} // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif // SCORE_LCM_ERROR_DOMAIN_H_

--- a/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/Monitor.h
+++ b/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/Monitor.h
@@ -21,7 +21,7 @@
 
 #include "score/lcm/MonitorImplWrapper.h"
 
-namespace score::mw::health
+namespace score::mw::lifecycle
 {
 
 /// @brief Enumeration of elementary supervision status
@@ -125,7 +125,7 @@ public:
     {
         if (monitorImplWrapperPtr.get() != nullptr)
         {
-            monitorImplWrapperPtr->ReportCheckpoint(static_cast<score::mw::health::Checkpoint>(checkpointId));
+            monitorImplWrapperPtr->ReportCheckpoint(static_cast<score::mw::lifecycle::Checkpoint>(checkpointId));
         }
     }
 
@@ -143,7 +143,7 @@ private:
 
     /// @brief Assert if enumeration used during the construction of Monitor class
     ///        is of the type std::uint32_t
-    static_assert(std::is_same<underlyingCheckpointIdType, score::mw::health::Checkpoint>::value,
+    static_assert(std::is_same<underlyingCheckpointIdType, score::mw::lifecycle::Checkpoint>::value,
                   "The enumeration class used during the construction of Monitor class must be of "
                   "type 'std::uint32_t'!");
 };
@@ -159,5 +159,5 @@ extern "C"
 }
 #endif
 
-}  // namespace score::mw::health
+}  // namespace score::mw::lifecycle
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/Monitor.h
+++ b/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/Monitor.h
@@ -21,9 +21,7 @@
 
 #include "score/lcm/MonitorImplWrapper.h"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::health
 {
 
 /// @brief Enumeration of elementary supervision status
@@ -127,7 +125,7 @@ public:
     {
         if (monitorImplWrapperPtr.get() != nullptr)
         {
-            monitorImplWrapperPtr->ReportCheckpoint(static_cast<score::lcm::Checkpoint>(checkpointId));
+            monitorImplWrapperPtr->ReportCheckpoint(static_cast<score::mw::health::Checkpoint>(checkpointId));
         }
     }
 
@@ -145,7 +143,7 @@ private:
 
     /// @brief Assert if enumeration used during the construction of Monitor class
     ///        is of the type std::uint32_t
-    static_assert(std::is_same<underlyingCheckpointIdType, score::lcm::Checkpoint>::value,
+    static_assert(std::is_same<underlyingCheckpointIdType, score::mw::health::Checkpoint>::value,
                   "The enumeration class used during the construction of Monitor class must be of "
                   "type 'std::uint32_t'!");
 };
@@ -161,6 +159,5 @@ extern "C"
 }
 #endif
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::health
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/MonitorImplWrapper.h
+++ b/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/MonitorImplWrapper.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <string_view>
 
-namespace score::mw::health
+namespace score::mw::lifecycle
 {
 
 /// @brief Represents a Checkpoint
@@ -30,9 +30,9 @@ class MonitorImpl;
 /// @brief Forward declaration of enumeration of local supervision status
 enum class LocalSupervisionStatus : std::uint32_t;
 
-/// @brief Wrapper of implementation class for score::mw::health::Monitor class
-///        This class is just a wrapper and forwards the calls from score::mw::health::Monitor class
-///        to the actual implementation class, i.e., score::mw::health::MonitorImpl
+/// @brief Wrapper of implementation class for score::mw::lifecycle::Monitor class
+///        This class is just a wrapper and forwards the calls from score::mw::lifecycle::Monitor class
+///        to the actual implementation class, i.e., score::mw::lifecycle::MonitorImpl
 class MonitorImplWrapper
 {
 public:
@@ -70,13 +70,13 @@ public:
 
     /// @brief Reports an occurrence of a Checkpoint
     /// @param [in] f_checkpointId   Checkpoint identifier.
-    void ReportCheckpoint(score::mw::health::Checkpoint f_checkpointId) const noexcept(true);
+    void ReportCheckpoint(score::mw::lifecycle::Checkpoint f_checkpointId) const noexcept(true);
 
 private:
     /// @brief Unique pointer to the implementation class of Monitor
     std::unique_ptr<MonitorImpl> monitorImplPtr;
 };
 
-}  // namespace score::mw::health
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/MonitorImplWrapper.h
+++ b/src/launch_manager_daemon/health_monitor_lib/include/score/lcm/MonitorImplWrapper.h
@@ -18,9 +18,7 @@
 #include <memory>
 #include <string_view>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::health
 {
 
 /// @brief Represents a Checkpoint
@@ -32,9 +30,9 @@ class MonitorImpl;
 /// @brief Forward declaration of enumeration of local supervision status
 enum class LocalSupervisionStatus : std::uint32_t;
 
-/// @brief Wrapper of implementation class for score::lcm::Monitor class
-///        This class is just a wrapper and forwards the calls from score::lcm::Monitor class
-///        to the actual implementation class, i.e., score::lcm::MonitorImpl
+/// @brief Wrapper of implementation class for score::mw::health::Monitor class
+///        This class is just a wrapper and forwards the calls from score::mw::health::Monitor class
+///        to the actual implementation class, i.e., score::mw::health::MonitorImpl
 class MonitorImplWrapper
 {
 public:
@@ -72,14 +70,13 @@ public:
 
     /// @brief Reports an occurrence of a Checkpoint
     /// @param [in] f_checkpointId   Checkpoint identifier.
-    void ReportCheckpoint(score::lcm::Checkpoint f_checkpointId) const noexcept(true);
+    void ReportCheckpoint(score::mw::health::Checkpoint f_checkpointId) const noexcept(true);
 
 private:
     /// @brief Unique pointer to the implementation class of Monitor
     std::unique_ptr<MonitorImpl> monitorImplPtr;
 };
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::health
 
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/Monitor.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/Monitor.cpp
@@ -21,7 +21,7 @@ extern "C" {
 
 void* score_lcm_monitor_initialize(const char* instanceSpecifier) noexcept {
     try {
-        auto* monitorPtr = new score::mw::health::Monitor<Dummy>(instanceSpecifier);
+        auto* monitorPtr = new score::mw::lifecycle::Monitor<Dummy>(instanceSpecifier);
         return static_cast<void*>(monitorPtr);
     } catch (...) {
         return nullptr;
@@ -29,12 +29,12 @@ void* score_lcm_monitor_initialize(const char* instanceSpecifier) noexcept {
 }
 
 void score_lcm_monitor_deinitialize(void* instance) noexcept {
-    auto* monitorPtr = static_cast<score::mw::health::Monitor<Dummy>*>(instance);
+    auto* monitorPtr = static_cast<score::mw::lifecycle::Monitor<Dummy>*>(instance);
     delete monitorPtr;
 }
 
 void score_lcm_monitor_report_checkpoint(void* instance, std::uint32_t checkpointId) noexcept {
-    static_cast<score::mw::health::Monitor<Dummy>*>(instance)->ReportCheckpoint(static_cast<Dummy>(checkpointId));
+    static_cast<score::mw::lifecycle::Monitor<Dummy>*>(instance)->ReportCheckpoint(static_cast<Dummy>(checkpointId));
 }
 
 #ifdef __cplusplus

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/Monitor.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/Monitor.cpp
@@ -21,7 +21,7 @@ extern "C" {
 
 void* score_lcm_monitor_initialize(const char* instanceSpecifier) noexcept {
     try {
-        auto* monitorPtr = new score::lcm::Monitor<Dummy>(instanceSpecifier);
+        auto* monitorPtr = new score::mw::health::Monitor<Dummy>(instanceSpecifier);
         return static_cast<void*>(monitorPtr);
     } catch (...) {
         return nullptr;
@@ -29,12 +29,12 @@ void* score_lcm_monitor_initialize(const char* instanceSpecifier) noexcept {
 }
 
 void score_lcm_monitor_deinitialize(void* instance) noexcept {
-    auto* monitorPtr = static_cast<score::lcm::Monitor<Dummy>*>(instance);
+    auto* monitorPtr = static_cast<score::mw::health::Monitor<Dummy>*>(instance);
     delete monitorPtr;
 }
 
 void score_lcm_monitor_report_checkpoint(void* instance, std::uint32_t checkpointId) noexcept {
-    static_cast<score::lcm::Monitor<Dummy>*>(instance)->ReportCheckpoint(static_cast<Dummy>(checkpointId));
+    static_cast<score::mw::health::Monitor<Dummy>*>(instance)->ReportCheckpoint(static_cast<Dummy>(checkpointId));
 }
 
 #ifdef __cplusplus

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.cpp
@@ -24,9 +24,7 @@
 #include <fstream>
 
 #include "flatbuffers/flatbuffers.h"
-namespace score
-{
-namespace lcm
+namespace score::mw::health
 {
 
 namespace
@@ -75,7 +73,7 @@ MonitorImpl::MonitorImpl(const std::string_view& f_instanceSpecifier_r,
     connectToPhmDaemon();
 }
 
-void MonitorImpl::ReportCheckpoint(score::lcm::Checkpoint f_checkpointId) const noexcept(true)
+void MonitorImpl::ReportCheckpoint(Checkpoint f_checkpointId) const noexcept(true)
 {
     (void)ipcClient->sendEmplace(score::lcm::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
 }
@@ -168,5 +166,4 @@ std::pair<bool, std::string> MonitorImpl::readConfig(std::string& f_returnIfPath
 
 }
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::health

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.cpp
@@ -24,7 +24,7 @@
 #include <fstream>
 
 #include "flatbuffers/flatbuffers.h"
-namespace score::mw::health
+namespace score::mw::lifecycle
 {
 
 namespace
@@ -166,4 +166,4 @@ std::pair<bool, std::string> MonitorImpl::readConfig(std::string& f_returnIfPath
 
 }
 
-}  // namespace score::mw::health
+}  // namespace score::mw::lifecycle

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.h
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.h
@@ -24,12 +24,10 @@
 #include "score/lcm/saf/ipc/IpcClient.hpp"
 #include "score/lcm/saf/logging/PhmLogger.hpp"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::health
 {
 
-/// @brief Implementation class for score::lcm::Monitor class
+/// @brief Implementation class for score::mw::health::Monitor class
 ///        This class is responsible for establishing the connection between the application and PHM daemon
 ///        by invoking the calls to PHM class methods and to forward the reported checkpoints from the application
 ///        to PHM daemon for supervision evaluation
@@ -73,7 +71,7 @@ public:
 
     /// @brief Reports an occurrence of a Checkpoint
     /// @param [in] f_checkpointId   Checkpoint identifier.
-    void ReportCheckpoint(score::lcm::Checkpoint f_checkpointId) const noexcept(true);
+    void ReportCheckpoint(Checkpoint f_checkpointId) const noexcept(true);
 
 private:
     /// @brief Connect the application process with PHM daemon using IPC
@@ -108,7 +106,6 @@ private:
     score::lcm::saf::logging::PhmLogger& logger_r;
 };
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::health
 
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.h
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImpl.h
@@ -24,10 +24,10 @@
 #include "score/lcm/saf/ipc/IpcClient.hpp"
 #include "score/lcm/saf/logging/PhmLogger.hpp"
 
-namespace score::mw::health
+namespace score::mw::lifecycle
 {
 
-/// @brief Implementation class for score::mw::health::Monitor class
+/// @brief Implementation class for score::mw::lifecycle::Monitor class
 ///        This class is responsible for establishing the connection between the application and PHM daemon
 ///        by invoking the calls to PHM class methods and to forward the reported checkpoints from the application
 ///        to PHM daemon for supervision evaluation
@@ -106,6 +106,6 @@ private:
     score::lcm::saf::logging::PhmLogger& logger_r;
 };
 
-}  // namespace score::mw::health
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImplWrapper.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImplWrapper.cpp
@@ -16,7 +16,7 @@
 #include "score/lcm/hmlib/MonitorImpl.h"
 #include "score/lcm/Monitor.h"
 
-namespace score::mw::health
+namespace score::mw::lifecycle
 {
 
 MonitorImplWrapper::MonitorImplWrapper(
@@ -39,4 +39,4 @@ void MonitorImplWrapper::ReportCheckpoint(Checkpoint f_checkpointId) const noexc
     }
 }
 
-}  // namespace score::mw::health
+}  // namespace score::mw::lifecycle

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImplWrapper.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/hmlib/MonitorImplWrapper.cpp
@@ -16,9 +16,7 @@
 #include "score/lcm/hmlib/MonitorImpl.h"
 #include "score/lcm/Monitor.h"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::health
 {
 
 MonitorImplWrapper::MonitorImplWrapper(
@@ -33,7 +31,7 @@ MonitorImplWrapper::~MonitorImplWrapper() noexcept(true)
     monitorImplPtr.reset();
 }
 
-void MonitorImplWrapper::ReportCheckpoint(score::lcm::Checkpoint f_checkpointId) const noexcept(true)
+void MonitorImplWrapper::ReportCheckpoint(Checkpoint f_checkpointId) const noexcept(true)
 {
     if (monitorImplPtr.get() != nullptr)
     {
@@ -41,5 +39,4 @@ void MonitorImplWrapper::ReportCheckpoint(score::lcm::Checkpoint f_checkpointId)
     }
 }
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::health

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.cpp
@@ -47,7 +47,7 @@ Global::Global(const GlobalSupervisionCfg& f_globalCfg_r) :
     // Should always be true as the vectors are paired
     assert(k_expiredTolerances.size() == k_refFuntionGroupStates.size());
 
-    assert((globalStatus == score::mw::health::GlobalSupervisionStatus::kDeactivated) &&
+    assert((globalStatus == score::mw::lifecycle::GlobalSupervisionStatus::kDeactivated) &&
            ("Global Supervision must start in deactivated state, see SWS_PHM_00218"));
 }
 
@@ -118,7 +118,7 @@ void Global::registerLocalSupervision(const Local& f_localSupervision_r)
 {
     // coverity[autosar_cpp14_a8_5_2_violation:FALSE] type auto shall not be initialized with {} AUTOSAR.8.5.3A
     const auto ret =
-        localStatusOverTime.insert({&f_localSupervision_r, score::mw::health::LocalSupervisionStatus::kDeactivated});
+        localStatusOverTime.insert({&f_localSupervision_r, score::mw::lifecycle::LocalSupervisionStatus::kDeactivated});
     static_cast<void>(ret);
     assert(ret.second && "Same local supervision element was registered twice!");
 }
@@ -139,7 +139,7 @@ void Global::evaluate(const timers::NanoSecondType f_syncTimestamp)
 
     // We still need to check the debounce timer in case we are in expired state.
     // Debouncing was only evaluated against timestamp from local supervision update / pg state change before.
-    if (score::mw::health::GlobalSupervisionStatus::kExpired == globalStatus)
+    if (score::mw::lifecycle::GlobalSupervisionStatus::kExpired == globalStatus)
     {
         if (isDebounced(f_syncTimestamp))
         {
@@ -182,29 +182,29 @@ void Global::evaluateLocalSupervisionUpdate(const TimeSortedLocalSupState& f_loc
 
     switch (globalStatus)
     {
-        case score::mw::health::GlobalSupervisionStatus::kDeactivated:
+        case score::mw::lifecycle::GlobalSupervisionStatus::kDeactivated:
         {
             checkTransitionsOutOfDeactivated(f_local_r);
             break;
         }
 
-        case score::mw::health::GlobalSupervisionStatus::kOK:
+        case score::mw::lifecycle::GlobalSupervisionStatus::kOK:
         {
             checkTransitionsOutOfOk(f_local_r);
             break;
         }
 
-        case score::mw::health::GlobalSupervisionStatus::kFailed:
+        case score::mw::lifecycle::GlobalSupervisionStatus::kFailed:
         {
             checkTransitionsOutOfFailed(f_local_r);
             break;
         }
-        case score::mw::health::GlobalSupervisionStatus::kExpired:
+        case score::mw::lifecycle::GlobalSupervisionStatus::kExpired:
         {
             checkTransitionsOutOfExpired(f_local_r);
             break;
         }
-        case score::mw::health::GlobalSupervisionStatus::kStopped:
+        case score::mw::lifecycle::GlobalSupervisionStatus::kStopped:
         {
             checkTransitionsOutOfStopped();
             break;
@@ -222,13 +222,13 @@ void Global::evaluateLocalSupervisionUpdate(const TimeSortedLocalSupState& f_loc
 void Global::evaluatePGStateChange(const TimeSortedPGStateChange f_pgChange) noexcept
 {
     expiredTolerance = f_pgChange.expiredTolerance;
-    if ((score::mw::health::GlobalSupervisionStatus::kExpired == globalStatus) && (isDebounced(f_pgChange.timestamp)))
+    if ((score::mw::lifecycle::GlobalSupervisionStatus::kExpired == globalStatus) && (isDebounced(f_pgChange.timestamp)))
     {
         switchToStopped(EGlobalStoppedReason::expirationTimeout);
     }
 }
 
-score::mw::health::GlobalSupervisionStatus Global::getStatus(void) const noexcept
+score::mw::lifecycle::GlobalSupervisionStatus Global::getStatus(void) const noexcept
 {
     return globalStatus;
 }
@@ -241,17 +241,17 @@ void Global::registerRecoveryNotification(score::lcm::saf::recovery::Notificatio
 
 void Global::checkTransitionsOutOfDeactivated(const TimeSortedLocalSupState& f_local_r)
 {
-    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::lifecycle::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::mw::health::LocalSupervisionStatus::kOK == status)
+    if (score::mw::lifecycle::LocalSupervisionStatus::kOK == status)
     {
         switchToOk();
     }
-    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kFailed == status)
     {
         switchToFailed();
     }
-    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -273,21 +273,21 @@ void Global::checkTransitionsOutOfDeactivated(const TimeSortedLocalSupState& f_l
 
 void Global::checkTransitionsOutOfOk(const TimeSortedLocalSupState& f_local_r)
 {
-    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::lifecycle::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::mw::health::LocalSupervisionStatus::kDeactivated == status)
+    if (score::mw::lifecycle::LocalSupervisionStatus::kDeactivated == status)
     {
-        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::lifecycle::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::lifecycle::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
     }
-    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kFailed == status)
     {
         switchToFailed();
     }
-    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -309,9 +309,9 @@ void Global::checkTransitionsOutOfOk(const TimeSortedLocalSupState& f_local_r)
 
 void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_r)
 {
-    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::lifecycle::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::mw::health::LocalSupervisionStatus::kExpired == status)
+    if (score::mw::lifecycle::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -325,18 +325,18 @@ void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_
             switchToExpired(f_local_r.timestamp);
         }
     }
-    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kFailed == status)
     {
         // Remain in status Failed
     }
     else  // Local Supervision reported Deactivated or Ok
     {
-        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::lifecycle::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::lifecycle::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
-        else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
+        else if (score::mw::lifecycle::LocalSupervisionStatus::kOK == accState)
         {
             switchToOk();
         }
@@ -351,28 +351,28 @@ void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_
     function.", true_no_defect) */
 void Global::checkTransitionsOutOfExpired(const TimeSortedLocalSupState& f_local_r)
 {
-    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::lifecycle::LocalSupervisionStatus status{f_local_r.state};
 
     if (isDebounced(f_local_r.timestamp))
     {
         switchToStopped(EGlobalStoppedReason::expirationTimeout);
     }
-    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kExpired == status)
     {
         // Remain in status Expired
     }
     else  // Local Supervision reported Deactivated, Ok or Failed
     {
-        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::lifecycle::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::lifecycle::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
-        else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
+        else if (score::mw::lifecycle::LocalSupervisionStatus::kOK == accState)
         {
             switchToOk();
         }
-        else if (score::mw::health::LocalSupervisionStatus::kFailed == accState)
+        else if (score::mw::lifecycle::LocalSupervisionStatus::kFailed == accState)
         {
             switchToFailed();
         }
@@ -385,16 +385,16 @@ void Global::checkTransitionsOutOfExpired(const TimeSortedLocalSupState& f_local
 
 void Global::checkTransitionsOutOfStopped()
 {
-    const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
-    if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
+    const score::mw::lifecycle::LocalSupervisionStatus accState{getAccumulatedState()};
+    if (score::mw::lifecycle::LocalSupervisionStatus::kDeactivated == accState)
     {
         switchToDeactivated();
     }
-    else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kOK == accState)
     {
         switchToOk();
     }
-    else if (score::mw::health::LocalSupervisionStatus::kFailed == accState)
+    else if (score::mw::lifecycle::LocalSupervisionStatus::kFailed == accState)
     {
         switchToFailed();
     }
@@ -407,7 +407,7 @@ void Global::checkTransitionsOutOfStopped()
 void Global::switchToDeactivated() noexcept
 {
     logger_r.LogDebug() << "Global Supervision (" << getConfigName() << ") switched to DEACTIVATED.";
-    globalStatus = score::mw::health::GlobalSupervisionStatus::kDeactivated;
+    globalStatus = score::mw::lifecycle::GlobalSupervisionStatus::kDeactivated;
 
     startExpired = UINT64_MAX;
     expiredTolerance = 0U;
@@ -416,7 +416,7 @@ void Global::switchToDeactivated() noexcept
 void Global::switchToOk() noexcept
 {
     logger_r.LogInfo() << "Global Supervision (" << getConfigName() << ") switched to OK.";
-    globalStatus = score::mw::health::GlobalSupervisionStatus::kOK;
+    globalStatus = score::mw::lifecycle::GlobalSupervisionStatus::kOK;
 
     startExpired = UINT64_MAX;
 }
@@ -424,7 +424,7 @@ void Global::switchToOk() noexcept
 void Global::switchToFailed() noexcept
 {
     logger_r.LogWarn() << "Global Supervision (" << getConfigName() << ") switched to FAILED.";
-    globalStatus = score::mw::health::GlobalSupervisionStatus::kFailed;
+    globalStatus = score::mw::lifecycle::GlobalSupervisionStatus::kFailed;
 
     startExpired = UINT64_MAX;
 }
@@ -432,7 +432,7 @@ void Global::switchToFailed() noexcept
 void Global::switchToExpired(const timers::NanoSecondType f_starttime) noexcept
 {
     logger_r.LogWarn() << "Global Supervision (" << getConfigName() << ") switched to EXPIRED.";
-    globalStatus = score::mw::health::GlobalSupervisionStatus::kExpired;
+    globalStatus = score::mw::lifecycle::GlobalSupervisionStatus::kExpired;
     startExpired = f_starttime;
 }
 
@@ -454,7 +454,7 @@ void Global::switchToStopped(EGlobalStoppedReason f_reason) noexcept
             break;
     }
 
-    globalStatus = score::mw::health::GlobalSupervisionStatus::kStopped;
+    globalStatus = score::mw::lifecycle::GlobalSupervisionStatus::kStopped;
     startExpired = UINT64_MAX;
 
     for (auto notification : registeredRecoveryNotifications)
@@ -481,7 +481,7 @@ void Global::switchToStopped(EGlobalStoppedReason f_reason) noexcept
     }
 }
 
-score::mw::health::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
+score::mw::lifecycle::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
 {
     // Accumulating the state is done by calculating the maximum enum value.
     // This approach is only valid if the enum values are in the expected order:
@@ -489,13 +489,13 @@ score::mw::health::LocalSupervisionStatus Global::getAccumulatedState(void) noex
     // - Highest critical case => highest value
     // kDeactivated is an exception to this rule, which is treated differently in the
     // calculation of accumulated state below
-    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kOK) == 0U,
+    static_assert(static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kOK) == 0U,
                   "Value of score::lcm::LocalSupervision::kOK is 0 as expected.");
-    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kFailed) == 1U,
+    static_assert(static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kFailed) == 1U,
                   "Value of score::lcm::LocalSupervision::kFailed is 1 as expected.");
-    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kExpired) == 2U,
+    static_assert(static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kExpired) == 2U,
                   "Value of score::lcm::LocalSupervision::kExpired is 2 as expected.");
-    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kDeactivated) == 4U,
+    static_assert(static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kDeactivated) == 4U,
                   "Value of score::lcm::LocalSupervision::kDeactivated is 4 as expected.");
 
     // Value of -1 is treated as kDeactivated. Using the underlying integer of kDeactivated would
@@ -507,20 +507,20 @@ score::mw::health::LocalSupervisionStatus Global::getAccumulatedState(void) noex
     {
         // coverity[autosar_cpp14_a8_5_2_violation:FALSE] type auto shall not be initialized with {} AUTOSAR.8.5.3A
         const auto localStatus = local.second;
-        if (localStatus != score::mw::health::LocalSupervisionStatus::kDeactivated)
+        if (localStatus != score::mw::lifecycle::LocalSupervisionStatus::kDeactivated)
         {
             aggregateState = std::max(static_cast<std::int32_t>(localStatus), aggregateState);
-            if (score::mw::health::LocalSupervisionStatus::kExpired == localStatus)
+            if (score::mw::lifecycle::LocalSupervisionStatus::kExpired == localStatus)
             {
                 break;  // Worst state already reached
             }
         }
     }
 
-    score::mw::health::LocalSupervisionStatus accState{score::mw::health::LocalSupervisionStatus::kDeactivated};
+    score::mw::lifecycle::LocalSupervisionStatus accState{score::mw::lifecycle::LocalSupervisionStatus::kDeactivated};
     if (aggregateState != kDeactivatedPlaceholder)
     {
-        accState = static_cast<score::mw::health::LocalSupervisionStatus>(aggregateState);
+        accState = static_cast<score::mw::lifecycle::LocalSupervisionStatus>(aggregateState);
     }
 
     return accState;

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.cpp
@@ -47,7 +47,7 @@ Global::Global(const GlobalSupervisionCfg& f_globalCfg_r) :
     // Should always be true as the vectors are paired
     assert(k_expiredTolerances.size() == k_refFuntionGroupStates.size());
 
-    assert((globalStatus == score::lcm::GlobalSupervisionStatus::kDeactivated) &&
+    assert((globalStatus == score::mw::health::GlobalSupervisionStatus::kDeactivated) &&
            ("Global Supervision must start in deactivated state, see SWS_PHM_00218"));
 }
 
@@ -118,7 +118,7 @@ void Global::registerLocalSupervision(const Local& f_localSupervision_r)
 {
     // coverity[autosar_cpp14_a8_5_2_violation:FALSE] type auto shall not be initialized with {} AUTOSAR.8.5.3A
     const auto ret =
-        localStatusOverTime.insert({&f_localSupervision_r, score::lcm::LocalSupervisionStatus::kDeactivated});
+        localStatusOverTime.insert({&f_localSupervision_r, score::mw::health::LocalSupervisionStatus::kDeactivated});
     static_cast<void>(ret);
     assert(ret.second && "Same local supervision element was registered twice!");
 }
@@ -139,7 +139,7 @@ void Global::evaluate(const timers::NanoSecondType f_syncTimestamp)
 
     // We still need to check the debounce timer in case we are in expired state.
     // Debouncing was only evaluated against timestamp from local supervision update / pg state change before.
-    if (score::lcm::GlobalSupervisionStatus::kExpired == globalStatus)
+    if (score::mw::health::GlobalSupervisionStatus::kExpired == globalStatus)
     {
         if (isDebounced(f_syncTimestamp))
         {
@@ -182,29 +182,29 @@ void Global::evaluateLocalSupervisionUpdate(const TimeSortedLocalSupState& f_loc
 
     switch (globalStatus)
     {
-        case score::lcm::GlobalSupervisionStatus::kDeactivated:
+        case score::mw::health::GlobalSupervisionStatus::kDeactivated:
         {
             checkTransitionsOutOfDeactivated(f_local_r);
             break;
         }
 
-        case score::lcm::GlobalSupervisionStatus::kOK:
+        case score::mw::health::GlobalSupervisionStatus::kOK:
         {
             checkTransitionsOutOfOk(f_local_r);
             break;
         }
 
-        case score::lcm::GlobalSupervisionStatus::kFailed:
+        case score::mw::health::GlobalSupervisionStatus::kFailed:
         {
             checkTransitionsOutOfFailed(f_local_r);
             break;
         }
-        case score::lcm::GlobalSupervisionStatus::kExpired:
+        case score::mw::health::GlobalSupervisionStatus::kExpired:
         {
             checkTransitionsOutOfExpired(f_local_r);
             break;
         }
-        case score::lcm::GlobalSupervisionStatus::kStopped:
+        case score::mw::health::GlobalSupervisionStatus::kStopped:
         {
             checkTransitionsOutOfStopped();
             break;
@@ -222,13 +222,13 @@ void Global::evaluateLocalSupervisionUpdate(const TimeSortedLocalSupState& f_loc
 void Global::evaluatePGStateChange(const TimeSortedPGStateChange f_pgChange) noexcept
 {
     expiredTolerance = f_pgChange.expiredTolerance;
-    if ((score::lcm::GlobalSupervisionStatus::kExpired == globalStatus) && (isDebounced(f_pgChange.timestamp)))
+    if ((score::mw::health::GlobalSupervisionStatus::kExpired == globalStatus) && (isDebounced(f_pgChange.timestamp)))
     {
         switchToStopped(EGlobalStoppedReason::expirationTimeout);
     }
 }
 
-score::lcm::GlobalSupervisionStatus Global::getStatus(void) const noexcept
+score::mw::health::GlobalSupervisionStatus Global::getStatus(void) const noexcept
 {
     return globalStatus;
 }
@@ -241,17 +241,17 @@ void Global::registerRecoveryNotification(score::lcm::saf::recovery::Notificatio
 
 void Global::checkTransitionsOutOfDeactivated(const TimeSortedLocalSupState& f_local_r)
 {
-    score::lcm::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::lcm::LocalSupervisionStatus::kOK == status)
+    if (score::mw::health::LocalSupervisionStatus::kOK == status)
     {
         switchToOk();
     }
-    else if (score::lcm::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
     {
         switchToFailed();
     }
-    else if (score::lcm::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -273,21 +273,21 @@ void Global::checkTransitionsOutOfDeactivated(const TimeSortedLocalSupState& f_l
 
 void Global::checkTransitionsOutOfOk(const TimeSortedLocalSupState& f_local_r)
 {
-    score::lcm::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::lcm::LocalSupervisionStatus::kDeactivated == status)
+    if (score::mw::health::LocalSupervisionStatus::kDeactivated == status)
     {
-        const score::lcm::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::lcm::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
     }
-    else if (score::lcm::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
     {
         switchToFailed();
     }
-    else if (score::lcm::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -309,9 +309,9 @@ void Global::checkTransitionsOutOfOk(const TimeSortedLocalSupState& f_local_r)
 
 void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_r)
 {
-    score::lcm::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
 
-    if (score::lcm::LocalSupervisionStatus::kExpired == status)
+    if (score::mw::health::LocalSupervisionStatus::kExpired == status)
     {
         expiredSupervision = f_local_r.supervisionType;
         executionError = f_local_r.executionError;
@@ -325,18 +325,18 @@ void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_
             switchToExpired(f_local_r.timestamp);
         }
     }
-    else if (score::lcm::LocalSupervisionStatus::kFailed == status)
+    else if (score::mw::health::LocalSupervisionStatus::kFailed == status)
     {
         // Remain in status Failed
     }
     else  // Local Supervision reported Deactivated or Ok
     {
-        const score::lcm::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::lcm::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
-        else if (score::lcm::LocalSupervisionStatus::kOK == accState)
+        else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
         {
             switchToOk();
         }
@@ -351,28 +351,28 @@ void Global::checkTransitionsOutOfFailed(const TimeSortedLocalSupState& f_local_
     function.", true_no_defect) */
 void Global::checkTransitionsOutOfExpired(const TimeSortedLocalSupState& f_local_r)
 {
-    score::lcm::LocalSupervisionStatus status{f_local_r.state};
+    score::mw::health::LocalSupervisionStatus status{f_local_r.state};
 
     if (isDebounced(f_local_r.timestamp))
     {
         switchToStopped(EGlobalStoppedReason::expirationTimeout);
     }
-    else if (score::lcm::LocalSupervisionStatus::kExpired == status)
+    else if (score::mw::health::LocalSupervisionStatus::kExpired == status)
     {
         // Remain in status Expired
     }
     else  // Local Supervision reported Deactivated, Ok or Failed
     {
-        const score::lcm::LocalSupervisionStatus accState{getAccumulatedState()};
-        if (score::lcm::LocalSupervisionStatus::kDeactivated == accState)
+        const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
+        if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
         {
             switchToDeactivated();
         }
-        else if (score::lcm::LocalSupervisionStatus::kOK == accState)
+        else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
         {
             switchToOk();
         }
-        else if (score::lcm::LocalSupervisionStatus::kFailed == accState)
+        else if (score::mw::health::LocalSupervisionStatus::kFailed == accState)
         {
             switchToFailed();
         }
@@ -385,16 +385,16 @@ void Global::checkTransitionsOutOfExpired(const TimeSortedLocalSupState& f_local
 
 void Global::checkTransitionsOutOfStopped()
 {
-    const score::lcm::LocalSupervisionStatus accState{getAccumulatedState()};
-    if (score::lcm::LocalSupervisionStatus::kDeactivated == accState)
+    const score::mw::health::LocalSupervisionStatus accState{getAccumulatedState()};
+    if (score::mw::health::LocalSupervisionStatus::kDeactivated == accState)
     {
         switchToDeactivated();
     }
-    else if (score::lcm::LocalSupervisionStatus::kOK == accState)
+    else if (score::mw::health::LocalSupervisionStatus::kOK == accState)
     {
         switchToOk();
     }
-    else if (score::lcm::LocalSupervisionStatus::kFailed == accState)
+    else if (score::mw::health::LocalSupervisionStatus::kFailed == accState)
     {
         switchToFailed();
     }
@@ -407,7 +407,7 @@ void Global::checkTransitionsOutOfStopped()
 void Global::switchToDeactivated() noexcept
 {
     logger_r.LogDebug() << "Global Supervision (" << getConfigName() << ") switched to DEACTIVATED.";
-    globalStatus = score::lcm::GlobalSupervisionStatus::kDeactivated;
+    globalStatus = score::mw::health::GlobalSupervisionStatus::kDeactivated;
 
     startExpired = UINT64_MAX;
     expiredTolerance = 0U;
@@ -416,7 +416,7 @@ void Global::switchToDeactivated() noexcept
 void Global::switchToOk() noexcept
 {
     logger_r.LogInfo() << "Global Supervision (" << getConfigName() << ") switched to OK.";
-    globalStatus = score::lcm::GlobalSupervisionStatus::kOK;
+    globalStatus = score::mw::health::GlobalSupervisionStatus::kOK;
 
     startExpired = UINT64_MAX;
 }
@@ -424,7 +424,7 @@ void Global::switchToOk() noexcept
 void Global::switchToFailed() noexcept
 {
     logger_r.LogWarn() << "Global Supervision (" << getConfigName() << ") switched to FAILED.";
-    globalStatus = score::lcm::GlobalSupervisionStatus::kFailed;
+    globalStatus = score::mw::health::GlobalSupervisionStatus::kFailed;
 
     startExpired = UINT64_MAX;
 }
@@ -432,7 +432,7 @@ void Global::switchToFailed() noexcept
 void Global::switchToExpired(const timers::NanoSecondType f_starttime) noexcept
 {
     logger_r.LogWarn() << "Global Supervision (" << getConfigName() << ") switched to EXPIRED.";
-    globalStatus = score::lcm::GlobalSupervisionStatus::kExpired;
+    globalStatus = score::mw::health::GlobalSupervisionStatus::kExpired;
     startExpired = f_starttime;
 }
 
@@ -454,7 +454,7 @@ void Global::switchToStopped(EGlobalStoppedReason f_reason) noexcept
             break;
     }
 
-    globalStatus = score::lcm::GlobalSupervisionStatus::kStopped;
+    globalStatus = score::mw::health::GlobalSupervisionStatus::kStopped;
     startExpired = UINT64_MAX;
 
     for (auto notification : registeredRecoveryNotifications)
@@ -481,7 +481,7 @@ void Global::switchToStopped(EGlobalStoppedReason f_reason) noexcept
     }
 }
 
-score::lcm::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
+score::mw::health::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
 {
     // Accumulating the state is done by calculating the maximum enum value.
     // This approach is only valid if the enum values are in the expected order:
@@ -489,13 +489,13 @@ score::lcm::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
     // - Highest critical case => highest value
     // kDeactivated is an exception to this rule, which is treated differently in the
     // calculation of accumulated state below
-    static_assert(static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kOK) == 0U,
+    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kOK) == 0U,
                   "Value of score::lcm::LocalSupervision::kOK is 0 as expected.");
-    static_assert(static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kFailed) == 1U,
+    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kFailed) == 1U,
                   "Value of score::lcm::LocalSupervision::kFailed is 1 as expected.");
-    static_assert(static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kExpired) == 2U,
+    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kExpired) == 2U,
                   "Value of score::lcm::LocalSupervision::kExpired is 2 as expected.");
-    static_assert(static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kDeactivated) == 4U,
+    static_assert(static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kDeactivated) == 4U,
                   "Value of score::lcm::LocalSupervision::kDeactivated is 4 as expected.");
 
     // Value of -1 is treated as kDeactivated. Using the underlying integer of kDeactivated would
@@ -507,20 +507,20 @@ score::lcm::LocalSupervisionStatus Global::getAccumulatedState(void) noexcept
     {
         // coverity[autosar_cpp14_a8_5_2_violation:FALSE] type auto shall not be initialized with {} AUTOSAR.8.5.3A
         const auto localStatus = local.second;
-        if (localStatus != score::lcm::LocalSupervisionStatus::kDeactivated)
+        if (localStatus != score::mw::health::LocalSupervisionStatus::kDeactivated)
         {
             aggregateState = std::max(static_cast<std::int32_t>(localStatus), aggregateState);
-            if (score::lcm::LocalSupervisionStatus::kExpired == localStatus)
+            if (score::mw::health::LocalSupervisionStatus::kExpired == localStatus)
             {
                 break;  // Worst state already reached
             }
         }
     }
 
-    score::lcm::LocalSupervisionStatus accState{score::lcm::LocalSupervisionStatus::kDeactivated};
+    score::mw::health::LocalSupervisionStatus accState{score::mw::health::LocalSupervisionStatus::kDeactivated};
     if (aggregateState != kDeactivatedPlaceholder)
     {
-        accState = static_cast<score::lcm::LocalSupervisionStatus>(aggregateState);
+        accState = static_cast<score::mw::health::LocalSupervisionStatus>(aggregateState);
     }
 
     return accState;

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.hpp
@@ -121,7 +121,7 @@ public:
 
     /// @brief Get global supervision status
     /// @return GlobalSupervisionStatus  Current global supervision status
-    score::lcm::GlobalSupervisionStatus getStatus(void) const noexcept;
+    score::mw::health::GlobalSupervisionStatus getStatus(void) const noexcept;
 
     /// @brief Register the given recovery notification object
     /// @param [in] f_notification_r  Recovery notification object
@@ -139,7 +139,7 @@ PHM_PRIVATE:
         // cppcheck-suppress unusedStructMember
         LocalSupervisionId localId{nullptr};
         /// @brief New status of a local supervision
-        score::lcm::LocalSupervisionStatus state{score::lcm::LocalSupervisionStatus::kDeactivated};
+        score::mw::health::LocalSupervisionStatus state{score::mw::health::LocalSupervisionStatus::kDeactivated};
         /// @brief The type of supervision that caused the local supervision state change
         ICheckpointSupervision::EType supervisionType{ICheckpointSupervision::EType::aliveSupervision};
         /// @brief Timestamp of the local supervision state change
@@ -208,7 +208,7 @@ PHM_PRIVATE:
     /// 1. Ok
     /// 2. Failed
     /// 3. Expired
-    score::lcm::LocalSupervisionStatus getAccumulatedState(void) noexcept;
+    score::mw::health::LocalSupervisionStatus getAccumulatedState(void) noexcept;
 
     /// @brief Check if escalation to Stopped is required
     /// @param [in] f_time       Current time (0 ns is treated as error value)
@@ -237,7 +237,7 @@ PHM_PRIVATE:
     const std::vector<common::ProcessGroupId> k_refFuntionGroupStates;
 
     /// @brief Current global supervision status
-    score::lcm::GlobalSupervisionStatus globalStatus{score::lcm::GlobalSupervisionStatus::kDeactivated};
+    score::mw::health::GlobalSupervisionStatus globalStatus{score::mw::health::GlobalSupervisionStatus::kDeactivated};
 
     /// @brief Start Timestamp of Expired State
     timers::NanoSecondType startExpired{UINT64_MAX};
@@ -254,7 +254,7 @@ PHM_PRIVATE:
 
     /// @brief Map of the current status of all associated supervisions
     /// Map is updated in the timestamp-based order of local supervision updates
-    std::map<LocalSupervisionId, score::lcm::LocalSupervisionStatus> localStatusOverTime{};
+    std::map<LocalSupervisionId, score::mw::health::LocalSupervisionStatus> localStatusOverTime{};
 
     /// @brief Vector of registered Recovery Notifications
     std::vector<score::lcm::saf::recovery::Notification*> registeredRecoveryNotifications{};

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Global.hpp
@@ -121,7 +121,7 @@ public:
 
     /// @brief Get global supervision status
     /// @return GlobalSupervisionStatus  Current global supervision status
-    score::mw::health::GlobalSupervisionStatus getStatus(void) const noexcept;
+    score::mw::lifecycle::GlobalSupervisionStatus getStatus(void) const noexcept;
 
     /// @brief Register the given recovery notification object
     /// @param [in] f_notification_r  Recovery notification object
@@ -139,7 +139,7 @@ PHM_PRIVATE:
         // cppcheck-suppress unusedStructMember
         LocalSupervisionId localId{nullptr};
         /// @brief New status of a local supervision
-        score::mw::health::LocalSupervisionStatus state{score::mw::health::LocalSupervisionStatus::kDeactivated};
+        score::mw::lifecycle::LocalSupervisionStatus state{score::mw::lifecycle::LocalSupervisionStatus::kDeactivated};
         /// @brief The type of supervision that caused the local supervision state change
         ICheckpointSupervision::EType supervisionType{ICheckpointSupervision::EType::aliveSupervision};
         /// @brief Timestamp of the local supervision state change
@@ -208,7 +208,7 @@ PHM_PRIVATE:
     /// 1. Ok
     /// 2. Failed
     /// 3. Expired
-    score::mw::health::LocalSupervisionStatus getAccumulatedState(void) noexcept;
+    score::mw::lifecycle::LocalSupervisionStatus getAccumulatedState(void) noexcept;
 
     /// @brief Check if escalation to Stopped is required
     /// @param [in] f_time       Current time (0 ns is treated as error value)
@@ -237,7 +237,7 @@ PHM_PRIVATE:
     const std::vector<common::ProcessGroupId> k_refFuntionGroupStates;
 
     /// @brief Current global supervision status
-    score::mw::health::GlobalSupervisionStatus globalStatus{score::mw::health::GlobalSupervisionStatus::kDeactivated};
+    score::mw::lifecycle::GlobalSupervisionStatus globalStatus{score::mw::lifecycle::GlobalSupervisionStatus::kDeactivated};
 
     /// @brief Start Timestamp of Expired State
     timers::NanoSecondType startExpired{UINT64_MAX};
@@ -254,7 +254,7 @@ PHM_PRIVATE:
 
     /// @brief Map of the current status of all associated supervisions
     /// Map is updated in the timestamp-based order of local supervision updates
-    std::map<LocalSupervisionId, score::mw::health::LocalSupervisionStatus> localStatusOverTime{};
+    std::map<LocalSupervisionId, score::mw::lifecycle::LocalSupervisionStatus> localStatusOverTime{};
 
     /// @brief Vector of registered Recovery Notifications
     std::vector<score::lcm::saf::recovery::Notification*> registeredRecoveryNotifications{};

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ICheckpointSupervision.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ICheckpointSupervision.hpp
@@ -72,10 +72,10 @@ public:
     /// to allow for variation.
     enum class EStatus : uint32_t
     {
-        deactivated = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kDeactivated),
-        ok = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kOK),
-        failed = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kFailed),
-        expired = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kExpired)
+        deactivated = static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kDeactivated),
+        ok = static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kOK),
+        failed = static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kFailed),
+        expired = static_cast<uint32_t>(score::mw::lifecycle::LocalSupervisionStatus::kExpired)
     };
 
     /// @brief Supervision Type Enumeration

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ICheckpointSupervision.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/ICheckpointSupervision.hpp
@@ -72,10 +72,10 @@ public:
     /// to allow for variation.
     enum class EStatus : uint32_t
     {
-        deactivated = static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kDeactivated),
-        ok = static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kOK),
-        failed = static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kFailed),
-        expired = static_cast<uint32_t>(score::lcm::LocalSupervisionStatus::kExpired)
+        deactivated = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kDeactivated),
+        ok = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kOK),
+        failed = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kFailed),
+        expired = static_cast<uint32_t>(score::mw::health::LocalSupervisionStatus::kExpired)
     };
 
     /// @brief Supervision Type Enumeration

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
@@ -39,7 +39,7 @@ Local::Local(const LocalSupervisionCfg f_localCfg) :
     // Satisfy Misra for minimum number of instructions
     static_cast<void>(0);
 
-    assert((localStatus == score::lcm::LocalSupervisionStatus::kDeactivated) &&
+    assert((localStatus == score::mw::health::LocalSupervisionStatus::kDeactivated) &&
            ("Local Supervision must start in deactivated state, see SWS_PHM_00204"));
 }
 
@@ -104,7 +104,7 @@ void Local::evaluate(const timers::NanoSecondType f_syncTimestamp)
 
 void Local::handleDataLossReaction(void) noexcept
 {
-    if (score::lcm::LocalSupervisionStatus::kExpired != localStatus)
+    if (score::mw::health::LocalSupervisionStatus::kExpired != localStatus)
     {
         switchToExpired(supervisionTypeDataLoss, ifexm::ProcessCfg::kDefaultProcessExecutionError, "due to data loss.");
     }
@@ -112,7 +112,7 @@ void Local::handleDataLossReaction(void) noexcept
     timeSortingCheckpointSupEvent.clear();
 }
 
-score::lcm::LocalSupervisionStatus Local::getStatus(void) const noexcept
+score::mw::health::LocalSupervisionStatus Local::getStatus(void) const noexcept
 {
     return localStatus;
 }
@@ -131,25 +131,25 @@ void Local::updateState(const CheckpointSupervisionEvent& f_checkpointSupervisio
 {
     switch (localStatus)
     {
-        case score::lcm::LocalSupervisionStatus::kDeactivated:
+        case score::mw::health::LocalSupervisionStatus::kDeactivated:
         {
             checkTransitionsOutOfDeactivated(f_checkpointSupervision_r);
             break;
         }
 
-        case score::lcm::LocalSupervisionStatus::kOK:
+        case score::mw::health::LocalSupervisionStatus::kOK:
         {
             checkTransitionsOutOfOk(f_checkpointSupervision_r);
             break;
         }
 
-        case score::lcm::LocalSupervisionStatus::kFailed:
+        case score::mw::health::LocalSupervisionStatus::kFailed:
         {
             checkTransitionsOutOfFailed(f_checkpointSupervision_r);
             break;
         }
 
-        case score::lcm::LocalSupervisionStatus::kExpired:
+        case score::mw::health::LocalSupervisionStatus::kExpired:
         {
             checkTransitionsOutOfExpired(f_checkpointSupervision_r);
             break;
@@ -271,7 +271,7 @@ void Local::switchToDeactivated(ICheckpointSupervision::EType f_type) noexcept
 {
     supervisionType = f_type;
     logger_r.LogDebug() << "Local Supervision (" << getConfigName() << ") switched to DEACTIVATED.";
-    localStatus = score::lcm::LocalSupervisionStatus::kDeactivated;
+    localStatus = score::mw::health::LocalSupervisionStatus::kDeactivated;
     pushResultToObservers();
 }
 
@@ -279,7 +279,7 @@ void Local::switchToOk(ICheckpointSupervision::EType f_type) noexcept
 {
     supervisionType = f_type;
     logger_r.LogInfo() << "Local Supervision (" << getConfigName() << ") switched to OK.";
-    localStatus = score::lcm::LocalSupervisionStatus::kOK;
+    localStatus = score::mw::health::LocalSupervisionStatus::kOK;
     pushResultToObservers();
 }
 
@@ -287,7 +287,7 @@ void Local::switchToFailed(ICheckpointSupervision::EType f_type, std::string_vie
 {
     supervisionType = f_type;
     logger_r.LogWarn() << "Local Supervision (" << getConfigName() << ") switched to FAILED," << reason_p;
-    localStatus = score::lcm::LocalSupervisionStatus::kFailed;
+    localStatus = score::mw::health::LocalSupervisionStatus::kFailed;
     pushResultToObservers();
 }
 
@@ -322,7 +322,7 @@ void Local::switchToExpired(ICheckpointSupervision::EType f_type,
     {
         logger_r.LogWarn() << "Local Supervision (" << getConfigName() << ") switched to EXPIRED," << reason_p;
     }
-    localStatus = score::lcm::LocalSupervisionStatus::kExpired;
+    localStatus = score::mw::health::LocalSupervisionStatus::kExpired;
     pushResultToObservers();
 }
 

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.cpp
@@ -39,7 +39,7 @@ Local::Local(const LocalSupervisionCfg f_localCfg) :
     // Satisfy Misra for minimum number of instructions
     static_cast<void>(0);
 
-    assert((localStatus == score::mw::health::LocalSupervisionStatus::kDeactivated) &&
+    assert((localStatus == score::mw::lifecycle::LocalSupervisionStatus::kDeactivated) &&
            ("Local Supervision must start in deactivated state, see SWS_PHM_00204"));
 }
 
@@ -104,7 +104,7 @@ void Local::evaluate(const timers::NanoSecondType f_syncTimestamp)
 
 void Local::handleDataLossReaction(void) noexcept
 {
-    if (score::mw::health::LocalSupervisionStatus::kExpired != localStatus)
+    if (score::mw::lifecycle::LocalSupervisionStatus::kExpired != localStatus)
     {
         switchToExpired(supervisionTypeDataLoss, ifexm::ProcessCfg::kDefaultProcessExecutionError, "due to data loss.");
     }
@@ -112,7 +112,7 @@ void Local::handleDataLossReaction(void) noexcept
     timeSortingCheckpointSupEvent.clear();
 }
 
-score::mw::health::LocalSupervisionStatus Local::getStatus(void) const noexcept
+score::mw::lifecycle::LocalSupervisionStatus Local::getStatus(void) const noexcept
 {
     return localStatus;
 }
@@ -131,25 +131,25 @@ void Local::updateState(const CheckpointSupervisionEvent& f_checkpointSupervisio
 {
     switch (localStatus)
     {
-        case score::mw::health::LocalSupervisionStatus::kDeactivated:
+        case score::mw::lifecycle::LocalSupervisionStatus::kDeactivated:
         {
             checkTransitionsOutOfDeactivated(f_checkpointSupervision_r);
             break;
         }
 
-        case score::mw::health::LocalSupervisionStatus::kOK:
+        case score::mw::lifecycle::LocalSupervisionStatus::kOK:
         {
             checkTransitionsOutOfOk(f_checkpointSupervision_r);
             break;
         }
 
-        case score::mw::health::LocalSupervisionStatus::kFailed:
+        case score::mw::lifecycle::LocalSupervisionStatus::kFailed:
         {
             checkTransitionsOutOfFailed(f_checkpointSupervision_r);
             break;
         }
 
-        case score::mw::health::LocalSupervisionStatus::kExpired:
+        case score::mw::lifecycle::LocalSupervisionStatus::kExpired:
         {
             checkTransitionsOutOfExpired(f_checkpointSupervision_r);
             break;
@@ -271,7 +271,7 @@ void Local::switchToDeactivated(ICheckpointSupervision::EType f_type) noexcept
 {
     supervisionType = f_type;
     logger_r.LogDebug() << "Local Supervision (" << getConfigName() << ") switched to DEACTIVATED.";
-    localStatus = score::mw::health::LocalSupervisionStatus::kDeactivated;
+    localStatus = score::mw::lifecycle::LocalSupervisionStatus::kDeactivated;
     pushResultToObservers();
 }
 
@@ -279,7 +279,7 @@ void Local::switchToOk(ICheckpointSupervision::EType f_type) noexcept
 {
     supervisionType = f_type;
     logger_r.LogInfo() << "Local Supervision (" << getConfigName() << ") switched to OK.";
-    localStatus = score::mw::health::LocalSupervisionStatus::kOK;
+    localStatus = score::mw::lifecycle::LocalSupervisionStatus::kOK;
     pushResultToObservers();
 }
 
@@ -287,7 +287,7 @@ void Local::switchToFailed(ICheckpointSupervision::EType f_type, std::string_vie
 {
     supervisionType = f_type;
     logger_r.LogWarn() << "Local Supervision (" << getConfigName() << ") switched to FAILED," << reason_p;
-    localStatus = score::mw::health::LocalSupervisionStatus::kFailed;
+    localStatus = score::mw::lifecycle::LocalSupervisionStatus::kFailed;
     pushResultToObservers();
 }
 
@@ -322,7 +322,7 @@ void Local::switchToExpired(ICheckpointSupervision::EType f_type,
     {
         logger_r.LogWarn() << "Local Supervision (" << getConfigName() << ") switched to EXPIRED," << reason_p;
     }
-    localStatus = score::mw::health::LocalSupervisionStatus::kExpired;
+    localStatus = score::mw::lifecycle::LocalSupervisionStatus::kExpired;
     pushResultToObservers();
 }
 

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
@@ -119,7 +119,7 @@ public:
 
     /// @brief Get local supervision status
     /// @return LocalSupervisionStatus  Current local supervision status
-    score::lcm::LocalSupervisionStatus getStatus(void) const noexcept;
+    score::mw::health::LocalSupervisionStatus getStatus(void) const noexcept;
 
     /// @brief Get Supervision Type
     /// @return     Type of Supervision which caused the current state transition
@@ -193,7 +193,7 @@ PHM_PRIVATE:
     bool isOneFailed() const noexcept;
 
     /// @brief Current local supervision status
-    score::lcm::LocalSupervisionStatus localStatus{score::lcm::LocalSupervisionStatus::kDeactivated};
+    score::mw::health::LocalSupervisionStatus localStatus{score::mw::health::LocalSupervisionStatus::kDeactivated};
 
     /// @brief Supervision Type that caused the current state transition
     /// @note Initial value has no special meaning it just needs to be one of the possible supervision types

--- a/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
+++ b/src/launch_manager_daemon/health_monitor_lib/src/score/lcm/saf/supervision/Local.hpp
@@ -119,7 +119,7 @@ public:
 
     /// @brief Get local supervision status
     /// @return LocalSupervisionStatus  Current local supervision status
-    score::mw::health::LocalSupervisionStatus getStatus(void) const noexcept;
+    score::mw::lifecycle::LocalSupervisionStatus getStatus(void) const noexcept;
 
     /// @brief Get Supervision Type
     /// @return     Type of Supervision which caused the current state transition
@@ -193,7 +193,7 @@ PHM_PRIVATE:
     bool isOneFailed() const noexcept;
 
     /// @brief Current local supervision status
-    score::mw::health::LocalSupervisionStatus localStatus{score::mw::health::LocalSupervisionStatus::kDeactivated};
+    score::mw::lifecycle::LocalSupervisionStatus localStatus{score::mw::lifecycle::LocalSupervisionStatus::kDeactivated};
 
     /// @brief Supervision Type that caused the current state transition
     /// @note Initial value has no special meaning it just needs to be one of the possible supervision types

--- a/src/launch_manager_daemon/lifecycle_client_lib/include/score/lcm/lifecycle_client.h
+++ b/src/launch_manager_daemon/lifecycle_client_lib/include/score/lcm/lifecycle_client.h
@@ -24,9 +24,7 @@
 #include "score/result/result.h"
 #include "score/lcm/exec_error_domain.h"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 /// @brief Defines the internal states of a Process (see 7.3.1). Scoped Enumeration of uint8_t
 enum class ExecutionState : std::uint8_t {
@@ -68,9 +66,9 @@ class LifecycleClient final {
     ///
     /// @param state Value of the Execution State
     /// @returns An instance of score::Result. The instance holds an ErrorCode containing either one of the specified errors or a void-value.
-    /// @error score::lcm::ExecErrc::kGeneralError if some unspecified error occurred
-    /// @error score::lcm::ExecErrc::kCommunicationError Communication error between Application and Launch Manager, e.g. unable to report state for Non-reporting Process.
-    /// @error score::lcm::ExecErrc::kInvalidTransition  Invalid transition request (e.g. to Running when already in Running state)
+    /// @error score::mw::lifecycle::ExecErrc::kGeneralError if some unspecified error occurred
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError Communication error between Application and Launch Manager, e.g. unable to report state for Non-reporting Process.
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidTransition  Invalid transition request (e.g. to Running when already in Running state)
     score::Result<std::monostate> ReportExecutionState(ExecutionState state) const noexcept;
 
    private:
@@ -79,9 +77,7 @@ class LifecycleClient final {
     std::unique_ptr<LifecycleClientImpl> lifecycle_client_impl_;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 extern "C" {
 #else

--- a/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclient.cpp
+++ b/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclient.cpp
@@ -13,9 +13,7 @@
 
 #include "lifecycleclientimpl.hpp"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 LifecycleClient::LifecycleClient() noexcept
 {
@@ -48,13 +46,11 @@ score::Result<std::monostate> LifecycleClient::ReportExecutionState(ExecutionSta
     }
     else
     {
-        return score::Result<std::monostate>{score::MakeUnexpected(score::lcm::ExecErrc::kCommunicationError)};
+        return score::Result<std::monostate>{score::MakeUnexpected(ExecErrc::kCommunicationError)};
     }
 }
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,8 +58,8 @@ extern "C" {
 
 int8_t score_lcm_ReportExecutionStateRunning(void) {
     // RULECHECKER_comment(1, 2, check_static_object_dynamic_initialization, "static variable is in function scope so this initlization is safe", false)
-    static score::lcm::LifecycleClient g_lm{};
-    const auto result = g_lm.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    static score::mw::lifecycle::LifecycleClient g_lm{};
+    const auto result = g_lm.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
     if (!result) {
         return -1;
     }

--- a/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclientimpl.cpp
+++ b/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclientimpl.cpp
@@ -26,11 +26,7 @@
 
 using namespace score::lcm::internal::osal;
 
-namespace score
-{
-
-    namespace lcm
-    {
+namespace score::mw::lifecycle {
         std::atomic_bool LifecycleClient::LifecycleClientImpl::reported{false};
 
         LifecycleClient::LifecycleClientImpl::LifecycleClientImpl() noexcept = default;
@@ -40,18 +36,18 @@ namespace score
         score::Result<std::monostate> LifecycleClient::LifecycleClientImpl::ReportExecutionState(ExecutionState state) const noexcept
         {
 
-            score::Result<std::monostate> retVal{score::MakeUnexpected(score::lcm::ExecErrc::kCommunicationError)};
+            score::Result<std::monostate> retVal{score::MakeUnexpected(ExecErrc::kCommunicationError)};
 
             // Check if the state is valid
-            if (score::lcm::ExecutionState::kRunning != state)
+            if (ExecutionState::kRunning != state)
             {
                 LM_LOG_ERROR() << "[Lifecycle Client] Invalid execution state!";
-                retVal = score::Result<std::monostate>{score::MakeUnexpected(score::lcm::ExecErrc::kInvalidTransition)};
+                retVal = score::Result<std::monostate>{score::MakeUnexpected(ExecErrc::kInvalidTransition)};
             }
             else if (reported)
             {
                 LM_LOG_INFO() << "[Lifecycle Client] Reported kRunning already!";
-                retVal = score::Result<std::monostate>{score::MakeUnexpected(score::lcm::ExecErrc::kInvalidTransition)};
+                retVal = score::Result<std::monostate>{score::MakeUnexpected(ExecErrc::kInvalidTransition)};
             }
             else
             {
@@ -63,7 +59,7 @@ namespace score
 
         score::Result<std::monostate> LifecycleClient::LifecycleClientImpl::reportKRunningtoDaemon() const noexcept
         {
-            score::Result<std::monostate> comms_error {score::MakeUnexpected(score::lcm::ExecErrc::kCommunicationError)};
+            score::Result<std::monostate> comms_error {score::MakeUnexpected(ExecErrc::kCommunicationError)};
 
             // Define necessary constants
             const int sync_fd = IpcCommsSync::sync_fd;
@@ -122,6 +118,4 @@ namespace score
             return score::Result<std::monostate>{};
         }
 
-    } // namespace lcm
-
-} // namespace score
+}  // namespace score::mw::lifecycle

--- a/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclientimpl.hpp
+++ b/src/launch_manager_daemon/lifecycle_client_lib/src/lifecycleclientimpl.hpp
@@ -20,9 +20,7 @@
 #include "score/lcm/lifecycle_client.h"
 #include "score/lcm/internal/osal/osalipccomms.hpp"
 
-namespace score {
-
-namespace lcm {
+namespace score::mw::lifecycle {
 
 /// @brief  Class implementing Pimpl (pointer to implementation) design pattern for LifecycleClient (an AUTOSAR data type).
 /// The lifecycle_client_lib strive to provide ABI compatibility as much as we can, so for this reason Pimpl pattern is deployed.
@@ -43,9 +41,9 @@ class LifecycleClient::LifecycleClientImpl final {
     ///
     /// @param state Value of the Execution State
     /// @returns An instance of score::Result. The instance holds an ErrorCode containing either one of the specified errors or a void-value.
-    /// @error score::lcm::ExecErrc::kGeneralError if some unspecified error occurred
-    /// @error score::lcm::ExecErrc::kCommunicationError Communication error between Application and Launch Manager, e.g. unable to report state for Non-reporting Process.
-    /// @error score::lcm::ExecErrc::kInvalidTransition  Invalid transition request (e.g. to Running when already in Running state)
+    /// @error score::mw::lifecycle::ExecErrc::kGeneralError if some unspecified error occurred
+    /// @error score::mw::lifecycle::ExecErrc::kCommunicationError Communication error between Application and Launch Manager, e.g. unable to report state for Non-reporting Process.
+    /// @error score::mw::lifecycle::ExecErrc::kInvalidTransition  Invalid transition request (e.g. to Running when already in Running state)
     score::Result<std::monostate> ReportExecutionState(ExecutionState state) const noexcept;
 
    private:
@@ -64,8 +62,6 @@ class LifecycleClient::LifecycleClientImpl final {
     score::Result<std::monostate> reportKRunningtoDaemon() const noexcept;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // _INCLUDED_LIFECYCLECLIENTIMPL_

--- a/src/launch_manager_daemon/process_state_client_lib/include/score/lcm/processstatereceiver.hpp
+++ b/src/launch_manager_daemon/process_state_client_lib/include/score/lcm/processstatereceiver.hpp
@@ -56,7 +56,7 @@ class ProcessStateReceiver final : public IProcessStateReceiver {
     /// @brief Returns the queued PosixProcess, which changed and PHM has not yet parsed.
     /// @returns Returns the queued PosixProcess, which PHM has not yet parsed.
     ///          "std::nullopt" is returned in case there is no new information.
-    ///          "score::lcm::ExecErrc::kGeneralError" is returned in case of any other error.
+    ///          "score::mw::lifecycle::ExecErrc::kGeneralError" is returned in case of any other error.
     score::Result<std::optional<PosixProcess>> getNextChangedPosixProcess() noexcept override;
 
    private:

--- a/src/launch_manager_daemon/process_state_client_lib/src/processstateclient_UT.cpp
+++ b/src/launch_manager_daemon/process_state_client_lib/src/processstateclient_UT.cpp
@@ -142,5 +142,5 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcessTooMany_Fails)
     // Ensure that no processes can be retrieved
     auto result = receiver_->getNextChangedPosixProcess();
     ASSERT_FALSE(result.has_value()) << "Expected no processes to be retrievable";
-    EXPECT_EQ(result.error(), score::lcm::ExecErrc::kCommunicationError);
+    EXPECT_EQ(result.error(), score::mw::lifecycle::ExecErrc::kCommunicationError);
 }

--- a/src/launch_manager_daemon/process_state_client_lib/src/processstatereceiver.cpp
+++ b/src/launch_manager_daemon/process_state_client_lib/src/processstatereceiver.cpp
@@ -31,7 +31,7 @@ ProcessStateReceiver::getNextChangedPosixProcess() noexcept {
         << "ProcessStateReceiver::getNextChangedPosixProcess: Overflow occurred, "
            "will be reported as kCommunicationError";
     return score::Result<std::optional<score::lcm::PosixProcess>>{
-        score::MakeUnexpected(score::lcm::ExecErrc::kCommunicationError)};
+        score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
   }
 
   if (ring_buffer_->empty()) {
@@ -42,7 +42,7 @@ ProcessStateReceiver::getNextChangedPosixProcess() noexcept {
   if (res) {
     return score::Result<std::optional<score::lcm::PosixProcess>>{changedProcess};
   } else {
-    return score::Result<std::optional<score::lcm::PosixProcess>>{score::MakeUnexpected(score::lcm::ExecErrc::kGeneralError)};
+    return score::Result<std::optional<score::lcm::PosixProcess>>{score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kGeneralError)};
   }
 }
 } // namespace lcm

--- a/src/lifecycle_client_lib/src/lifecyclemanager.cpp
+++ b/src/lifecycle_client_lib/src/lifecyclemanager.cpp
@@ -170,7 +170,7 @@ void score::mw::lifecycle::LifeCycleManager::handle_signal()
 void score::mw::lifecycle::LifeCycleManager::report_running() noexcept
 {
     mw::log::LogInfo() << "Reporting kRunning to Launch Manager";
-    const auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    const auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
     if (!result.has_value())
     {
         mw::log::LogError() << "Failed to report kRunning to Launch Manager: " << result.error().Message();

--- a/tests/integration/complex_monitoring/component_complex_monitoring.cpp
+++ b/tests/integration/complex_monitoring/component_complex_monitoring.cpp
@@ -25,7 +25,7 @@ TEST(ComplexMonitoring, ComponentComplexMonitoring)
     score::mw::log::rust::StdoutLoggerBuilder builder;
     builder.Context("APP").LogLevel(score::mw::log::rust::LogLevel::Verbose).SetAsDefaultLogger();
 
-    using namespace score::hm;
+    using namespace score::mw::health;
     using namespace std::chrono_literals;
 
     auto hm_result = HealthMonitorBuilder()
@@ -46,7 +46,7 @@ TEST(ComplexMonitoring, ComponentComplexMonitoring)
 
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 

--- a/tests/integration/complex_monitoring/control_client_mock.cpp
+++ b/tests/integration/complex_monitoring/control_client_mock.cpp
@@ -20,13 +20,13 @@
 
 TEST(ComplexMonitoring, ControlClientMock)
 {
-    score::lcm::ControlClient client;
+    score::mw::lifecycle::ControlClient client;
     
     ASSERT_TRUE(check_clean({test_end_location, fallback_file}));
 
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     // We have to wait for the initial state transition to fully complete, otherwise unexpected failures can occur

--- a/tests/integration/crash_on_startup/control_client_mock.cpp
+++ b/tests/integration/crash_on_startup/control_client_mock.cpp
@@ -20,13 +20,13 @@
 
 TEST(CrashOnStartup, ControlClientMock)
 {
-    score::lcm::ControlClient client;
+    score::mw::lifecycle::ControlClient client;
     
     ASSERT_TRUE(check_clean({crashed_once_file, crashed_twice_file, test_end_location, fallback_file}));
 
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 

--- a/tests/integration/crash_on_startup/process_crashing_on_startup_twice.cpp
+++ b/tests/integration/crash_on_startup/process_crashing_on_startup_twice.cpp
@@ -21,7 +21,7 @@ TEST(CrashOnStartup, ProcessCrashingOnStartupTwice)
 {
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 }

--- a/tests/integration/incorrect_config_non_reporting/non_reporting_process.cpp
+++ b/tests/integration/incorrect_config_non_reporting/non_reporting_process.cpp
@@ -42,7 +42,7 @@ TEST(NonReporting, Process)
     }
 
     // Invalid kRunning report
-    auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
     EXPECT_FALSE(result.has_value()) << "ReportExecutionState() should not succeed";
 
     close(ipc::sync_fd);

--- a/tests/integration/process_crash_monitoring/control_client_mock.cpp
+++ b/tests/integration/process_crash_monitoring/control_client_mock.cpp
@@ -25,13 +25,13 @@
 
 TEST(ProcessCrashMonitoring, ControlClientMock)
 {
-    score::lcm::ControlClient client;
+    score::mw::lifecycle::ControlClient client;
     
     ASSERT_TRUE(check_clean({test_end_location, fallback_file}));
     // Establish communication with launch manager
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 

--- a/tests/integration/process_crash_monitoring/process_crashing_on_runtime.cpp
+++ b/tests/integration/process_crash_monitoring/process_crashing_on_runtime.cpp
@@ -19,7 +19,7 @@ TEST(ProcessCrashMonitoring, CrashingProcess)
 {
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 }

--- a/tests/integration/process_launch_args/process_initial.cpp
+++ b/tests/integration/process_launch_args/process_initial.cpp
@@ -31,7 +31,7 @@ TEST(ProcessLaunchArgs, ProcessInitial)
     // Then, the process is started and:
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     TEST_STEP("Check args")

--- a/tests/integration/smoke/control_daemon_mock.cpp
+++ b/tests/integration/smoke/control_daemon_mock.cpp
@@ -23,11 +23,11 @@
 
 TEST(Smoke, Daemon) {
 
-    score::lcm::ControlClient client {};
+    score::mw::lifecycle::ControlClient client {};
 
     TEST_STEP("Control daemon report kRunning") {
         // report kRunning
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "client.ReportExecutionState() failed: " << result.error().Message();
     }
     TEST_STEP("Activate RunTarget Running") {

--- a/tests/integration/smoke/gtest_process.cpp
+++ b/tests/integration/smoke/gtest_process.cpp
@@ -20,7 +20,7 @@
 
 TEST(Smoke, Process) {
     // report kRunning
-    auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
 
     ASSERT_TRUE(result.has_value()) << "client.ReportExecutionState() failed";
 }

--- a/tests/integration/switch_run_target/component_a.cpp
+++ b/tests/integration/switch_run_target/component_a.cpp
@@ -21,7 +21,7 @@ TEST(ComponentA, RunAndVerify)
     TEST_STEP("Report running")
     {
         EXPECT_TRUE(touch_file(a_started)) << "failed to deploy file";
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     TEST_STEP("Verify startup order")

--- a/tests/integration/switch_run_target/component_b.cpp
+++ b/tests/integration/switch_run_target/component_b.cpp
@@ -26,7 +26,7 @@ TEST(ComponentB, RunAndVerify)
     TEST_STEP("Report running")
     {
         EXPECT_TRUE(touch_file(b_started)) << "failed to deploy file";
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     while (!TestRunner::exitRequested)

--- a/tests/integration/switch_run_target/component_d.cpp
+++ b/tests/integration/switch_run_target/component_d.cpp
@@ -21,7 +21,7 @@ TEST(ComponentD, RunAndVerify)
     TEST_STEP("Report running")
     {
         EXPECT_TRUE(touch_file(d_started)) << "failed to deploy file";
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     while (!TestRunner::exitRequested)

--- a/tests/integration/switch_run_target/control_client_mock.cpp
+++ b/tests/integration/switch_run_target/control_client_mock.cpp
@@ -35,12 +35,12 @@
 
 TEST(SwitchRunTarget, ControlClientMock)
 {
-    score::lcm::ControlClient client;
+    score::mw::lifecycle::ControlClient client;
     
     ASSERT_TRUE(check_clean({test_end_location, a_started, b_started, d_started, e_started}));
     TEST_STEP("Report kRunning")
     {
-        auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+        auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
     // When we switch run to run target A

--- a/tests/utils/test_helper/reporting_process.cpp
+++ b/tests/utils/test_helper/reporting_process.cpp
@@ -19,7 +19,7 @@
 
 TEST(ReportingProcess, ReportsRunning)
 {
-    auto result = score::lcm::LifecycleClient{}.ReportExecutionState(score::lcm::ExecutionState::kRunning);
+    auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
     EXPECT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
 }
 


### PR DESCRIPTION
## Summary

- Move lifecycle public API types (`ControlClient`, `LifecycleClient`,
`ExecutionState`, `ExecErrc`, `ExecErrorDomain`, `MakeError`) from `score::lcm` to `score::mw::lifecycle`

- Move PHM checkpoint/supervision types (`Monitor<EnumT>`, `MonitorImplWrapper`, `Checkpoint`, `ElementarySupervisionStatus`, `LocalSupervisionStatus`, `GlobalSupervisionStatus`) from `score::lcm` to `score::mw::lifecycle` (1:1 rename — these were `score::lcm`, not `score::hm`)

- Move health monitoring public API types (`HealthMonitor`, `HealthMonitorBuilder`, `Error`, `TimeRange`) from `score::hm` to `score::mw::health`

- Move sub-namespaces: `score::hm::deadline` → `score::mw::health::deadline`, `score::hm::heartbeat` → `score::mw::health::heartbeat`, `score::hm::logic` → `score::mw::health::logic`

- Internal namespaces (`score::lcm::internal`, `score::lcm::saf`) are unchanged

## Notes

Breaking change - no backward compatibility aliases. Team decision: limited
existing public API consumers make the added complexity of deprecated aliases
unjustifiable.
  
Backwards compatibility in this issue discussed [here](https://github.com/orgs/eclipse-score/discussions/2386#discussioncomment-16666555)

Closes #147