### PR TITLE
Change fd 3 to 111

### DIFF
--- a/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
+++ b/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
@@ -69,8 +69,8 @@ struct IpcCommsSync final
 
     /// @brief Constant for the synchronization file descriptor.
     /// The `sync_fd` is a constant representing the file descriptor used for synchronization
-    /// during communication. It is set to a value of 3 by default.
-    static const int sync_fd = 3;
+    /// during communication. It is set to a value of 111 by default.
+    static const int sync_fd = 111;
 
     /// @brief Constant for the file descriptor used to signal state transitions
     /// The semaphore used to signal state transitions is stored in an unlinked shared memory area. This requires


### PR DESCRIPTION
On aarch64, the fd 3 might already be taken up which can result in LaunchManager startup failure.
Therefore, changing this to 111.

As future improvement, the hardcoded fds should vanish altogether (when using mw::com, mw::message_passing) or should be made configurable.