### PR TITLE
Add [[nodiscard]] to OsalReturnType and fix all discarded return values

### DIFF
--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -32,14 +32,14 @@ void ControlClientChannel::initialize()
 {
     request_.empty_.store(true);
     response_.empty_.store(true);
-    nudge_LM_Handler_.init(0U, true);
+    static_cast<void>(nudge_LM_Handler_.init(0U, true));
     initial_result_count_ = 0U;
     LM_LOG_DEBUG() << "ControlClientChannel initialized";
 }
 
 void ControlClientChannel::deinitialize()
 {
-    nudge_LM_Handler_.deinit();
+    static_cast<void>(nudge_LM_Handler_.deinit());
 }
 
 bool ControlClientChannel::sendResponse(ControlClientMessage& msg)
@@ -50,7 +50,7 @@ bool ControlClientChannel::sendResponse(ControlClientMessage& msg)
     {
         response_.msg_ = msg;
         response_.empty_ = false;
-        nudge_LM_Handler_.post();
+        static_cast<void>(nudge_LM_Handler_.post());
         result = true;
         LM_LOG_DEBUG() << "Response sent.";
     }
@@ -93,12 +93,12 @@ void ControlClientChannel::sendRequest(ControlClientMessage& msg)
         LM_LOG_DEBUG() << "Request sent. Waiting for acknowledgment...";
         auto* semaphore = static_cast<osal::Semaphore*>(nudgeLM);
         // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if statement.
-        semaphore->post();  // Post the semaphore
+        static_cast<void>(semaphore->post());  // Post the semaphore
 
         munmap(nudgeLM, sizeof(osal::Semaphore));  // Unmap the semaphore
     }
 
-    nudge_LM_Handler_.wait();
+    static_cast<void>(nudge_LM_Handler_.wait());
 
     // Wait for acknowledgment
     while (!request_.empty_)
@@ -122,7 +122,7 @@ ControlClientMessage& ControlClientChannel::request()
 
 void ControlClientChannel::acknowledgeRequest()
 {
-    nudge_LM_Handler_.post();
+    static_cast<void>(nudge_LM_Handler_.post());
     request_.empty_ = true;
     LM_LOG_DEBUG() << "Request acknowledged.";
 }
@@ -223,14 +223,14 @@ void ControlClientChannel::nudgeControlClientHandler()
 {
     if (nudgeControlClientHandler_)
     {
-        nudgeControlClientHandler_->post();
+        static_cast<void>(nudgeControlClientHandler_->post());
         LM_LOG_DEBUG() << "Control Client handler nudged";
     }
 }
 
 void ControlClientChannel::nudgeLMHandler()
 {
-    nudge_LM_Handler_.post();
+    static_cast<void>(nudge_LM_Handler_.post());
 }
 
 void ControlClientChannel::releaseParentMapping()

--- a/score/launch_manager/src/daemon/src/osal/return_types.hpp
+++ b/score/launch_manager/src/daemon/src/osal/return_types.hpp
@@ -48,7 +48,7 @@ enum class CommsType : std::uint_least8_t {
 ///@brief This enum class likely represents the return status or outcome of an operating system abstraction layer (OSAL)
 /// function or operation and also it provides a clear way to convey success or failure status for OSAL-related operations in a codebase.
 
-enum class OsalReturnType {
+enum class [[nodiscard]] OsalReturnType {
     ///@brief Represents a successful operation. The value 0 is commonly associated with success.
 
     kSuccess = 0,

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
@@ -162,7 +162,7 @@ inline bool ProcessGroupManager::initializeControlClientHandler()
                     ControlClientChannel::nudgeControlClientHandler_ = static_cast<osal::Semaphore*>(buf);
                     // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if
                     // statement.
-                    ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
+                    static_cast<void>(ControlClientChannel::nudgeControlClientHandler_->init(0U, true));
                     result = true;
                 }
             }
@@ -366,7 +366,7 @@ inline void ProcessGroupManager::allProcessGroupsOff()
                 osal::ProcessID pid = node->getPid();
                 if (pid > 0)
                 {
-                    process_interface_.forceTermination(pid);
+                    static_cast<void>(process_interface_.forceTermination(pid));
                 }
             }
         }


### PR DESCRIPTION
Mark OsalReturnType as [[nodiscard]] so the compiler warns whenever a caller ignores the return value of any function returning it.

Wrap the 10 call sites that intentionally discard the result with static_cast<void>() to silence the warnings explicitly, consistent with the existing pattern in process_info_node.cpp.

Closes: #282