### PR TITLE
Make `OsalReturnType` `nodiscard` and handle remaining warnings

### DIFF
--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -32,34 +32,40 @@ void ControlClientChannel::initialize()
 {
     request_.empty_.store(true);
     response_.empty_.store(true);
-    nudge_LM_Handler_.init(0U, true);
+
+    const auto result = nudge_LM_Handler_.init(0U, true);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore init failed");
+
     initial_result_count_ = 0U;
+
     LM_LOG_DEBUG() << "ControlClientChannel initialized";
 }
 
 void ControlClientChannel::deinitialize()
 {
-    nudge_LM_Handler_.deinit();
+    const auto result = nudge_LM_Handler_.deinit();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore deinit failed");
 }
 
 bool ControlClientChannel::sendResponse(ControlClientMessage& msg)
 {
-    bool result = false;
-
-    if (response_.empty_)
-    {
-        response_.msg_ = msg;
-        response_.empty_ = false;
-        nudge_LM_Handler_.post();
-        result = true;
-        LM_LOG_DEBUG() << "Response sent.";
-    }
-    else
+    if (!response_.empty_)
     {
         LM_LOG_DEBUG() << "Failed to send response: response is not empty.";
+        return false;
     }
 
-    return result;
+    response_.msg_ = msg;
+    response_.empty_ = false;
+
+    const auto result = nudge_LM_Handler_.post();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore post failed");
+
+    LM_LOG_DEBUG() << "Response sent.";
+    return true;
 }
 
 bool ControlClientChannel::getResponse(ControlClientMessage& msg)
@@ -92,13 +98,18 @@ void ControlClientChannel::sendRequest(ControlClientMessage& msg)
     {
         LM_LOG_DEBUG() << "Request sent. Waiting for acknowledgment...";
         auto* semaphore = static_cast<osal::Semaphore*>(nudgeLM);
+
         // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if statement.
-        semaphore->post();  // Post the semaphore
+        const auto result = semaphore->post();
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                                "ControlClientChannel semaphore post failed");
 
         munmap(nudgeLM, sizeof(osal::Semaphore));  // Unmap the semaphore
     }
 
-    nudge_LM_Handler_.wait();
+    const auto result = nudge_LM_Handler_.wait();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore wait failed");
 
     // Wait for acknowledgment
     while (!request_.empty_)
@@ -122,8 +133,12 @@ ControlClientMessage& ControlClientChannel::request()
 
 void ControlClientChannel::acknowledgeRequest()
 {
-    nudge_LM_Handler_.post();
+    const auto result = nudge_LM_Handler_.post();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore post failed");
+
     request_.empty_ = true;
+
     LM_LOG_DEBUG() << "Request acknowledged.";
 }
 
@@ -223,14 +238,19 @@ void ControlClientChannel::nudgeControlClientHandler()
 {
     if (nudgeControlClientHandler_)
     {
-        nudgeControlClientHandler_->post();
+        const auto result = nudgeControlClientHandler_->post();
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                                "ControlClientChannel semaphore post failed");
+
         LM_LOG_DEBUG() << "Control Client handler nudged";
     }
 }
 
 void ControlClientChannel::nudgeLMHandler()
 {
-    nudge_LM_Handler_.post();
+    const auto result = nudge_LM_Handler_.post();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(result == osal::OsalReturnType::kSuccess,
+                                            "ControlClientChannel semaphore post failed");
 }
 
 void ControlClientChannel::releaseParentMapping()

--- a/score/launch_manager/src/daemon/src/osal/return_types.hpp
+++ b/score/launch_manager/src/daemon/src/osal/return_types.hpp
@@ -48,7 +48,7 @@ enum class CommsType : std::uint_least8_t {
 ///@brief This enum class likely represents the return status or outcome of an operating system abstraction layer (OSAL)
 /// function or operation and also it provides a clear way to convey success or failure status for OSAL-related operations in a codebase.
 
-enum class OsalReturnType {
+ enum class [[nodiscard]] OsalReturnType {
     ///@brief Represents a successful operation. The value 0 is commonly associated with success.
 
     kSuccess = 0,

--- a/score/launch_manager/src/daemon/src/osal/semaphore.hpp
+++ b/score/launch_manager/src/daemon/src/osal/semaphore.hpp
@@ -63,7 +63,7 @@ class Semaphore final {
     /// @return An OsalReturnType indicating the result of the operation.
     ///         - `OsalReturnType::KSuccess`: The semaphore was successfully initialized.
     ///         - `OsalReturnType::KFail`: An error occurred during the initialization.
-    [[nodiscard]] OsalReturnType init(uint32_t value, bool shared);
+    OsalReturnType init(uint32_t value, bool shared);
 
     /// @brief Destroys the semaphore and releases any resources associated with it.
     /// This method uses `sem_destroy` to destroy the semaphore:
@@ -72,7 +72,7 @@ class Semaphore final {
     /// @return An OsalReturnType indicating the result of the deinitialization.
     ///         - `OsalReturnType::KSuccess`: The semaphore was successfully deinitialized.
     ///         - `OsalReturnType::KFail`: An error occurred during the deinitialization.
-    [[nodiscard]] OsalReturnType deinit();
+    OsalReturnType deinit();
 
     /// @brief Decrement the semaphore, blocking until the semaphore can be decremented or the timeout expires.
     /// This method does not use `sem_timedwait` to attempt to decrement the semaphore because that does not use a monotonic clock.
@@ -85,7 +85,7 @@ class Semaphore final {
     ///        - `OsalReturnType::KSuccess`: The semaphore was successfully decremented within the specified time.
     ///        - `OsalReturnType::KTimeout`: The semaphore was not decremented because the wait timed out.
     ///        - `OsalReturnType::KFail`: An error occurred during the wait operation (e.g., if the system clock could not be read).
-    [[nodiscard]] OsalReturnType timedWait(std::chrono::milliseconds delay);
+    OsalReturnType timedWait(std::chrono::milliseconds delay);
 
     /// @brief Increments (posts) the semaphore.
     /// This method uses `sem_post` to increment the semaphore:
@@ -96,7 +96,7 @@ class Semaphore final {
     /// @return An OsalReturnType indicating the result of the operation.
     ///        - `OsalReturnType::KSuccess`: The semaphore was successfully incremented (posted).
     ///        - `OsalReturnType::KFail`: An error occurred during the increment (post) operation.
-    [[nodiscard]] OsalReturnType post();
+    OsalReturnType post();
 
     /// @brief Decrements (waits) the semaphore.
     /// This method uses `sem_wait` to decrement the semaphore:
@@ -107,7 +107,7 @@ class Semaphore final {
     /// @return An OsalReturnType indicating the result of the operation.
     ///        - `OsalReturnType::KSuccess`: The semaphore was successfully decremented (waited).
     ///        - `OsalReturnType::KFail`: An error occurred during the decrement (wait) operation.
-    [[nodiscard]] OsalReturnType wait();
+    OsalReturnType wait();
 
    private:
     /// @brief POSIX semaphore object

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
@@ -16,9 +16,9 @@
 #include <unistd.h>
 #include <csignal>
 
+#include "score/mw/launch_manager/common/log.hpp"
 #include "score/mw/launch_manager/process_group_manager/ialive_monitor_thread.hpp"
 #include "score/mw/launch_manager/process_group_manager/process_group_manager.hpp"
-#include "score/mw/launch_manager/common/log.hpp"
 
 namespace score::lcm::internal
 {
@@ -162,7 +162,10 @@ inline bool ProcessGroupManager::initializeControlClientHandler()
                     ControlClientChannel::nudgeControlClientHandler_ = static_cast<osal::Semaphore*>(buf);
                     // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if
                     // statement.
-                    ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
+                    const auto osal_result = ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
+                    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(osal_result == OsalReturnType::kSuccess,
+                                                            "ControlClientChannel semaphore init failed");
+
                     result = true;
                 }
             }
@@ -272,7 +275,13 @@ bool ProcessGroupManager::run()
         while (!em_cancelled.load())
         {
             // Wait for something to happen...
-            ControlClientChannel::nudgeControlClientHandler_->timedWait(std::chrono::milliseconds(100));
+            const auto osal_result =
+                ControlClientChannel::nudgeControlClientHandler_->timedWait(std::chrono::milliseconds(100));
+
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+                osal_result == OsalReturnType::kSuccess || osal_result == OsalReturnType::kTimeout,
+                "ControlClientChannel semaphore wait failed");
+
             for (auto pg : process_groups_)
             {
                 controlClientHandler(*pg);
@@ -366,7 +375,8 @@ inline void ProcessGroupManager::allProcessGroupsOff()
                 osal::ProcessID pid = node->getPid();
                 if (pid > 0)
                 {
-                    process_interface_.forceTermination(pid);
+                    // forceTermination already handles errors appropriately, so we can ignore its result.
+                    static_cast<void>(process_interface_.forceTermination(pid));
                 }
             }
         }
@@ -528,8 +538,7 @@ inline void ProcessGroupManager::recoveryActionHandler()
 
         if (nullptr == pg)
         {
-            LM_LOG_ERROR() << "recoveryActionHandler: Unknown process "
-                           << *recovery_request;
+            LM_LOG_ERROR() << "recoveryActionHandler: Unknown process " << *recovery_request;
             continue;
         }
 
@@ -537,8 +546,8 @@ inline void ProcessGroupManager::recoveryActionHandler()
         const IdentifierHash recovery_state = configuration_manager_.getNameOfRecoveryState(pg->getProcessGroupName());
         const GraphState graph_state = pg->getState();
 
-        LM_LOG_DEBUG() << "recoveryActionHandler: Processing recovery request for PG "
-                       << *recovery_request << " to state " << recovery_state;
+        LM_LOG_DEBUG() << "recoveryActionHandler: Processing recovery request for PG " << *recovery_request
+                       << " to state " << recovery_state;
 
         if (GraphState::kInTransition == graph_state)
         {


### PR DESCRIPTION
Fixes #282.

Requires #292 to be merged first.