### PR TITLE
Treat warnings as errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,10 +23,15 @@ build --java_runtime_version=remotejdk_17
 build --tool_java_runtime_version=remotejdk_17
 build --credential_helper=*.qnx.com=%workspace%/scripts/internal/qnx_creds.py
 
+# Treat warnings as errors, except in external code
+build --copt=-Wall
+build --copt=-Wextra
+build --copt=-Werror
+build --per_file_copt=external/.*@-Wno-error
+
 # Common test flags for all platforms
 test --test_output=errors
 test --@score_baselibs//score/json:base_library=nlohmann
-test --cxxopt=-Wno-deprecated-declarations
 
 # Coverage configuration for C++
 coverage --features=coverage

--- a/examples/c_supervised_app/BUILD
+++ b/examples/c_supervised_app/BUILD
@@ -14,9 +14,8 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 cc_binary(
     name = "c_supervised_app",
-    srcs = [
-        "main.c",
-    ],
+    srcs = ["main.c"],
+    copts = ["-std=gnu11"],
     linkopts = select({
         "@platforms//os:qnx": [
             "-lsocket",

--- a/examples/c_supervised_app/main.c
+++ b/examples/c_supervised_app/main.c
@@ -14,7 +14,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <time.h>
 
 #include <score/mw/lifecycle/alive.h>
 #include <score/mw/lifecycle/report_running.h>
@@ -28,6 +28,11 @@ static void signal_handler(int signal)
         exit_requested = 1;
     }
 }
+
+const struct timespec interval = {
+    .tv_sec = 0,
+    .tv_nsec = 50000000,
+};
 
 int main(void)
 {
@@ -51,7 +56,7 @@ int main(void)
     while (!exit_requested)
     {
         score_lcm_alive_report_alive(alive);
-        usleep(50000);
+        nanosleep(&interval, NULL);
     }
 
     score_lcm_alive_deinitialize(alive);

--- a/examples/control_application/control_daemon.cpp
+++ b/examples/control_application/control_daemon.cpp
@@ -26,7 +26,7 @@ void signalHandler(int) {
     exitRequested = true;
 }
 
-int main(int argc, char** argv) {
+int main() {
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);
 

--- a/score/health_monitor/src/cpp/common.h
+++ b/score/health_monitor/src/cpp/common.h
@@ -98,12 +98,12 @@ class TimeRange
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION(min_ms_ <= max_ms_);
     }
 
-    const uint32_t min_ms() const
+    uint32_t min_ms() const
     {
         return min_ms_.count();
     }
 
-    const uint32_t max_ms() const
+    uint32_t max_ms() const
     {
         return max_ms_.count();
     }

--- a/score/launch_manager/src/control_client/src/control_client.cpp
+++ b/score/launch_manager/src/control_client/src/control_client.cpp
@@ -30,7 +30,9 @@ inline score::concurrency::InterruptibleFuture<void> GetErrorFuture(ExecErrc err
 }
 
 ControlClient::ControlClient() noexcept {
-    static std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback = [](const score::lcm::ExecutionErrorEvent& event) {};
+    static std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback =
+        []([[maybe_unused]] const score::lcm::ExecutionErrorEvent& event) {};
+
     try {
         control_client_impl_ = std::make_unique<ControlClientImpl>(undefinedStateCallback);
     } catch (...) {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -47,7 +47,7 @@ namespace
 {
 /// @brief Prefix for all log messages
 // coverity[autosar_cpp14_a2_10_4_violation:FALSE] Empty namespace ensures uniqueness for cpp file scope
-static constexpr const char* kLogPrefix{"Factory for FlatCfg AR24-11:"};
+static constexpr const std::string_view kLogPrefix{"Factory for FlatCfg AR24-11:"};
 
 std::unique_ptr<char[]> read_flatbuffer_file(const std::string& f_filename_r)
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.cpp
@@ -39,7 +39,7 @@ namespace
 {
 /// @brief Prefix for all log messages
 // coverity[autosar_cpp14_a2_10_4_violation:FALSE] Empty namespace ensures uniqueness for cpp file scope
-static constexpr const char* kLogPrefix{"Factory for FlatCfg MachineConfig:"};
+static constexpr const std::string_view kLogPrefix{"Factory for FlatCfg MachineConfig:"};
 
 /// @brief Update a field in case the provided value is not the flatbuffer default value
 /// @note In case of optional integer values in flatbuffer files, the flatbuffer API will just return 0 if the value was

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory_new.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory_new.cpp
@@ -33,7 +33,7 @@ using NanoSecondType = timers::NanoSecondType;
 
 namespace
 {
-static constexpr char const* kLogPrefix{"Factory for FlatCfg MachineConfig:"};
+static constexpr const std::string_view kLogPrefix{"Factory for FlatCfg MachineConfig:"};
 }  // namespace
 
 MachineConfigFactory::MachineConfigFactory() noexcept(true) : watchdog::IDeviceConfigFactory()

--- a/score/launch_manager/src/daemon/src/configuration/configuration_manager.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_manager.cpp
@@ -765,7 +765,7 @@ bool ConfigurationManager::checkOrSetFlatConfigEnvVar(const std::string& name, c
         if (setenv(name.c_str(), path.c_str(), overwrite_) == 0) {
             result = true;
         } else {
-            LM_LOG_DEBUG() << name.c_str() << "not set, so default flat config binary path loaded";
+            LM_LOG_DEBUG() << name << "not set, so default flat config binary path loaded";
         }
     }
 

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
@@ -35,7 +35,7 @@ namespace
 
 template <typename T>
 score::cpp::expected<T, IConfigLoader::Error> requireScalarValue(const ::flatbuffers::Optional<T>& field,
-                                                                 const char* field_name)
+                                                                 const std::string_view field_name)
 {
     if (!field.has_value())
     {

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
@@ -38,7 +38,7 @@ namespace details
 // --- Range validation ---
 
 template <typename TargetT>
-score::cpp::expected<TargetT, IConfigLoader::Error> validateRange(int64_t value, const char* field_name)
+score::cpp::expected<TargetT, IConfigLoader::Error> validateRange(int64_t value, const std::string_view field_name)
 {
     // Asserts ensure that std::numeric_limits<TargetT>::min() and std::numeric_limits<TargetT>::max() can be 
     // safely cast to int64_t for the range check:

--- a/score/launch_manager/src/daemon/src/process_state_client/process_state_client_ut.cpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/process_state_client_ut.cpp
@@ -58,6 +58,7 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcess_Succeeds)
         .id = score::lcm::IdentifierHash("Process1"),
         .processStateId = score::lcm::ProcessState::kRunning,
         .processGroupStateId = score::lcm::IdentifierHash("PGState1"),
+        .systemClockTimestamp = {},
     };
 
     // Queue one process
@@ -91,6 +92,7 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueMaxNumberOfProcesses_Succe
             .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
             .processStateId = score::lcm::ProcessState::kRunning,
             .processGroupStateId = score::lcm::IdentifierHash("PGState" + std::to_string(i)),
+            .systemClockTimestamp = {},
         };
         bool queued = notifier_->queuePosixProcess(process);
         ASSERT_TRUE(queued) << "Failed to queue process at index " << i;
@@ -121,6 +123,7 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcessTooMany_Fails)
         .id = score::lcm::IdentifierHash("Process1"),
         .processStateId = score::lcm::ProcessState::kRunning,
         .processGroupStateId = score::lcm::IdentifierHash("PGState1"),
+        .systemClockTimestamp = {},
     };
 
     // Fill the buffer to capacity
@@ -130,6 +133,7 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcessTooMany_Fails)
             .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
             .processStateId = score::lcm::ProcessState::kRunning,
             .processGroupStateId = score::lcm::IdentifierHash("PGState" + std::to_string(i)),
+            .systemClockTimestamp = {},
         };
         bool queued = notifier_->queuePosixProcess(proc);
         ASSERT_TRUE(queued) << "Failed to queue process at index " << i;

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -86,7 +86,7 @@ bool WatchdogImpl::init(std::int64_t f_cycleTimeInNs, const IDeviceConfigFactory
     {
         isSuccess = false;
         watchdogDevices.clear();
-        LM_LOG_ERROR() << "Watchdog: Watchdog initialization failed:" << e.what();
+        LM_LOG_ERROR() << "Watchdog: Watchdog initialization failed:" << std::string(e.what());
     }
     return isSuccess;
 }

--- a/tests/integration/complex_monitoring/component_complex_monitoring.cpp
+++ b/tests/integration/complex_monitoring/component_complex_monitoring.cpp
@@ -63,7 +63,7 @@ TEST(ComplexMonitoring, ComponentComplexMonitoring)
     // When heartbeats are no longer sent...
 }
 
-int main(int argc, char** argv)
+int main()
 {
     TestRunner(__FILE__, TerminationBehavior::kContinue).RunTests();
     // Then expect kill due to recovery action (verified by control client)

--- a/tests/integration/complex_monitoring/control_client_mock.cpp
+++ b/tests/integration/complex_monitoring/control_client_mock.cpp
@@ -49,7 +49,7 @@ TEST(ComplexMonitoring, ControlClientMock)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kWait, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/integration/crash_on_startup/control_client_mock.cpp
+++ b/tests/integration/crash_on_startup/control_client_mock.cpp
@@ -65,7 +65,7 @@ TEST(CrashOnStartup, ControlClientMock)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kWait, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/integration/process_complex_rep_failure/control_client_mock.cpp
+++ b/tests/integration/process_complex_rep_failure/control_client_mock.cpp
@@ -76,7 +76,7 @@ TEST(RecoveryActionComplexRepFailure, ControlClientMock) {
   TEST_STEP("Activate RunTarget Off") { client.ActivateRunTarget("Off"); }
 }
 
-int main(int argc, char **argv) {
+int main() {
   return TestRunner(__FILE__, TerminationBehavior::kContinue,
                     TerminationNotification::kTestEnd)
       .RunTests();

--- a/tests/integration/process_crash_monitoring/control_client_mock.cpp
+++ b/tests/integration/process_crash_monitoring/control_client_mock.cpp
@@ -64,7 +64,7 @@ TEST(ProcessCrashMonitoring, ControlClientMock)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kWait, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/integration/process_simple_rep_failure/control_client_mock.cpp
+++ b/tests/integration/process_simple_rep_failure/control_client_mock.cpp
@@ -76,7 +76,7 @@ TEST(RecoveryActionSimpleRepFailure, ControlClientMock) {
   TEST_STEP("Activate RunTarget Off") { client.ActivateRunTarget("Off"); }
 }
 
-int main(int argc, char **argv) {
+int main() {
   return TestRunner(__FILE__, TerminationBehavior::kContinue,
                     TerminationNotification::kTestEnd)
       .RunTests();

--- a/tests/integration/process_wrong_binary_failure/control_client_mock.cpp
+++ b/tests/integration/process_wrong_binary_failure/control_client_mock.cpp
@@ -46,7 +46,7 @@ TEST(MissingBinaryFailure, ControlClientMock)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kContinue, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/integration/smoke/control_daemon_mock.cpp
+++ b/tests/integration/smoke/control_daemon_mock.cpp
@@ -47,7 +47,7 @@ TEST(Smoke, Daemon)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kWait, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/integration/switch_run_target/control_client_mock.cpp
+++ b/tests/integration/switch_run_target/control_client_mock.cpp
@@ -73,7 +73,7 @@ TEST(SwitchRunTarget, ControlClientMock)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     return TestRunner(__FILE__, TerminationBehavior::kWait, TerminationNotification::kTestEnd).RunTests();
 }

--- a/tests/utils/test_helper/complex_reporting_process.cpp
+++ b/tests/utils/test_helper/complex_reporting_process.cpp
@@ -30,13 +30,13 @@ char **g_argv;
 class LifecycleApp final : public score::mw::lifecycle::Application {
 public:
   std::int32_t
-  Initialize(const score::mw::lifecycle::ApplicationContext &appCtx) override {
+  Initialize([[maybe_unused]] const score::mw::lifecycle::ApplicationContext &appCtx) override {
     optind = 1;
 
     return 0;
   }
 
-  std::int32_t Run(const score::cpp::stop_token &stopToken) override {
+  std::int32_t Run([[maybe_unused]] const score::cpp::stop_token &stopToken) override {
     return EXIT_SUCCESS;
   }
 };


### PR DESCRIPTION
This ensures that warnings are not ignored, by causing the build to fail.