### PR TITLE
Register assertion handler to print failure details to stderr

### DIFF
--- a/score/launch_manager/src/daemon/BUILD
+++ b/score/launch_manager/src/daemon/BUILD
@@ -32,6 +32,7 @@ cc_binary(
         "//score/launch_manager/src/daemon/src/process_group_manager:alive_monitor_thread",
         "//score/launch_manager/src/daemon/src/process_state_client:process_state_notifier",
         "//score/launch_manager/src/daemon/src/recovery_client",
+        "@score_baselibs//score/language/futurecpp",
     ] + select({
         "//config:lm_use_new_configuration": [
             "//score/launch_manager/src/daemon/src/configuration:flatbuffer_config_loader",

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -14,6 +14,9 @@
 #include <unistd.h>
 #include <cstring>
 #include <iostream>
+#include <sstream>
+
+#include <score/assert.hpp>
 
 #include "score/mw/launch_manager/common/log.hpp"
 
@@ -158,6 +161,20 @@ int main(int argc, const char* argv[])
 int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
 {
 #endif
+    score::cpp::set_assertion_handler([](const score::cpp::handler_parameters& params) {
+        std::ostringstream msg;
+        msg << "Assertion failed: " << (params.condition != nullptr ? params.condition : "")
+            << "\n  Location: " << (params.file != nullptr ? params.file : "?") << ":" << params.line
+            << " (" << (params.function != nullptr ? params.function : "?") << ")";
+        if (params.message != nullptr)
+        {
+            msg << "\n  Message:  " << params.message;
+        }
+        msg << "\n";
+        std::cerr << msg.str();
+    });
+
+
     // reserve files descriptor osal::IpcCommsSync::sync_fd (fd3) and
     // osal::IpcCommsSync::control_client_handler_nudge_fd (fd4) for communication tpyes: kNoComms !fd3 & !fd4
     // kReporting  fd3 & !fd4


### PR DESCRIPTION
Without a registered handler, SCORE_LANGUAGE_FUTURECPP_ASSERT failures call std::abort silently, giving no indication of what failed or where.

Register a handler at daemon startup that writes the failed condition, optional message, file, line, and function to stderr before abort.

Closes: #296