### PR TITLE
Adding central ecu log config

### DIFF
--- a/tests/utils/environments/BUILD
+++ b/tests/utils/environments/BUILD
@@ -11,6 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+exports_files(
+    ["ecu_logging_config.json"],
+    visibility = ["//tests/utils/environments:__subpackages__"],
+)
+
 # Empty target for native builds
 filegroup(
     name = "empty_target",

--- a/tests/utils/environments/ecu_logging_config.json
+++ b/tests/utils/environments/ecu_logging_config.json
@@ -1,0 +1,7 @@
+{
+    "ecuId": "ECU1",
+    "appId": "LM",
+    "logLevel": "kDebug",
+    "logLevelThresholdConsole": "kDebug",
+    "logMode": "kConsole"
+}

--- a/tests/utils/environments/x86_64-linux/BUILD
+++ b/tests/utils/environments/x86_64-linux/BUILD
@@ -11,10 +11,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+pkg_files(
+    name = "ecu_logging_config_files",
+    srcs = ["//tests/utils/environments:ecu_logging_config.json"],
+    attributes = pkg_attributes(mode = "0644"),
+    prefix = "etc",
+)
+
+pkg_tar(
+    name = "ecu_logging_config_layer",
+    srcs = [":ecu_logging_config_files"],
+)
 
 oci_image(
     name = "image",
     base = "@debian-test-runtime",
+    tars = [":ecu_logging_config_layer"],
 )
 
 oci_load(

--- a/tests/utils/testing_utils/setup_test.py
+++ b/tests/utils/testing_utils/setup_test.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 def setup_test(request, target):
     """Sets up the test by uploading and extracting the test binaries tar"""
 
+    # silence logs coming from docker which uses urllib3
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     bin_path = Path(request.config.getoption("--score-test-binary-path"))
     remote_dir = Path(request.config.getoption("--score-test-remote-directory"))
 


### PR DESCRIPTION
Adds a log config for the test environment.

Fixes https://github.com/eclipse-score/lifecycle/issues/223