### PR TITLE
Fix Spurious recovery action trigger on first run target activation (#198)

### DIFF
--- a/score/launch_manager/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/daemon/src/process_group_manager/details/graph.cpp
@@ -275,7 +275,10 @@ bool Graph::startTransition(ProcessGroupStateID pg_state)
 
     if (nullptr != process_index_list)
     {
-        setState(GraphState::kInTransition);
+        {
+            std::shared_lock lock(transition_completion_mutex_);
+            setState(GraphState::kInTransition);
+        }
 
         if (GraphState::kInTransition == getState())
         {
@@ -315,7 +318,10 @@ bool Graph::startTransitionToOffState()
         requested_state_.pg_state_name_ = off_state_;
     }
     bool result = false;
-    setState(GraphState::kInTransition);
+    {
+        std::shared_lock lock(transition_completion_mutex_);
+        setState(GraphState::kInTransition);
+    }
     if (GraphState::kInTransition == getState())
     {
         std::vector<uint32_t> empty_list{};
@@ -327,6 +333,8 @@ bool Graph::startTransitionToOffState()
 
 void Graph::nodeExecuted()
 {
+    std::unique_lock lock(transition_completion_mutex_);
+
     GraphState current_state = getState();
 
     if (current_state == GraphState::kInTransition)
@@ -390,7 +398,6 @@ inline void Graph::handleNonTransitionExecution(GraphState current_state)
                            << (static_cast<double>(clock()) / (static_cast<double>(CLOCKS_PER_SEC) / 1000.0)) << "ms";
         }
         setState(GraphState::kUndefinedState);
-
         if (current_state == GraphState::kAborting)
         {
             setPendingEvent(abort_code_);
@@ -414,6 +421,7 @@ void Graph::abort(uint32_t code, ControlClientCode reason)
 
 void Graph::cancel()
 {
+    std::shared_lock lock(transition_completion_mutex_);
     setState(GraphState::kCancelled);
 
     if (getState() == GraphState::kCancelled)

--- a/score/launch_manager/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/daemon/src/process_group_manager/details/graph.hpp
@@ -416,7 +416,7 @@ class Graph final {
     /// @brief Mutex protecting concurrent access to requested_state_.pg_state_name_
     mutable std::mutex requested_state_mutex_{};
 
-    /// @brief Mutex protecting new transitions from interferring with concluding transitions.
+    /// @brief Mutex protecting new transitions from interfering with concluding transitions.
     /// This enforces that, when a transition has completed successfully, it cannot then be cancelled.
     std::shared_mutex transition_completion_mutex_;
 

--- a/score/launch_manager/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/daemon/src/process_group_manager/details/graph.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <atomic>
 #include <mutex>
+#include <shared_mutex>
 #include <string_view>
 #include <vector>
 
@@ -414,6 +415,10 @@ class Graph final {
     ProcessGroupStateID requested_state_{};
     /// @brief Mutex protecting concurrent access to requested_state_.pg_state_name_
     mutable std::mutex requested_state_mutex_{};
+
+    /// @brief Mutex protecting new transitions from interferring with concluding transitions.
+    /// This enforces that, when a transition has completed successfully, it cannot then be cancelled.
+    std::shared_mutex transition_completion_mutex_;
 
     /// @brief Pointer to the ProcessGroupManager.
     ProcessGroupManager* pgm_;

--- a/tests/integration/complex_monitoring/control_client_mock.cpp
+++ b/tests/integration/complex_monitoring/control_client_mock.cpp
@@ -29,9 +29,6 @@ TEST(ComplexMonitoring, ControlClientMock)
         auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
-    // We have to wait for the initial state transition to fully complete, otherwise unexpected failures can occur
-    // Tracked in https://github.com/eclipse-score/lifecycle/issues/198
-    sleep(1);
     
     TEST_STEP("Launch monitored process")
     {

--- a/tests/integration/crash_on_startup/control_client_mock.cpp
+++ b/tests/integration/crash_on_startup/control_client_mock.cpp
@@ -30,10 +30,6 @@ TEST(CrashOnStartup, ControlClientMock)
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
 
-    // We have to wait for the initial state transition to fully complete, otherwise unexpected failures can occur
-    // Tracked in https://github.com/eclipse-score/lifecycle/issues/198
-    sleep(1);
-
     // Given a process that crashes on startup twice
     TEST_STEP("Launch process crashing on startup twice")
     {

--- a/tests/integration/process_crash_monitoring/control_client_mock.cpp
+++ b/tests/integration/process_crash_monitoring/control_client_mock.cpp
@@ -34,10 +34,6 @@ TEST(ProcessCrashMonitoring, ControlClientMock)
         auto result = score::mw::lifecycle::LifecycleClient{}.ReportExecutionState(score::mw::lifecycle::ExecutionState::kRunning);
         ASSERT_TRUE(result.has_value()) << "ReportExecutionState() failed: " << result.error().Message();
     }
-
-    // We have to wait for the initial state transition to fully complete, otherwise unexpected failures can occur
-    // Tracked in https://github.com/eclipse-score/lifecycle/issues/198
-    sleep(1);
     
     TEST_STEP("Start crashing process")
     {

--- a/tests/integration/smoke/control_daemon_mock.cpp
+++ b/tests/integration/smoke/control_daemon_mock.cpp
@@ -31,10 +31,6 @@ TEST(Smoke, Daemon)
         ASSERT_TRUE(result.has_value()) << "client.ReportExecutionState() failed: " << result.error().Message();
     }
 
-    // We have to wait for the initial state transition to fully complete, otherwise unexpected failures can occur
-    // Tracked in https://github.com/eclipse-score/lifecycle/issues/198
-    sleep(1);
-
     TEST_STEP("Activate RunTarget Running")
     {
         score::cpp::stop_token stop_token;


### PR DESCRIPTION
Added a shared mutex to protect completing transitions. This resolves a race where a transition would finish (in `Graph::handleTransitionExecution`) and the state would be changed to `kCancelled` by another thread just after being set to `kSuccess`, which is a blocked transition. This led to the undefined state being set and a recovery action triggering.

Fixes #198 