### PR TITLE
Fix Deprecated score::StringLiteral in applicationcontext.h causes build failures in downstream consumers (#214)

### DIFF
--- a/docs/module/lifecycle_client_lib/model/structural_view.uxf
+++ b/docs/module/lifecycle_client_lib/model/structural_view.uxf
@@ -55,7 +55,7 @@ environments</panel_attributes><additional_attributes></additional_attributes></
 operation
 + initialize(const ApplicationContext&amp;): std::int32_t override
 + run(amp::stop_token stop_token): std::int32_t override
-+ AasApplicationContainer(cosnt std::int32_t argc, const char* const* argv, const std::size_t count_expected_applications): noexcept
++ AasApplicationContainer(const std::int32_t argc, const char* const* argv, const std::size_t count_expected_applications): noexcept
 + With&lt;App,...Args&gt;(Args&amp;&amp;.. args) : AasApplicationContainer&amp;
 + Launch() : std::int32_t
 --

--- a/docs/module/lifecycle_client_lib/model/structural_view.uxf
+++ b/docs/module/lifecycle_client_lib/model/structural_view.uxf
@@ -6,7 +6,7 @@ Operation
 + run(amp::stop_token stop_token): std::int32_t virtual = 0</panel_attributes><additional_attributes></additional_attributes></element><element><id>UMLClass</id><coordinates><x>171</x><y>855</y><w>486</w><h>135</h></coordinates><panel_attributes>score::mw::lifecycle::ApplicationContext
 --
 Operations
-+ ApplicationContext(const int32_t argc, const score::StringLiteral argv[])
++ ApplicationContext(const int32_t argc, const char* const argv[])
 + get_arguments(): const std::vector&lt;std::string&gt;&amp; const noexcept
 + get_argument(const amp::string_view flag): std::string const noexcept
 -- 
@@ -39,7 +39,7 @@ manages</panel_attributes><additional_attributes>10;130;10;10</additional_attrib
 Run
 --
 Operation
-+ Run(const int32_t argc, const score::StringLiteral* argv)
++ Run(const int32_t argc, const char* const* argv)
 + AsPosixProcess(Args&amp;&amp;... args): std::int32_t const
 
 --
@@ -55,7 +55,7 @@ environments</panel_attributes><additional_attributes></additional_attributes></
 operation
 + initialize(const ApplicationContext&amp;): std::int32_t override
 + run(amp::stop_token stop_token): std::int32_t override
-+ AasApplicationContainer(cosnt std::int32_t argc, const score::StringLiteral* argv, const std::size_t count_expected_applications): noexcept
++ AasApplicationContainer(cosnt std::int32_t argc, const char* const* argv, const std::size_t count_expected_applications): noexcept
 + With&lt;App,...Args&gt;(Args&amp;&amp;.. args) : AasApplicationContainer&amp;
 + Launch() : std::int32_t
 --

--- a/docs/module/lifecycle_client_lib/model/structural_view.uxf
+++ b/docs/module/lifecycle_client_lib/model/structural_view.uxf
@@ -39,7 +39,7 @@ manages</panel_attributes><additional_attributes>10;130;10;10</additional_attrib
 Run
 --
 Operation
-+ Run(const int32_t argc, const char* const* argv)
++ Run(const int32_t argc, const char* const argv[])
 + AsPosixProcess(Args&amp;&amp;... args): std::int32_t const
 
 --
@@ -55,7 +55,7 @@ environments</panel_attributes><additional_attributes></additional_attributes></
 operation
 + initialize(const ApplicationContext&amp;): std::int32_t override
 + run(amp::stop_token stop_token): std::int32_t override
-+ AasApplicationContainer(const std::int32_t argc, const char* const* argv, const std::size_t count_expected_applications): noexcept
++ AasApplicationContainer(const std::int32_t argc, const char* const argv[], const std::size_t count_expected_applications): noexcept
 + With&lt;App,...Args&gt;(Args&amp;&amp;.. args) : AasApplicationContainer&amp;
 + Launch() : std::int32_t
 --

--- a/score/launch_manager/daemon/src/alive_monitor/details/MonitorImpl.cpp
+++ b/score/launch_manager/daemon/src/alive_monitor/details/MonitorImpl.cpp
@@ -119,15 +119,15 @@ std::string MonitorImpl::getIpcPath(void) noexcept(false)
 }
 
 std::unique_ptr<char[]> MonitorImpl::read_flatbuffer_file() const {
-    const char* configFilePath = getenv("CONFIG_PATH");
-    if(!configFilePath) {
+    const std::string_view configFilePath {getenv("CONFIG_PATH")};
+    if(!configFilePath.data()) {
         return nullptr;
     }
 
     logger_r.LogDebug() << "Attempting to read config file from " << configFilePath;
 
     std::ifstream infile;
-    infile.open(configFilePath, std::ios::binary | std::ios::in);
+    infile.open(configFilePath.data(), std::ios::binary | std::ios::in);
     if (!infile.is_open()) {
         return nullptr;
     }

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
@@ -24,7 +24,7 @@ namespace lifecycle
 {
 
 AasApplicationContainer::AasApplicationContainer(const std::int32_t argc,
-                                                 const char* const* argv,
+                                                 const char* const argv[],
                                                  const std::size_t count_expected_applications) noexcept
     : Application{}, context_{argc, argv}, applications_{}, count_expected_applications_{count_expected_applications}
 {

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
@@ -23,9 +23,8 @@ namespace mw
 namespace lifecycle
 {
 
-
 AasApplicationContainer::AasApplicationContainer(const std::int32_t argc,
-                                                 const score::StringLiteral* argv,
+                                                 const char** argv,
                                                  const std::size_t count_expected_applications) noexcept
     : Application{}, context_{argc, argv}, applications_{}, count_expected_applications_{count_expected_applications}
 {

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.cpp
@@ -24,7 +24,7 @@ namespace lifecycle
 {
 
 AasApplicationContainer::AasApplicationContainer(const std::int32_t argc,
-                                                 const char** argv,
+                                                 const char* const* argv,
                                                  const std::size_t count_expected_applications) noexcept
     : Application{}, context_{argc, argv}, applications_{}, count_expected_applications_{count_expected_applications}
 {

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
@@ -41,7 +41,7 @@ class AasApplicationContainer : public Application
      * @param count_expected_applications The expected number of applications.
      */
     AasApplicationContainer(const std::int32_t argc,
-                            const score::StringLiteral* argv,
+                            const char** argv,
                             const std::size_t count_expected_applications) noexcept;
 
     AasApplicationContainer(const AasApplicationContainer&) = delete;
@@ -69,7 +69,7 @@ class AasApplicationContainer : public Application
     AasApplicationContainer& With(Args&&... args)
     {
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(applications_.size() + 1 <= count_expected_applications_,
-                               "Passed more Applications than expected");
+                                                    "Passed more Applications than expected");
         applications_.push_back(std::make_unique<App>(std::forward<Args>(args)...));
         return *this;
     }

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
@@ -41,7 +41,7 @@ class AasApplicationContainer : public Application
      * @param count_expected_applications The expected number of applications.
      */
     AasApplicationContainer(const std::int32_t argc,
-                            const char* const* argv,
+                            const char* const argv[],
                             const std::size_t count_expected_applications) noexcept;
 
     AasApplicationContainer(const AasApplicationContainer&) = delete;

--- a/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
+++ b/score/launch_manager/lifecycle_client/src/aasapplicationcontainer.h
@@ -41,7 +41,7 @@ class AasApplicationContainer : public Application
      * @param count_expected_applications The expected number of applications.
      */
     AasApplicationContainer(const std::int32_t argc,
-                            const char** argv,
+                            const char* const* argv,
                             const std::size_t count_expected_applications) noexcept;
 
     AasApplicationContainer(const AasApplicationContainer&) = delete;

--- a/score/launch_manager/lifecycle_client/src/applicationcontext.cpp
+++ b/score/launch_manager/lifecycle_client/src/applicationcontext.cpp
@@ -18,7 +18,7 @@
 
 score::mw::lifecycle::ApplicationContext::ApplicationContext(
     const std::int32_t argc,
-    const char* argv[])  // NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments
+    const char* const argv[])  // NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments
     : m_args(argv, argv + argc), m_app_path(argv[0])  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic): array
                                                       // tolerated for command line arguments
 {

--- a/score/launch_manager/lifecycle_client/src/applicationcontext.cpp
+++ b/score/launch_manager/lifecycle_client/src/applicationcontext.cpp
@@ -18,7 +18,7 @@
 
 score::mw::lifecycle::ApplicationContext::ApplicationContext(
     const std::int32_t argc,
-    const score::StringLiteral argv[])  // NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments
+    const char* argv[])  // NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments
     : m_args(argv, argv + argc), m_app_path(argv[0])  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic): array
                                                       // tolerated for command line arguments
 {

--- a/score/launch_manager/lifecycle_client/src/applicationcontext.h
+++ b/score/launch_manager/lifecycle_client/src/applicationcontext.h
@@ -14,9 +14,10 @@
 #ifndef SCORE_MW_LIFECYCLE_APPLICATIONCONTEXT_H
 #define SCORE_MW_LIFECYCLE_APPLICATIONCONTEXT_H
 
-#include <string_view>
+#include "score/memory/string_literal.h"
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace score
@@ -37,7 +38,7 @@ class ApplicationContext
 
   public:
     /* NOLINTNEXTLINE(modernize-avoid-c-arrays): array tolerated for command line arguments */
-    ApplicationContext(const std::int32_t argc, const char* argv[]);
+    ApplicationContext(const std::int32_t argc, const char* const argv[]);
 
     /**
      * \brief Utility function.

--- a/score/launch_manager/lifecycle_client/src/applicationcontext.h
+++ b/score/launch_manager/lifecycle_client/src/applicationcontext.h
@@ -14,7 +14,6 @@
 #ifndef SCORE_MW_LIFECYCLE_APPLICATIONCONTEXT_H
 #define SCORE_MW_LIFECYCLE_APPLICATIONCONTEXT_H
 
-#include "score/memory/string_literal.h"
 #include <string_view>
 #include <cstdint>
 #include <string>
@@ -38,7 +37,7 @@ class ApplicationContext
 
   public:
     /* NOLINTNEXTLINE(modernize-avoid-c-arrays): array tolerated for command line arguments */
-    ApplicationContext(const std::int32_t argc, const score::StringLiteral argv[]);
+    ApplicationContext(const std::int32_t argc, const char* argv[]);
 
     /**
      * \brief Utility function.

--- a/score/launch_manager/lifecycle_client/src/applicationcontextmock.cpp
+++ b/score/launch_manager/lifecycle_client/src/applicationcontextmock.cpp
@@ -21,7 +21,7 @@ namespace
 
 auto& GetConstructorCallback() noexcept
 {
-    static std::function<void(const std::int32_t argc, const score::StringLiteral argv[])> constructor_callback{};
+    static std::function<void(const std::int32_t argc, const char* argv[])> constructor_callback{};
     return constructor_callback;
 }
 
@@ -41,7 +41,7 @@ auto& GetGetArgumentCallback() noexcept
 
 score::mw::lifecycle::ApplicationContextMock::ApplicationContextMock()
 {
-    GetConstructorCallback() = [this](const std::int32_t argc, const score::StringLiteral argv[]) {
+    GetConstructorCallback() = [this](const std::int32_t argc, const char* argv[]) {
         ctor(argc, argv);
     };
     GetGetArgumentsCallback() = [this]() -> decltype(auto) {
@@ -59,7 +59,7 @@ score::mw::lifecycle::ApplicationContextMock::~ApplicationContextMock()
     GetGetArgumentCallback() = nullptr;
 }
 
-score::mw::lifecycle::ApplicationContext::ApplicationContext(const std::int32_t argc, const score::StringLiteral argv[])
+score::mw::lifecycle::ApplicationContext::ApplicationContext(const std::int32_t argc, const char* argv[])
 {
     auto& constructor_callback = GetConstructorCallback();
     constructor_callback(argc, argv);

--- a/score/launch_manager/lifecycle_client/src/applicationcontextmock.cpp
+++ b/score/launch_manager/lifecycle_client/src/applicationcontextmock.cpp
@@ -21,7 +21,7 @@ namespace
 
 auto& GetConstructorCallback() noexcept
 {
-    static std::function<void(const std::int32_t argc, const char* argv[])> constructor_callback{};
+    static std::function<void(const std::int32_t argc, const char* const argv[])> constructor_callback{};
     return constructor_callback;
 }
 
@@ -41,7 +41,7 @@ auto& GetGetArgumentCallback() noexcept
 
 score::mw::lifecycle::ApplicationContextMock::ApplicationContextMock()
 {
-    GetConstructorCallback() = [this](const std::int32_t argc, const char* argv[]) {
+    GetConstructorCallback() = [this](const std::int32_t argc, const char* const argv[]) {
         ctor(argc, argv);
     };
     GetGetArgumentsCallback() = [this]() -> decltype(auto) {
@@ -59,7 +59,7 @@ score::mw::lifecycle::ApplicationContextMock::~ApplicationContextMock()
     GetGetArgumentCallback() = nullptr;
 }
 
-score::mw::lifecycle::ApplicationContext::ApplicationContext(const std::int32_t argc, const char* argv[])
+score::mw::lifecycle::ApplicationContext::ApplicationContext(const std::int32_t argc, const char* const argv[])
 {
     auto& constructor_callback = GetConstructorCallback();
     constructor_callback(argc, argv);

--- a/score/launch_manager/lifecycle_client/src/applicationcontextmock.h
+++ b/score/launch_manager/lifecycle_client/src/applicationcontextmock.h
@@ -36,7 +36,7 @@ class ApplicationContextMock
     ~ApplicationContextMock();
 
     MOCK_METHOD(const std::vector<std::string>&, get_arguments, (), ());
-    MOCK_METHOD(void, ctor, (const std::int32_t argc, const char* argv[]), ());
+    MOCK_METHOD(void, ctor, (const std::int32_t argc, const char* const argv[]), ());
     MOCK_METHOD(std::string, get_argument, (const std::string_view flag), ());
 };
 

--- a/score/launch_manager/lifecycle_client/src/applicationcontextmock.h
+++ b/score/launch_manager/lifecycle_client/src/applicationcontextmock.h
@@ -36,7 +36,7 @@ class ApplicationContextMock
     ~ApplicationContextMock();
 
     MOCK_METHOD(const std::vector<std::string>&, get_arguments, (), ());
-    MOCK_METHOD(void, ctor, (const std::int32_t argc, const score::StringLiteral argv[]), ());
+    MOCK_METHOD(void, ctor, (const std::int32_t argc, const char* argv[]), ());
     MOCK_METHOD(std::string, get_argument, (const std::string_view flag), ());
 };
 

--- a/score/launch_manager/lifecycle_client/src/lifecyclemanager.cpp
+++ b/score/launch_manager/lifecycle_client/src/lifecyclemanager.cpp
@@ -94,7 +94,7 @@ std::int32_t score::mw::lifecycle::LifeCycleManager::run(Application& app, const
     const auto run_status = m_app->Run(m_stop_source.get_token());  // LCOV_EXCL_BR_LINE
     if (run_status != 0)
     {
-        mw::log::LogError() << "Error occured during Run";
+        mw::log::LogError() << "Error occurred during Run";
     }
     mw::log::LogInfo() << "Shutting down Application";
     mw::log::LogInfo() << "Application" << application_name << "run finished with" << run_status;

--- a/score/launch_manager/lifecycle_client/src/runapplication.h
+++ b/score/launch_manager/lifecycle_client/src/runapplication.h
@@ -15,7 +15,6 @@
 #define SCORE_MW_LIFECYCLE_RUNAPPLICATION_H
 
 #include "score/mw/lifecycle/lifecycle_client/lifecyclemanager.h"
-#include "score/memory/string_literal.h"
 #include "score/mw/lifecycle/lifecycle_client/applicationcontext.h"
 
 #include <cstdint>
@@ -32,8 +31,7 @@ class Run final
 {
   public:
     Run(const std::int32_t argc,
-        const score::StringLiteral*
-            argv) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
+        const char** argv) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
         : context_{argc, argv}
     {
     }
@@ -66,7 +64,7 @@ class Run final
 template <typename ApplicationType, typename... Args>
 
 /* NOLINTNEXTLINE(modernize-avoid-c-arrays): array tolerated for command line arguments */
-std::int32_t run_application(const std::int32_t argc, const score::StringLiteral argv[], Args&&... args)
+std::int32_t run_application(const std::int32_t argc, const char* argv[], Args&&... args)
 {
     score::mw::lifecycle::Run<ApplicationType> runner(argc, argv);
     return runner.AsPosixProcess(std::forward<Args>(args)...);
@@ -77,4 +75,3 @@ std::int32_t run_application(const std::int32_t argc, const score::StringLiteral
 }  // namespace score
 
 #endif  // SCORE_MW_LIFECYCLE_RUNAPPLICATION_H
-

--- a/score/launch_manager/lifecycle_client/src/runapplication.h
+++ b/score/launch_manager/lifecycle_client/src/runapplication.h
@@ -31,7 +31,7 @@ class Run final
 {
   public:
     Run(const std::int32_t argc,
-        const char* const* argv) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
+        const char* const argv[]) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
         : context_{argc, argv}
     {
     }

--- a/score/launch_manager/lifecycle_client/src/runapplication.h
+++ b/score/launch_manager/lifecycle_client/src/runapplication.h
@@ -31,7 +31,7 @@ class Run final
 {
   public:
     Run(const std::int32_t argc,
-        const char** argv) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
+        const char* const* argv) /* NOLINT(modernize-avoid-c-arrays): array tolerated for command line arguments */
         : context_{argc, argv}
     {
     }
@@ -64,7 +64,7 @@ class Run final
 template <typename ApplicationType, typename... Args>
 
 /* NOLINTNEXTLINE(modernize-avoid-c-arrays): array tolerated for command line arguments */
-std::int32_t run_application(const std::int32_t argc, const char* argv[], Args&&... args)
+std::int32_t run_application(const std::int32_t argc, const char* const argv[], Args&&... args)
 {
     score::mw::lifecycle::Run<ApplicationType> runner(argc, argv);
     return runner.AsPosixProcess(std::forward<Args>(args)...);


### PR DESCRIPTION
- Replaced score::StringLiteral with char*
- Fixed a warning from logging a char*

Fixes #214 