### PR TITLE
bazel: use profile-update=atomic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,8 @@ coverage --features=coverage
 coverage --combined_report=lcov
 coverage --cache_test_results=no
 coverage --test_tag_filters=-no-coverage
+coverage --copt=-fprofile-update=atomic
+coverage --linkopt=-fprofile-update=atomic
 
 # Common Lifecycle Toolchain flags for build (do not use it in case of system toolchains!)
 build:toolchain_common --incompatible_strict_action_env

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -29,7 +29,6 @@ jobs:
       bazel-target: "//score/..."
       bazel-config: "x86_64-linux"
       extra-bazel-flags: "--test_output=errors --nocache_test_results --lockfile_mode=error"
-      genhtml-extra-flags: "--ignore-errors=negative"
       artifact-name-suffix: "_cpp"
       retention-days: 10
       min-coverage: 76


### PR DESCRIPTION
`bazel coverage` sometimes return negative count on U24. Use atomic profile update instead of ignoring the error.