### PR TITLE
log: fix stack use after scope in log init

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -134,6 +134,11 @@ use_repo(oci, "debian-test-runtime", "debian-test-runtime_linux_amd64")
 
 bazel_dep(name = "score_baselibs_rust", version = "0.1.2")
 bazel_dep(name = "score_baselibs", version = "0.2.8")
+git_override(
+    module_name = "score_baselibs",
+    commit = "d0145e0645d4fe9661a36c348f0e62e13cf73f98",
+    remote = "https://github.com/eclipse-score/baselibs.git",
+)
 
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -820,8 +820,6 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.18.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/2.1.1/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs/0.2.8/MODULE.bazel": "167e2cdfea63ef2eb38546d83ceef833671263f9faae6e496e834f86c2427f0d",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs/0.2.8/source.json": "6a649da9895fcdcaa58b0a4de11be04770f3180bb7ff176d3dfcb9bfe72ef0f3",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs_rust/0.1.2/MODULE.bazel": "8a07e1c62986e941a6e182e39c9cd08391849eed55c2f4dbb02d72ef6f524346",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs_rust/0.1.2/source.json": "5d920b55b98cf3d87da75d5a3ab1915709867fda14991ef2843c5e7c33aa0391",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.2.2/MODULE.bazel": "343a1892b1d5c616e0b4cbecfb5e548fa69328d22bb4fd5862bdd3cfa902142b",

--- a/score/health_monitor/src/cpp/BUILD
+++ b/score/health_monitor/src/cpp/BUILD
@@ -80,10 +80,6 @@ cc_gtest_unit_test(
         "@platforms//os:qnx": ["-lsocket"],
         "@platforms//os:linux": [],
     }),
-    # TODO(eclipse-score/baselibs#253): stack-use-after-scope in score_baselibs_rust
-    # StdoutLoggerBuilder::SetAsDefaultLogger - context_ptr dangles after the
-    # if-block destroys its std::string before the Rust FFI call reads it.
-    tags = ["no-asan"],
     deps = [
         "//score/health_monitor/src/cpp:health_monitoring_cc_stub_supervisor",
         "//score/health_monitor/src/cpp/details:log_init",
@@ -99,9 +95,6 @@ cc_gtest_unit_test(
         "@platforms//os:qnx": ["-lsocket"],
         "@platforms//os:linux": [],
     }),
-    tags = [
-        "no-asan",
-    ],
     deps = [
         "//score/health_monitor/src/cpp:health_monitoring_cc_stub_supervisor",
         "//score/health_monitor/src/cpp/details:log_init",

--- a/score/health_monitor/src/cpp/details/BUILD
+++ b/score/health_monitor/src/cpp/details/BUILD
@@ -19,7 +19,7 @@ cc_library(
     visibility = ["//score/health_monitor/src/cpp:__pkg__"],
     deps = [
         "@googletest//:gtest",
-        "@score_baselibs_rust//src/log/stdout_logger_cpp_init",
+        "@score_baselibs//src/log/stdout_logger_cpp_init",
     ],
 )
 


### PR DESCRIPTION
Fix stack use after scope in stdout logger init.

Related to https://github.com/eclipse-score/baselibs/issues/253