### PR TITLE
Replace assert() with baselibs futurecpp assert macros

### DIFF
--- a/score/health_monitor/src/cpp/common.h
+++ b/score/health_monitor/src/cpp/common.h
@@ -13,7 +13,7 @@
 #ifndef SCORE_HM_COMMON_H
 #define SCORE_HM_COMMON_H
 
-#include <cassert>
+#include <score/assert.hpp>
 #include <chrono>
 #include <optional>
 
@@ -95,7 +95,7 @@ class TimeRange
   public:
     TimeRange(std::chrono::milliseconds min_ms, std::chrono::milliseconds max_ms) : min_ms_(min_ms), max_ms_(max_ms)
     {
-        assert(min_ms_ <= max_ms_);
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION(min_ms_ <= max_ms_);
     }
 
     const uint32_t min_ms() const

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/BUILD
@@ -26,6 +26,7 @@ cc_library(
     include_prefix = "score/mw/launch_manager/alive_monitor/details/common",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/alive_monitor/details/common",
     visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
+    deps = ["@score_baselibs//score/language/futurecpp"],
 )
 
 cc_library(

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
@@ -13,8 +13,8 @@
 #ifndef OBSERVER_HPP_INCLUDED
 #define OBSERVER_HPP_INCLUDED
 
+#include <score/assert.hpp>
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 
 #include <vector>
@@ -38,7 +38,7 @@ namespace common
 template <typename Type_Observable>
 class Observer
 {
-public:
+  public:
     /// @brief Constructor
     Observer() = default;
 
@@ -57,7 +57,7 @@ public:
     /// @param [in]  f_observable_r     Observable as reference.
     virtual void updateData(const Type_Observable& f_observable_r) noexcept(true) = 0;
 
-protected:
+  protected:
     /// @brief Move Constructor
     Observer(Observer&&) = default;
 };
@@ -72,7 +72,7 @@ protected:
 template <typename Type_Observable>
 class Observable
 {
-public:
+  public:
     /// @brief Default Constructor
     Observable(void) = default;
 
@@ -107,7 +107,7 @@ public:
         observers.erase(eraseFirstItConst, observers.cend());
     }
 
-protected:
+  protected:
     /// @brief Move Constructor
     /// Cannot be noexcept, since the std::vector move constructor is not noexcept
     Observable(Observable&&) = default;
@@ -120,12 +120,12 @@ protected:
         {
             // We can be sure that *this is of type Type_Observable, anything else would be a programming error.
             // The runtime checks performed by dynamic_cast are not necessary.
-            assert((dynamic_cast<Type_Observable*>(this)) != NULL);
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD((dynamic_cast<Type_Observable*>(this)) != NULL);
             observer->updateData(static_cast<Type_Observable&>(*this));
         }
     }
 
-private:
+  private:
     /// Observers attached to the observable object
     std::vector<Observer<Type_Observable>*> observers{};
 };

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -15,36 +15,60 @@
 #include <cstdint>
 #include <iostream>
 
+#include <score/assert.hpp>
+
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/logging/PhmLogger.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/watchdog/WatchdogImpl.hpp"
 
-namespace score {
-namespace lcm {
-namespace saf {
-namespace daemon {
+namespace score
+{
+namespace lcm
+{
+namespace saf
+{
+namespace daemon
+{
 
-AliveMonitorImpl::AliveMonitorImpl(std::shared_ptr<score::lcm::IRecoveryClient> recovery_client, std::unique_ptr<watchdog::IWatchdogIf> watchdog, std::unique_ptr<score::lcm::IProcessStateReceiver> process_state_receiver)
-    : m_recovery_client(recovery_client), m_watchdog(std::move(watchdog)), m_logger{score::lcm::saf::logging::PhmLogger::getLogger(score::lcm::saf::logging::PhmLogger::EContext::factory)}, m_process_state_receiver{std::move(process_state_receiver)} {}
+AliveMonitorImpl::AliveMonitorImpl(std::shared_ptr<score::lcm::IRecoveryClient> recovery_client,
+                                   std::unique_ptr<watchdog::IWatchdogIf> watchdog,
+                                   std::unique_ptr<score::lcm::IProcessStateReceiver> process_state_receiver)
+    : m_recovery_client(recovery_client),
+      m_watchdog(std::move(watchdog)),
+      m_logger{score::lcm::saf::logging::PhmLogger::getLogger(score::lcm::saf::logging::PhmLogger::EContext::factory)},
+      m_process_state_receiver{std::move(process_state_receiver)}
+{
+}
 
-EInitCode AliveMonitorImpl::init() noexcept {
+EInitCode AliveMonitorImpl::init() noexcept
+{
     score::lcm::saf::daemon::EInitCode initResult{score::lcm::saf::daemon::EInitCode::kGeneralError};
-    try {
+    try
+    {
         m_osClock.startMeasurement();
 
-        m_daemon = std::make_unique<score::lcm::saf::daemon::PhmDaemon>(m_osClock, m_logger, std::move(m_watchdog), std::move(m_process_state_receiver));
+        m_daemon = std::make_unique<score::lcm::saf::daemon::PhmDaemon>(
+            m_osClock, m_logger, std::move(m_watchdog), std::move(m_process_state_receiver));
         initResult = m_daemon->init(m_recovery_client);
 
-        if (initResult == score::lcm::saf::daemon::EInitCode::kNoError) {
+        if (initResult == score::lcm::saf::daemon::EInitCode::kNoError)
+        {
             const long ms{m_osClock.endMeasurement()};
             m_logger.LogDebug() << "AliveMonitor: Initialization took " << ms << " ms";
-        } else {
-            m_logger.LogError() << "AliveMonitor: Initialization failed with error code:" << static_cast<int>(initResult);
         }
-    } catch (const std::exception& e) {
+        else
+        {
+            m_logger.LogError() << "AliveMonitor: Initialization failed with error code:"
+                                << static_cast<int>(initResult);
+        }
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "AliveMonitor: Initialization failed due to standard exception: " << e.what() << ".\n";
         initResult = EInitCode::kGeneralError;
-    } catch (...) {
+    }
+    catch (...)
+    {
         std::cerr << "AliveMonitor: Initialization failed due to exception!\n";
         initResult = EInitCode::kGeneralError;
     }
@@ -52,8 +76,10 @@ EInitCode AliveMonitorImpl::init() noexcept {
     return initResult;
 }
 
-bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept {
-    assert(m_daemon != nullptr && "HealthMonitor: Instance is not initialized!");
+bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept
+{
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(m_daemon != nullptr,
+                                                      "HealthMonitor: Instance is not initialized!");
     return m_daemon->startCyclicExec(cancel_thread);
 }
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/BUILD
@@ -86,5 +86,6 @@ cc_library(
         ":i_health_monitor",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/logging:phm_logging",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/watchdog:watchdog_impl",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/BUILD
@@ -51,6 +51,7 @@ cc_library(
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:timers_os_clock",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/watchdog:i_device_config_factory",
         "@score_baselibs//score/flatbuffers:flatbufferscpp",
+        "@score_baselibs//score/language/futurecpp",
     ] + select({
         "@platforms//os:qnx": [],
         "@platforms//os:linux": ["//externals/acl"],

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.cpp
@@ -12,13 +12,14 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/factory/MachineConfigFactory.hpp"
 
+#include <fstream>
 #include <limits>
 #include <string_view>
-#include <fstream>
-#include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
-#include "score/mw/launch_manager/alive_monitor/config/hmcore_flatcfg_generated.h"
-#include "flatbuffers/flatbuffers.h"
 
+#include "flatbuffers/flatbuffers.h"
+#include "score/mw/launch_manager/alive_monitor/config/hmcore_flatcfg_generated.h"
+#include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
+#include <score/assert.hpp>
 
 namespace score
 {
@@ -33,7 +34,7 @@ namespace
 {
 /// @brief Prefix for all log messages
 // coverity[autosar_cpp14_a2_10_4_violation:FALSE] Empty namespace ensures uniqueness for cpp file scope
-static constexpr char const* kLogPrefix{"Factory for FlatCfg MachineConfig:"};
+static constexpr const char* kLogPrefix{"Factory for FlatCfg MachineConfig:"};
 
 /// @brief Update a field in case the provided value is not the flatbuffer default value
 /// @note In case of optional integer values in flatbuffer files, the flatbuffer API will just return 0 if the value was
@@ -50,12 +51,14 @@ void updateNonDefaultValue(std::uint16_t& f_field_r, const std::uint16_t f_value
     }
 }
 
-std::unique_ptr<char[]> read_flatbuffer_file(const std::string& f_filename_r) {
+std::unique_ptr<char[]> read_flatbuffer_file(const std::string& f_filename_r)
+{
     const std::string configFilePath = std::string("etc/") + f_filename_r.c_str();
 
     std::ifstream infile;
     infile.open(configFilePath, std::ios::binary | std::ios::in);
-    if (!infile.is_open()) {
+    if (!infile.is_open())
+    {
         return nullptr;
     }
     infile.seekg(0, std::ios::end);
@@ -68,14 +71,13 @@ std::unique_ptr<char[]> read_flatbuffer_file(const std::string& f_filename_r) {
 }
 }  // namespace
 
-MachineConfigFactory::MachineConfigFactory() noexcept(true) : watchdog::IDeviceConfigFactory()
-{
-}
+MachineConfigFactory::MachineConfigFactory() noexcept(true) : watchdog::IDeviceConfigFactory() {}
 
 bool MachineConfigFactory::init() noexcept(false)
 {
     std::unique_ptr<char[]> loadBuffer_p = read_flatbuffer_file("hmcore.bin");
-    if(!loadBuffer_p) {
+    if (!loadBuffer_p)
+    {
         logger_r.LogInfo() << kLogPrefix << "No HM Machine Configuration found. Using default configuration.";
         logConfiguration();
         return true;
@@ -116,7 +118,7 @@ void MachineConfigFactory::loadWatchdogDevices(const HMCOREFlatBuffer::HMCOREEcu
     {
         watchdog::DeviceConfig config{};
 
-        assert(wdg->maxTimeout() <= std::numeric_limits<std::uint16_t>::max());
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(wdg->maxTimeout() <= std::numeric_limits<std::uint16_t>::max());
         // coverity[autosar_cpp14_a4_7_1_violation] SDG definitions guarantee uint16 boundaries
         config.timeoutMax = static_cast<std::uint16_t>(wdg->maxTimeout());
 
@@ -161,8 +163,8 @@ void MachineConfigFactory::loadHmSettings(const HMCOREFlatBuffer::HMCOREEcuCfg& 
     }
 }
 
-std::optional<watchdog::IDeviceConfigFactory::DeviceConfigurations>
-MachineConfigFactory::getDeviceConfigurations() const
+std::optional<watchdog::IDeviceConfigFactory::DeviceConfigurations> MachineConfigFactory::getDeviceConfigurations()
+    const
 {
     return watchdogConfigs;
 }
@@ -180,7 +182,8 @@ const MachineConfigFactory::SupervisionBufferConfig& MachineConfigFactory::getSu
 
 void MachineConfigFactory::logConfiguration() noexcept(true)
 {
-    /* RULECHECKER_comment(0, 18, check_conditional_as_sub_expression, "Ternary operation is very simple", true_no_defect) */
+    /* RULECHECKER_comment(0, 18, check_conditional_as_sub_expression, "Ternary operation is very simple",
+     * true_no_defect) */
     logger_r.LogDebug() << kLogPrefix << "Alive Supervision buffer size:" << supBufferCfg.bufferSizeAliveSupervision;
     logger_r.LogDebug() << kLogPrefix << "Monitor buffer size:" << supBufferCfg.bufferSizeMonitor;
     logger_r.LogDebug() << kLogPrefix << "Periodicity:" << getCycleTimeInNs() << "ns";
@@ -195,7 +198,8 @@ void MachineConfigFactory::logConfiguration() noexcept(true)
         logger_r.LogDebug() << kLogPrefix << "Watchdog" << wdgCount << "- needs magic close:" << wdgMagicCloseBool;
         logger_r.LogDebug() << kLogPrefix << "Watchdog" << wdgCount
                             << "- deactivate on hm shutdown:" << wdgDeactivatedBool;
-        // coverity[autosar_cpp14_a4_7_1_violation] Value limited by amount of watchdog configurations, which is smaller.
+        // coverity[autosar_cpp14_a4_7_1_violation] Value limited by amount of watchdog configurations, which is
+        // smaller.
         ++wdgCount;
     }
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
@@ -13,7 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 
-#include <cassert>
+#include <score/assert.hpp>
 #include <string_view>
 
 #include "score/mw/launch_manager/alive_monitor/details/common/Types.hpp"
@@ -43,12 +43,14 @@ Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
       timeSortingUpdateEventBuffer(common::TimeSortingBuffer<TimeSortedUpdateEvent>(f_aliveCfg_r.checkpointBufferSize))
 {
     f_aliveCfg_r.checkpoint_r.attachObserver(*this);
-    assert((k_aliveReferenceCycle != 0U) && "k_aliveReferenceCycle=0 causes infinite loop during evaluation.");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
+        (k_aliveReferenceCycle != 0U), "k_aliveReferenceCycle=0 causes infinite loop during evaluation.");
 
-    assert((aliveStatus == EStatus::kDeactivated) &&
-           ("Alive Supervision must start in deactivated state, see SWS_PHM_00204"));
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
+        (aliveStatus == EStatus::kDeactivated), "Alive Supervision must start in deactivated state, see SWS_PHM_00204");
 
-    assert((recoveryClient_p != nullptr) && "Recovery client must be provided");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE((recoveryClient_p != nullptr),
+                                                      "Recovery client must be provided");
 }
 
 // coverity[exn_spec_violation:FALSE] std::length_error is not thrown from push() which uses fixed-size-vector
@@ -78,10 +80,9 @@ void Alive::updateData(const ifexm::ProcessState& f_observable_r) noexcept(true)
 {
     const ifexm::ProcessState::EProcState state{f_observable_r.getState()};
 
-    const bool isRelevant =
-        (state == ifexm::ProcessState::EProcState::running) ||
-        (state == ifexm::ProcessState::EProcState::sigterm) ||
-        (state == ifexm::ProcessState::EProcState::off);
+    const bool isRelevant = (state == ifexm::ProcessState::EProcState::running) ||
+                            (state == ifexm::ProcessState::EProcState::sigterm) ||
+                            (state == ifexm::ProcessState::EProcState::off);
 
     if (isRelevant)
     {
@@ -122,8 +123,9 @@ void Alive::evaluate(const timers::NanoSecondType f_syncTimestamp)
     while (sortedUpdateEvent_p != nullptr)
     {
         timers::NanoSecondType timestampOfUpdateEvent{getTimestampOfUpdateEvent(*sortedUpdateEvent_p)};
-        assert((timestampOfUpdateEvent <= f_syncTimestamp) &&
-               "Alive supervision: Checkpoint events are reported beyond syncTimestamp.");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            (timestampOfUpdateEvent <= f_syncTimestamp),
+            "Alive supervision: Checkpoint events are reported beyond syncTimestamp.");
 
         // Check if evaluation is to be triggered before processing current sorted update event
         const bool isEvaluationEvent{detectEvaluationEvent(timestampOfUpdateEvent, *sortedUpdateEvent_p)};
@@ -290,7 +292,7 @@ Alive::EUpdateEventType Alive::getAliveEventType(bool f_isEvaluationEvent,
     }
 
     // SyncSnapshot
-    assert(std::holds_alternative<SyncSnapshot>(f_updateEvent));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(std::holds_alternative<SyncSnapshot>(f_updateEvent));
     return EUpdateEventType::kSync;
 }
 
@@ -489,7 +491,7 @@ void Alive::switchToExpired(Alive::EReason reason) noexcept(true)
                                         << ") switched to EXPIRED, due to buffer overflow.";
                     break;
                 default:
-                    assert(dataLossReason != EDataLossReason::kNoDataLoss);
+                    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(dataLossReason != EDataLossReason::kNoDataLoss);
                     logger_r.LogError() << "Alive Supervision (" << getConfigName()
                                         << ") switched to EXPIRED, due to unknown data loss case.";
                     break;
@@ -593,7 +595,7 @@ timers::NanoSecondType Alive::getTimestampOfUpdateEvent(const TimeSortedUpdateEv
     }
     else
     {
-        assert(std::holds_alternative<SyncSnapshot>(f_updateEvent));
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(std::holds_alternative<SyncSnapshot>(f_updateEvent));
         // coverity[cert_exp34_c_violation] SyncSnapshot type is stored also check assert above
         // coverity[dereference] SyncSnapshot type is stored also check assert above
         timestamp = std::get<SyncSnapshot>(f_updateEvent);

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "//score/launch_manager/src/daemon/src/alive_monitor/details/logging:phm_logging",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:timers_os_clock",
         "//score/launch_manager/src/daemon/src/recovery_client",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/BUILD
@@ -44,6 +44,7 @@ cc_library(
     include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog",
     visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
+    deps = ["@score_baselibs//score/language/futurecpp"],
 )
 
 cc_library(
@@ -60,5 +61,6 @@ cc_library(
         ":watchdog",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/logging:phm_logging",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:os_clock_interface",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/DeviceIf.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/DeviceIf.cpp
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <cassert>
+#include <score/assert.hpp>
 
 namespace score
 {
@@ -42,11 +42,11 @@ std::int64_t DeviceIf::write(std::int32_t f_fd, const char* const f_buf_p, size_
 std::int32_t DeviceIf::open(const char* f_pathname_p, std::int32_t f_flags) noexcept
 {
     // O_CREAT and O_TMPFILE flags are not supported (additional mode argument required).
-    assert((f_flags & O_CREAT) == 0);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD((f_flags & O_CREAT) == 0);
 
     // qnx has no O_TMPFILE flag
 #if defined(__linux__)
-    assert((f_flags & O_TMPFILE) == 0);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD((f_flags & O_TMPFILE) == 0);
 #endif
 
     return ::open(f_pathname_p, f_flags);

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/WatchdogImpl.cpp
@@ -12,8 +12,8 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/watchdog/WatchdogImpl.hpp"
 
-#include <cassert>
 #include <fcntl.h>
+#include <score/assert.hpp>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -44,20 +44,21 @@ template <typename T>
 // coverity[autosar_cpp14_a2_10_4_violation] There is no static definition within the same namespace or no namespace.
 T secToMs(const T f_timeout)
 {
-    assert(f_timeout < std::numeric_limits<T>::max() / 1000);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(f_timeout < std::numeric_limits<T>::max() / 1000);
     // coverity[autosar_cpp14_a4_7_1_violation] Watchdog device implementations have a limit in second range.
     return f_timeout * 1000 /*ms per seconds*/;
 }
 #endif
 }  // namespace
 
-/* RULECHECKER_comment(0:0,3:0, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const ref",true_no_defect) */
+/* RULECHECKER_comment(0:0,3:0, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const
+ * ref",true_no_defect) */
 /* RULECHECKER_comment(0:0,9:0, check_min_instructions, "Constructor with empty body is valid", true_no_defect) */
-WatchdogImpl::WatchdogImpl() noexcept :
-    IWatchdogIf(),
-    watchdogDevices(),
-    state(ELibState::idle),
-    logger_r(logging::PhmLogger::getLogger(logging::PhmLogger::EContext::watchdog))
+WatchdogImpl::WatchdogImpl() noexcept
+    : IWatchdogIf(),
+      watchdogDevices(),
+      state(ELibState::idle),
+      logger_r(logging::PhmLogger::getLogger(logging::PhmLogger::EContext::watchdog))
 {
 }
 
@@ -165,12 +166,16 @@ void WatchdogImpl::serviceWatchdog() noexcept
         if (watchdogDevice.fileDescriptor >= 0)
         {
             // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
-            /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
-            /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-            /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-            /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
-            (void)DeviceIf::ioctl(watchdogDevice.fileDescriptor,
-                                  static_cast<DeviceIf::IoctlRequestType>(WDIOC_KEEPALIVE), nullptr);
+            /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
+             * true_no_defect) */
+            /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
+             * true_no_defect) */
+            /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+             * true_no_defect) */
+            /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+             * interface", true_no_defect) */
+            (void)DeviceIf::ioctl(
+                watchdogDevice.fileDescriptor, static_cast<DeviceIf::IoctlRequestType>(WDIOC_KEEPALIVE), nullptr);
         }
     }
 }
@@ -202,10 +207,13 @@ void WatchdogImpl::fireWatchdogReaction() noexcept
 bool WatchdogImpl::setEnableCardOption(std::int32_t f_fd) noexcept
 {
     std::int32_t options{WDIOS_ENABLECARD};
-    /* RULECHECKER_comment(1:0,4:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,4:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect)
+     */
     /* RULECHECKER_comment(1:0,3:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,2:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,1:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_plain_char_operator, "Linux-only constant from external interface",
+     * true_no_defect) */
+    /* RULECHECKER_comment(1:0,1:0, check_underlying_signedness_conversion, "Linux-only constant from external
+     * interface", true_no_defect) */
     std::int32_t result{DeviceIf::ioctl(f_fd, static_cast<DeviceIf::IoctlRequestType>(WDIOC_SETOPTIONS), &options)};
     return (result >= 0);
 }
@@ -214,10 +222,13 @@ std::int32_t WatchdogImpl::getConfiguredTimeout(std::int32_t& f_configuredTimeou
 {
     f_configuredTimeout_r = -1;
 
-    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect)
+     */
     /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+     * true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+     * interface", true_no_defect) */
     std::int32_t result{
         DeviceIf::ioctl(f_fd, static_cast<DeviceIf::IoctlRequestType>(WDIOC_GETTIMEOUT), &f_configuredTimeout_r)};
     if (result < 0)
@@ -235,10 +246,13 @@ std::int32_t WatchdogImpl::getConfiguredTimeout(std::int32_t& f_configuredTimeou
 std::int32_t WatchdogImpl::getRemainingTime(std::int32_t& f_remainingTime_r, std::int32_t f_fd) noexcept
 {
     f_remainingTime_r = -1;
-    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect)
+     */
     /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+     * true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+     * interface", true_no_defect) */
     std::int32_t result{
         DeviceIf::ioctl(f_fd, static_cast<DeviceIf::IoctlRequestType>(WDIOC_GETTIMELEFT), &f_remainingTime_r)};
     if (result < 0)
@@ -257,10 +271,13 @@ bool WatchdogImpl::setTimeout(std::int32_t f_fd, std::uint16_t f_timeoutInMs) co
 #ifndef __QNXNTO__
     std::int32_t timeout{static_cast<std::int32_t>(msToSec(f_timeoutInMs))};
     std::int32_t timeoutBefore{timeout};
-    /* RULECHECKER_comment(1:0,4:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,4:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect)
+     */
     /* RULECHECKER_comment(1:0,3:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,2:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,1:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_plain_char_operator, "Linux-only constant from external interface",
+     * true_no_defect) */
+    /* RULECHECKER_comment(1:0,1:0, check_underlying_signedness_conversion, "Linux-only constant from external
+     * interface", true_no_defect) */
     std::int32_t result{DeviceIf::ioctl(f_fd, static_cast<DeviceIf::IoctlRequestType>(WDIOC_SETTIMEOUT), &timeout)};
     timeout = secToMs(timeout);
     timeoutBefore = secToMs(timeoutBefore);
@@ -283,7 +300,7 @@ bool WatchdogImpl::setTimeout(std::int32_t f_fd, std::uint16_t f_timeoutInMs) co
 
 bool WatchdogImpl::enableDevice(WatchdogDevice& f_state_r) const noexcept
 {
-    assert(f_state_r.fileDescriptor == -1);  // this should always be true
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(f_state_r.fileDescriptor == -1);  // this should always be true
     f_state_r.fileDescriptor = DeviceIf::open(f_state_r.config.fileName.c_str(), O_WRONLY);
     bool isSuccess{true};
 
@@ -383,12 +400,15 @@ bool WatchdogImpl::disableDevice(WatchdogDevice& f_watchdogDevice_r) noexcept
         (void)DeviceIf::write(f_watchdogDevice_r.fileDescriptor, kMagicCloseChar, static_cast<size_t>(2));
     }
     std::int32_t option{WDIOS_DISABLECARD};
-    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect) */
+    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface", true_no_defect)
+     */
     /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface", true_no_defect) */
-    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external interface", true_no_defect) */
-    (void)DeviceIf::ioctl(f_watchdogDevice_r.fileDescriptor, static_cast<DeviceIf::IoctlRequestType>(WDIOC_SETOPTIONS),
-                          &option);
+    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+     * true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+     * interface", true_no_defect) */
+    (void)DeviceIf::ioctl(
+        f_watchdogDevice_r.fileDescriptor, static_cast<DeviceIf::IoctlRequestType>(WDIOC_SETOPTIONS), &option);
     (void)DeviceIf::close(f_watchdogDevice_r.fileDescriptor);
     f_watchdogDevice_r.fileDescriptor = -1;
     return true;
@@ -447,10 +467,11 @@ bool WatchdogImpl::validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, co
 
 #if defined(__CTC__) && defined(__CODE_COVERAGE_ANNOTATION__)
 /* RULECHECKER_comment(1:0,2:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
-#    pragma CTC ANNOTATION This function cannot be covered in tests as it implements an infinite loop.
-#    pragma CTC SKIP
+#pragma CTC ANNOTATION This function cannot be covered in tests as it implements an infinite loop.
+#pragma CTC SKIP
 #endif
-/* RULECHECKER_comment(1:0,1:0, check_member_function_missing_static, "Intentionally not static for testing", true_no_defect) */
+/* RULECHECKER_comment(1:0,1:0, check_member_function_missing_static, "Intentionally not static for testing",
+ * true_no_defect) */
 void WatchdogImpl::waitForever() const noexcept
 {
     // This code cannot be covered in tests, as it blocks execution forever
@@ -465,7 +486,7 @@ void WatchdogImpl::waitForever() const noexcept
 }
 #if defined(__CTC__) && defined(__CODE_COVERAGE_ANNOTATION__)
 /* RULECHECKER_comment(1:0,1:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
-#    pragma CTC ENDSKIP
+#pragma CTC ENDSKIP
 #endif
 }  // namespace watchdog
 }  // namespace saf

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/watchdog/WatchdogImpl.hpp
@@ -11,18 +11,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-
 #ifndef WATCHDOGIMPL_HPP_INCLUDED
 #define WATCHDOGIMPL_HPP_INCLUDED
 
 #include <cstdint>
 #include <memory>
-#include <cassert>
 
-#include <vector>
 #include "score/mw/launch_manager/alive_monitor/details/logging/PhmLogger.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/watchdog/IDeviceConfigFactory.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/watchdog/IWatchdogIf.hpp"
+#include <vector>
 
 namespace score
 {
@@ -35,13 +33,13 @@ namespace watchdog
 {
 
 // coverity[autosar_cpp14_m3_4_1_violation] block scope definition is intentionally avoided for maintainability
-constexpr char const* kMagicCloseChar{"V"};
+constexpr const char* kMagicCloseChar{"V"};
 
 /// @brief Simple Watchdog implementation
 /// @note As of now only supports simple watchdogs and no window watchdogs.
 class WatchdogImpl : public IWatchdogIf
 {
-public:
+  public:
     /// @brief Default Constructor
     explicit WatchdogImpl() noexcept;
 
@@ -77,15 +75,17 @@ public:
     /// @todo Decide if we want to use one of the predefined errors to trigger watchdog: E.g. WDIOF_OVERHEAT
     void fireWatchdogReaction() noexcept override;
 
-protected:
+  protected:
     /// @brief Waits forever
     /// This is the intended behavior after firing the watchdog.
     /// @note This function is intentionally virtual so we can overwrite it in tests
     virtual void waitForever() const noexcept;
 
-private:
-    /* RULECHECKER_comment(1:0,15:0, check_non_pod_struct, "We want to treat it as POD as alternative implementation would increase complexity", true_no_defect) */
-    /* RULECHECKER_comment(1:0,15:0, check_non_private_non_pod_field, "We want to treat it as POD as alternative implementation would increase complexity", true_no_defect) */
+  private:
+    /* RULECHECKER_comment(1:0,15:0, check_non_pod_struct, "We want to treat it as POD as alternative implementation
+     * would increase complexity", true_no_defect) */
+    /* RULECHECKER_comment(1:0,15:0, check_non_private_non_pod_field, "We want to treat it as POD as alternative
+     * implementation would increase complexity", true_no_defect) */
 
     /// @brief The watchdog device state.
     struct WatchdogDevice

--- a/score/launch_manager/src/daemon/src/configuration/BUILD
+++ b/score/launch_manager/src/daemon/src/configuration/BUILD
@@ -32,6 +32,7 @@ cc_library(
     include_prefix = "score/mw/launch_manager/configuration",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/configuration",
     visibility = ["//score:__subpackages__"],
+    deps = ["@score_baselibs//score/language/futurecpp"],
 )
 
 cc_test(
@@ -69,6 +70,7 @@ cc_library(
         ":config_loader",
         "//score/launch_manager/src/daemon/src/common:log",
         "@score_baselibs//score/flatbuffers:flatbufferscpp",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )
 
@@ -88,6 +90,7 @@ cc_library(
         "//score/launch_manager/src/daemon/src/common:log",
         "@score_baselibs//score/flatbuffers:flatbufferscpp",
         "@score_baselibs//score/flatbuffers:flatbufferutils",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )
 

--- a/score/launch_manager/src/daemon/src/configuration/details/config.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config.cpp
@@ -12,7 +12,7 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/configuration/config.hpp"
 
-#include <cassert>
+#include <score/assert.hpp>
 
 #include <utility>
 
@@ -24,7 +24,7 @@ namespace score::mw::launch_manager::configuration
 EnvironmentVariable::EnvironmentVariable(std::string_view key, std::string_view value)
     : entry_{std::string{key} + "=" + std::string{value}}, key_length_{key.size()}
 {
-    assert(!key.empty() && "Environment variable key must not be empty");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(!key.empty(), "Environment variable key must not be empty");
 }
 
 std::string_view EnvironmentVariable::key() const
@@ -44,8 +44,7 @@ const char* EnvironmentVariable::c_str() const
 
 // --- Environment ---
 
-Environment::Environment(Environment&& other) noexcept
-    : entries_{std::move(other.entries_)}
+Environment::Environment(Environment&& other) noexcept : entries_{std::move(other.entries_)}
 {
     rebuildPointers();
 }

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
@@ -20,7 +20,7 @@
 
 #include "score/mw/launch_manager/common/log.hpp"
 
-#include <cassert>
+#include <score/assert.hpp>
 #include <cstdint>
 #include <vector>
 
@@ -55,8 +55,7 @@ std::optional<IConfigLoader::Error> validateSchemaVersion(const fb::LaunchManage
     if (*config->schema_version() != FlatbufferConfigLoader::kExpectedSchemaVersion)
     {
         LM_LOG_ERROR() << "LaunchManagerConfig::schema_version " << *config->schema_version()
-                       << " does not match the supported version "
-                       << FlatbufferConfigLoader::kExpectedSchemaVersion;
+                       << " does not match the supported version " << FlatbufferConfigLoader::kExpectedSchemaVersion;
         return IConfigLoader::Error::UnsupportedVersion;
     }
     return std::nullopt;
@@ -83,9 +82,14 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
 
     ConfigBuilder builder;
 
-    assert(config->initial_run_target() && "LaunchManagerConfig::initial_run_target must never be nullptr as it is required in the schema");
-    assert(config->components() && "LaunchManagerConfig::components must never be nullptr as it is required in the schema");
-    assert(config->run_targets() && "LaunchManagerConfig::run_targets must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        config->initial_run_target(),
+        "LaunchManagerConfig::initial_run_target must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        config->components(), "LaunchManagerConfig::components must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        config->run_targets(),
+        "LaunchManagerConfig::run_targets must never be nullptr as it is required in the schema");
     builder.setInitialRunTarget(config->initial_run_target()->str());
 
     // Convert components
@@ -105,7 +109,9 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
     builder.setRunTargets(std::move(*run_targets));
 
     // Convert fallback run target
-    assert(config->fallback_run_target() && "LaunchManagerConfig::fallback_run_target must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        config->fallback_run_target(),
+        "LaunchManagerConfig::fallback_run_target must never be nullptr as it is required in the schema");
     auto fallback = convertFallbackRunTarget(config->fallback_run_target());
     if (!fallback.has_value())
     {
@@ -115,7 +121,9 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
     builder.setFallbackRunTarget(std::move(*fallback));
 
     // Convert alive supervision
-    assert(config->alive_supervision() && "LaunchManagerConfig::alive_supervision must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        config->alive_supervision(),
+        "LaunchManagerConfig::alive_supervision must never be nullptr as it is required in the schema");
     auto alive_sup = convertAliveSupervision(config->alive_supervision());
     if (!alive_sup.has_value())
     {

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
@@ -17,12 +17,12 @@
 
 #include "score/mw/launch_manager/common/log.hpp"
 
-#include <cassert>
+#include <sched.h>
+#include <score/assert.hpp>
+#include <sys/types.h>
 #include <cstdint>
 #include <limits>
-#include <sched.h>
 #include <string>
-#include <sys/types.h>
 #include <vector>
 
 namespace score::mw::launch_manager::configuration
@@ -34,9 +34,8 @@ namespace
 {
 
 template <typename T>
-score::cpp::expected<T, IConfigLoader::Error> requireScalarValue(
-    const ::flatbuffers::Optional<T>& field,
-    const char* field_name)
+score::cpp::expected<T, IConfigLoader::Error> requireScalarValue(const ::flatbuffers::Optional<T>& field,
+                                                                 const char* field_name)
 {
     if (!field.has_value())
     {
@@ -175,8 +174,10 @@ Environment convertEnvironmentalVariables(
         {
             if (ev != nullptr)
             {
-                assert(ev->key() && "EnvironmentalVariable::key must never be nullptr as it is required in the schema");
-                assert(ev->value() && "EnvironmentalVariable::value must never be nullptr as it is required in the schema");
+                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+                    ev->key(), "EnvironmentalVariable::key must never be nullptr as it is required in the schema");
+                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+                    ev->value(), "EnvironmentalVariable::value must never be nullptr as it is required in the schema");
                 result.add(ev->key()->str(), ev->value()->str());
             }
         }
@@ -216,13 +217,15 @@ std::optional<SwitchRunTargetAction> convertSwitchRunTargetAction(const fb::Swit
     {
         return std::nullopt;
     }
-    assert(sa->run_target() && "SwitchRunTargetAction::run_target must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        sa->run_target(), "SwitchRunTargetAction::run_target must never be nullptr as it is required in the schema");
     return SwitchRunTargetAction{sa->run_target()->str()};
 }
 
 SwitchRunTargetAction convertRequiredSwitchRunTargetAction(const fb::SwitchRunTargetAction* sa)
 {
-    assert(sa && "SwitchRunTargetAction must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        sa, "SwitchRunTargetAction must never be nullptr as it is required in the schema");
     return convertSwitchRunTargetAction(sa).value();
 }
 
@@ -232,12 +235,14 @@ score::cpp::expected<ComponentAliveSupervision, IConfigLoader::Error> convertCom
     ComponentAliveSupervision result{};
     if (fb_cas != nullptr)
     {
-        auto reporting_cycle = requireScalarValue(fb_cas->reporting_cycle(), "ComponentAliveSupervision::reporting_cycle");
+        auto reporting_cycle =
+            requireScalarValue(fb_cas->reporting_cycle(), "ComponentAliveSupervision::reporting_cycle");
         if (!reporting_cycle.has_value())
         {
             return score::cpp::make_unexpected(reporting_cycle.error());
         }
-        auto failed_cycles_tolerance = requireScalarValue(fb_cas->failed_cycles_tolerance(), "ComponentAliveSupervision::failed_cycles_tolerance");
+        auto failed_cycles_tolerance =
+            requireScalarValue(fb_cas->failed_cycles_tolerance(), "ComponentAliveSupervision::failed_cycles_tolerance");
         if (!failed_cycles_tolerance.has_value())
         {
             return score::cpp::make_unexpected(failed_cycles_tolerance.error());
@@ -255,7 +260,8 @@ score::cpp::expected<ComponentAliveSupervision, IConfigLoader::Error> convertCom
 
         if (!result.min_indications.has_value() && !result.max_indications.has_value())
         {
-            LM_LOG_ERROR() << "ComponentAliveSupervision requires at least one of min_indications or max_indications to be set";
+            LM_LOG_ERROR()
+                << "ComponentAliveSupervision requires at least one of min_indications or max_indications to be set";
             return score::cpp::make_unexpected(IConfigLoader::Error::InvalidFormat);
         }
     }
@@ -273,7 +279,8 @@ score::cpp::expected<ApplicationProfile, IConfigLoader::Error> convertApplicatio
         {
             return score::cpp::make_unexpected(application_type.error());
         }
-        auto is_self_terminating = requireScalarValue(fb_ap->is_self_terminating(), "ApplicationProfile::is_self_terminating");
+        auto is_self_terminating =
+            requireScalarValue(fb_ap->is_self_terminating(), "ApplicationProfile::is_self_terminating");
         if (!is_self_terminating.has_value())
         {
             return score::cpp::make_unexpected(is_self_terminating.error());
@@ -314,8 +321,12 @@ score::cpp::expected<ComponentProperties, IConfigLoader::Error> convertComponent
     ComponentProperties result{};
     if (fb_cp != nullptr)
     {
-        assert(fb_cp->binary_name() && "ComponentProperties::binary_name must never be nullptr as it is required in the schema");
-        assert(fb_cp->application_profile() && "ComponentProperties::application_profile must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_cp->binary_name(),
+            "ComponentProperties::binary_name must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_cp->application_profile(),
+            "ComponentProperties::application_profile must never be nullptr as it is required in the schema");
         result.binary_name = fb_cp->binary_name()->str();
         auto app_profile = convertApplicationProfile(fb_cp->application_profile());
         if (!app_profile.has_value())
@@ -340,7 +351,7 @@ score::cpp::expected<ComponentProperties, IConfigLoader::Error> convertComponent
 
 score::cpp::expected<Sandbox, IConfigLoader::Error> convertSandbox(const fb::Sandbox* fb_sb)
 {
-    assert(fb_sb && "Sandbox must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(fb_sb, "Sandbox must never be nullptr as it is required in the schema");
     auto fb_uid = requireScalarValue(fb_sb->uid(), "Sandbox::uid");
     if (!fb_uid.has_value())
     {
@@ -400,9 +411,13 @@ score::cpp::expected<DeploymentConfig, IConfigLoader::Error> convertDeploymentCo
     DeploymentConfig result{};
     if (fb_dc != nullptr)
     {
-        assert(fb_dc->bin_dir() && "DeploymentConfig::bin_dir must never be nullptr as it is required in the schema");
-        assert(fb_dc->working_dir() && "DeploymentConfig::working_dir must never be nullptr as it is required in the schema");
-        assert(fb_dc->sandbox() && "DeploymentConfig::sandbox must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_dc->bin_dir(), "DeploymentConfig::bin_dir must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_dc->working_dir(),
+            "DeploymentConfig::working_dir must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_dc->sandbox(), "DeploymentConfig::sandbox must never be nullptr as it is required in the schema");
         auto ready_timeout = requireScalarValue(fb_dc->ready_timeout(), "DeploymentConfig::ready_timeout");
         if (!ready_timeout.has_value())
         {
@@ -452,9 +467,14 @@ score::cpp::expected<ComponentConfig, IConfigLoader::Error> convertComponent(con
     ComponentConfig result{};
     if (fb_comp != nullptr)
     {
-        assert(fb_comp->name() && "Component::name must never be nullptr as it is required in the schema");
-        assert(fb_comp->component_properties() && "Component::component_properties must never be nullptr as it is required in the schema");
-        assert(fb_comp->deployment_config() && "Component::deployment_config must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_comp->name(), "Component::name must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_comp->component_properties(),
+            "Component::component_properties must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_comp->deployment_config(),
+            "Component::deployment_config must never be nullptr as it is required in the schema");
         result.name = fb_comp->name()->str();
         result.description = safeString(fb_comp->description());
         auto component_properties = convertComponentProperties(fb_comp->component_properties());
@@ -480,8 +500,11 @@ score::cpp::expected<RunTargetConfig, IConfigLoader::Error> convertRunTarget(con
     RunTargetConfig result{};
     if (fb_rt != nullptr)
     {
-        assert(fb_rt->name() && "RunTarget::name must never be nullptr as it is required in the schema");
-        assert(fb_rt->recovery_action() && "RunTarget::recovery_action must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_rt->name(), "RunTarget::name must never be nullptr as it is required in the schema");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            fb_rt->recovery_action(),
+            "RunTarget::recovery_action must never be nullptr as it is required in the schema");
         auto transition_timeout = requireScalarValue(fb_rt->transition_timeout(), "RunTarget::transition_timeout");
         if (!transition_timeout.has_value())
         {
@@ -508,7 +531,8 @@ score::cpp::expected<FallbackRunTargetConfig, IConfigLoader::Error> convertFallb
     FallbackRunTargetConfig result{};
     if (fb_frt != nullptr)
     {
-        auto transition_timeout = requireScalarValue(fb_frt->transition_timeout(), "FallbackRunTarget::transition_timeout");
+        auto transition_timeout =
+            requireScalarValue(fb_frt->transition_timeout(), "FallbackRunTarget::transition_timeout");
         if (!transition_timeout.has_value())
         {
             return score::cpp::make_unexpected(transition_timeout.error());
@@ -553,13 +577,15 @@ score::cpp::expected<std::optional<WatchdogConfig>, IConfigLoader::Error> conver
     {
         return std::optional<WatchdogConfig>{std::nullopt};
     }
-    assert(fb_wd->device_file_path() && "Watchdog::device_file_path must never be nullptr as it is required in the schema");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        fb_wd->device_file_path(), "Watchdog::device_file_path must never be nullptr as it is required in the schema");
     auto max_timeout = requireScalarValue(fb_wd->max_timeout(), "Watchdog::max_timeout");
     if (!max_timeout.has_value())
     {
         return score::cpp::make_unexpected(max_timeout.error());
     }
-    auto deactivate_on_shutdown = requireScalarValue(fb_wd->deactivate_on_shutdown(), "Watchdog::deactivate_on_shutdown");
+    auto deactivate_on_shutdown =
+        requireScalarValue(fb_wd->deactivate_on_shutdown(), "Watchdog::deactivate_on_shutdown");
     if (!deactivate_on_shutdown.has_value())
     {
         return score::cpp::make_unexpected(deactivate_on_shutdown.error());


### PR DESCRIPTION
Replaces all 37 plain assert() calls across 10 source files with the appropriate SCORE_LANGUAGE_FUTURECPP_* macros from score/assert.hpp, as required by project guidelines. Also adds the explicit @score_baselibs//score/language/futurecpp dep to 7 Bazel targets that now directly depend on the assert header.

Macro selection follows existing codebase convention:
- PRECONDITION[_PRD][_MESSAGE] for constructor/function-entry argument checks
- ASSERT_PRD[_MESSAGE] for mid-function invariants in the safety-critical daemon
- Default-level PRECONDITION (no PRD) for health_monitor, matching sibling files

The _PRD variants guarantee checks survive any future NDEBUG or ASSERT_LEVEL_PRODUCTION build configuration, which is appropriate for the alive_monitor daemon (AUTOSAR PHM code referencing SWS_PHM_00204).

Closes #263