### PR TITLE
Fixing missing headers build errors

### DIFF
--- a/score/launch_manager/src/alive/src/alive.cpp
+++ b/score/launch_manager/src/alive/src/alive.cpp
@@ -11,11 +11,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+#include <utility>
+
+#include <score/assert.hpp>
+
 #include "score/mw/lifecycle/alive.h"
 #include "score/mw/launch_manager/alive_monitor/details/AliveImpl.h"
 
-#include <cassert>
-#include <utility>
 
 // The public API is only sending alive notification. No need to support different checkpoints.
 static constexpr std::uint32_t kDefaultCheckpointId{1U};

--- a/score/launch_manager/src/alive/src/details/AliveImpl.h
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.h
@@ -15,7 +15,7 @@
 #define SCORE_LCM_ALIVEIMPL_H_
 
 #include <memory>
-#include <utility>
+#include <optional>
 
 #include <string>
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/DataStructures.hpp"

--- a/score/launch_manager/src/daemon/src/common/log.hpp
+++ b/score/launch_manager/src/daemon/src/common/log.hpp
@@ -180,7 +180,7 @@ class Logger
             localtime_r(&t, &now);
             stream << check_it_ << text_color_ << &now << appId_ << ctxId_ << "FATAL:   [";
         }
-        return std::move(stream);
+        return stream;
     }
 
     Stream LogError() noexcept
@@ -195,7 +195,7 @@ class Logger
             stream << check_it_ << text_color_ << &now << appId_ << ctxId_ << "ERROR:   [";
         }
 
-        return std::move(stream);
+        return stream;
     }
 
     Stream LogWarn() noexcept
@@ -209,7 +209,7 @@ class Logger
             localtime_r(&t, &now);
             stream << check_it_ << text_color_ << &now << appId_ << ctxId_ << "WARNING: [";
         }
-        return std::move(stream);
+        return stream;
     }
 
     Stream LogInfo() noexcept
@@ -223,7 +223,7 @@ class Logger
             localtime_r(&t, &now);
             stream << text_color_ << &now << appId_ << ctxId_ << "INFO:    [";
         }
-        return std::move(stream);
+        return stream;
     }
 
     Stream LogDebug() noexcept
@@ -237,7 +237,7 @@ class Logger
             localtime_r(&t, &now);
             stream << text_color_ << &now << appId_ << ctxId_ << "DEBUG:  [";
         }
-        return std::move(stream);
+        return stream;
     }
 
     Stream LogVerbose() noexcept
@@ -251,7 +251,7 @@ class Logger
             localtime_r(&t, &now);
             stream << text_color_ << &now << appId_ << ctxId_ << "VERBOSE: [";
         }
-        return std::move(stream);
+        return stream;
     }
 
   private:

--- a/score/launch_manager/src/daemon/src/control/BUILD
+++ b/score/launch_manager/src/daemon/src/control/BUILD
@@ -28,5 +28,6 @@ cc_library(
         "//score/launch_manager/src/daemon/src/common:log",
         "//score/launch_manager/src/daemon/src/common:process_group_state_id",
         "//score/launch_manager/src/daemon/src/osal:ipc_comms",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <thread>
 
+#include <score/assert.hpp>
+
 #include "control_client_channel.hpp"
 #include "score/mw/launch_manager/common/constants.hpp"
 #include "score/mw/launch_manager/common/log.hpp"


### PR DESCRIPTION
- With the `--config:user_cout_log=True` we do not get the dependencies of log and this is causing build errors.
- Out libraries should not rely on other packages dependencies to build, this is fixing some of this.