### PR TITLE
hmon: use internal memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator"
+version = "0.0.1"
+dependencies = [
+ "loom",
+ "pal",
+ "score_log",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,17 +141,11 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "containers"
-version = "0.1.0"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
+version = "0.0.1"
 dependencies = [
- "elementary",
+ "allocator",
  "score_log",
 ]
-
-[[package]]
-name = "elementary"
-version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 
 [[package]]
 name = "errno"
@@ -180,11 +183,13 @@ name = "health_monitoring_lib"
 version = "0.0.1"
 dependencies = [
  "alive_rs",
+ "allocator",
  "containers",
  "loom",
  "score_log",
  "score_testing_macros",
  "stdout_logger",
+ "sync",
  "thread",
 ]
 
@@ -285,9 +290,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "pal"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
- "containers",
  "score_log",
 ]
 
@@ -361,7 +364,6 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "score_log"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
  "score_log_fmt",
  "score_log_fmt_macro",
@@ -370,12 +372,10 @@ dependencies = [
 [[package]]
 name = "score_log_fmt"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 
 [[package]]
 name = "score_log_fmt_macro"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,7 +386,6 @@ dependencies = [
 [[package]]
 name = "score_testing_macros"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
  "quote",
  "stdout_logger",
@@ -480,7 +479,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "stdout_logger"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
  "score_log",
 ]
@@ -503,9 +501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync"
+version = "0.0.1"
+dependencies = [
+ "allocator",
+ "score_log",
+]
+
+[[package]]
 name = "thread"
 version = "0.0.1"
-source = "git+https://github.com/eclipse-score/baselibs.git?rev=f4f9df39275760a60e54e5e3c5112210e35ae2a3#f4f9df39275760a60e54e5e3c5112210e35ae2a3"
 dependencies = [
  "pal",
  "score_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ signal-hook = "0.3.18"
 
 alive_rs = { path = "score/launch_manager/src/alive/src/rust" } # Temporary API
 health_monitoring_lib = { path = "score/health_monitor/src" }
-score_log = { git = "https://github.com/eclipse-score/baselibs.git", rev = "f4f9df39275760a60e54e5e3c5112210e35ae2a3" }
-score_testing_macros = { git = "https://github.com/eclipse-score/baselibs.git", rev = "f4f9df39275760a60e54e5e3c5112210e35ae2a3" }
-stdout_logger = { git = "https://github.com/eclipse-score/baselibs.git", rev = "f4f9df39275760a60e54e5e3c5112210e35ae2a3" }
-containers = { git = "https://github.com/eclipse-score/baselibs.git", rev = "f4f9df39275760a60e54e5e3c5112210e35ae2a3" }
-thread = { git = "https://github.com/eclipse-score/baselibs.git", rev = "f4f9df39275760a60e54e5e3c5112210e35ae2a3" }
+score_log = { path = "../baselibs/score/log_rust/score_log" }
+score_testing_macros = { path = "../baselibs/score/testing_macros" }
+stdout_logger = { path = "../baselibs/score/log_rust/stdout_logger" }
+containers = { path = "../baselibs/score/containers_rust" }
+thread = { path = "../baselibs/score/thread" }
+allocator = { path = "../baselibs/score/allocator" }
+sync = { path = "../baselibs/score/sync" }
 
 [workspace.lints.clippy]
 std_instead_of_core = "warn"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -159,6 +159,10 @@ oci.pull(
 use_repo(oci, "debian-test-runtime", "debian-test-runtime_linux_amd64")
 
 bazel_dep(name = "score_baselibs", version = "0.2.9")
+local_path_override(
+    module_name = "score_baselibs",
+    path = "../baselibs"
+)
 
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -13,20 +13,29 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
     "https://bcr.bazel.build/modules/abseil-cpp/20240722.0/MODULE.bazel": "88668a07647adbdc14cb3a7cd116fb23c9dda37a90a1681590b6c9d8339a5b84",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
     "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.0/MODULE.bazel": "c4d02dd22cd87458516655a45512060246ee2a4732f1fbe948a5bd9eb614e626",
     "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/source.json": "d725d73707d01bb46ab3ca59ba408b8e9bd336642ca77a2269d4bfb8bbfd413d",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/MODULE.bazel": "c43c16ca2c432566cdb78913964497259903ebe8fb7d9b57b38e9f1425b427b8",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
     "https://bcr.bazel.build/modules/ape/1.0.1/MODULE.bazel": "37411cfd13bfc28cd264674d660a3ecb3b5b35b9dbe4c0b2be098683641b3fee",
     "https://bcr.bazel.build/modules/ape/1.0.1/source.json": "96bc5909d1e3ccc4203272815ef874dbfd99651e240c05049f12193d16c1110b",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
+    "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
+    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
     "https://bcr.bazel.build/modules/apple_support/1.22.1/MODULE.bazel": "90bd1a660590f3ceffbdf524e37483094b29352d85317060b2327fff8f3f4458",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
-    "https://bcr.bazel.build/modules/apple_support/1.24.1/source.json": "cf725267cbacc5f028ef13bb77e7f2c2e0066923a4dab1025e4a0511b1ed258a",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.11.0/MODULE.bazel": "cb1ba9f9999ed0bc08600c221f532c1ddd8d217686b32ba7d45b0713b5131452",
@@ -44,6 +53,7 @@
     "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.21.0/MODULE.bazel": "77dc393c43ad79398b05865444c5200c6f1aae6765615544f2c7730b5858d533",
     "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.21.0/source.json": "062b1d3dba8adcfeb28fe60c185647f5a53ec0487ffe93cf0ae91566596e4b49",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/MODULE.bazel": "01a1014e95e6816b68ecee2584ae929c7d6a1b72e4333ab1ff2d2c6c30babdf1",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.3.8/MODULE.bazel": "74bf20a7a6bd5f2be09607fdb4196cfd6f203422ea271752ec2b1afe95426101",
@@ -78,11 +88,13 @@
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.2.0/MODULE.bazel": "122b2b606622afbaa498913d54f52d9bcd2d19a5edd1bd6d6c5aa17441c4d5f9",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/source.json": "dfa5c4b01110313153b484a735764d247fee5624bbab63d25289e43b151a657a",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
@@ -160,21 +172,27 @@
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/c-ares/1.15.0/MODULE.bazel": "ba0a78360fdc83f02f437a9e7df0532ad1fbaa59b722f6e715c11effebaa0166",
-    "https://bcr.bazel.build/modules/c-ares/1.15.0/source.json": "5e3ed991616c5ec4cc09b0893b29a19232de4a1830eb78c567121bfea87453f7",
+    "https://bcr.bazel.build/modules/c-ares/1.19.1/MODULE.bazel": "73bca21720772370ff91cc8e88bbbaf14897720c6473e87c1ddc0f848284c313",
+    "https://bcr.bazel.build/modules/c-ares/1.34.5.bcr.1/MODULE.bazel": "f4632f68dbc075342966477d9c94a8a4a299d91e155980b042e1cd9f5a7ebcf5",
+    "https://bcr.bazel.build/modules/c-ares/1.34.5.bcr.1/source.json": "55fae1e004176f6cb36efcc77de9894f799d985f482b8f82fec989d556745a84",
     "https://bcr.bazel.build/modules/cel-spec/0.15.0/MODULE.bazel": "e1eed53d233acbdcf024b4b0bc1528116d92c29713251b5154078ab1348cb600",
-    "https://bcr.bazel.build/modules/cel-spec/0.15.0/source.json": "ab7dccdf21ea2261c0f809b5a5221a4d7f8b580309f285fdf1444baaca75d44a",
+    "https://bcr.bazel.build/modules/cel-spec/0.24.0/MODULE.bazel": "e310c7aff8490ed689ccafd32729b77a660b9547f5a5ba9b20e967011c324b36",
+    "https://bcr.bazel.build/modules/cel-spec/0.24.0/source.json": "522d08bc22524e07863276dd0f038f446a83166e91281dcfc07d5b8433c8d89e",
     "https://bcr.bazel.build/modules/civetweb/1.16/MODULE.bazel": "46a38f9daeb57392e3827fce7d40926be0c802bd23cdd6bfd3a96c804de42fae",
     "https://bcr.bazel.build/modules/civetweb/1.16/source.json": "ba8b9585adb8355cb51b999d57172fd05e7a762c56b8d4bac6db42c99de3beb7",
     "https://bcr.bazel.build/modules/curl/8.4.0/MODULE.bazel": "0bc250aa1cb69590049383df7a9537c809591fcf876c620f5f097c58fdc9bc10",
     "https://bcr.bazel.build/modules/curl/8.7.1/MODULE.bazel": "088221c35a2939c555e6e47cb31a81c15f8b59f4daa8009b1e9271a502d33485",
-    "https://bcr.bazel.build/modules/curl/8.7.1/source.json": "bf9890e809717445b10a3ddc323b6d25c46631589c693a232df8310a25964484",
+    "https://bcr.bazel.build/modules/curl/8.8.0/MODULE.bazel": "7da3b3e79b0b4ee8f8c95d640bc6ad7b430ce66ef6e9c9d2bc29b3b5ef85f6fe",
+    "https://bcr.bazel.build/modules/curl/8.8.0/source.json": "d7d138b6878cf38891692fee0649ace35357fd549b425614d571786f054374d4",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/MODULE.bazel": "868b3f5c956c3657420d2302004c6bb92606bfa47e314bab7f2ba0630c7c966c",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/source.json": "da318be900b8ca9c3d1018839d3bebc5a8e1645620d0848fa2c696d4ecf7c296",
     "https://bcr.bazel.build/modules/download_utils/1.0.1/MODULE.bazel": "f1d0afade59e37de978506d6bbf08d7fe5f94964e86944aaf58efcead827b41b",
     "https://bcr.bazel.build/modules/download_utils/1.2.2/MODULE.bazel": "7d185ec9dd3c5ee277f269e3a8e5f09b9de4cb7ba34d06b93dce9bf41c1279f8",
     "https://bcr.bazel.build/modules/download_utils/1.2.2/source.json": "c88be2bc48c98371d35665b805f307a647c98c83327345c918d9088822d77928",
     "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/MODULE.bazel": "24e05f6f52f37be63a795192848555a2c8c855e7814dbc1ed419fb04a7005464",
-    "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/source.json": "212043ab69d87f7a04aa4f627f725b540cff5e145a3a31a9403d8b6ec2e920c9",
+    "https://bcr.bazel.build/modules/envoy_api/0.0.0-20250128-4de3c74/MODULE.bazel": "1fe72489212c530086e3ffb0e018b2bfef4663200ca03571570f9f006bef1d75",
+    "https://bcr.bazel.build/modules/envoy_api/0.0.0-20251105-4a2b9a3/MODULE.bazel": "b66e87a0e0c2207f07e35c321388eb1feb036344565977444b52912c53a84466",
+    "https://bcr.bazel.build/modules/envoy_api/0.0.0-20251105-4a2b9a3/source.json": "c4780edf780977f2ab7d00a189432c5b0b2fa08c6e4e2e09d2950499364a687d",
     "https://bcr.bazel.build/modules/flatbuffers/25.12.19/MODULE.bazel": "fe3a7f7811f43264f68136ad99e64384d70b2a25245e09ab800c4bb83171da25",
     "https://bcr.bazel.build/modules/flatbuffers/25.12.19/source.json": "ea0204be7a79de9141cee5fa436e58a14e88b39b5b59227b21efa0394474ebea",
     "https://bcr.bazel.build/modules/flatbuffers/25.9.23/MODULE.bazel": "32753ba60bf3bacfe7737c0f3e8e3e55624b19af5d398c485580d57492d145d8",
@@ -186,39 +204,57 @@
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
+    "https://bcr.bazel.build/modules/gazelle/0.37.0/MODULE.bazel": "d1327ba0907d0275ed5103bfbbb13518f6c04955b402213319d0d6c0ce9839d4",
+    "https://bcr.bazel.build/modules/gazelle/0.39.1/MODULE.bazel": "1fa3fefad240e535066fd0e6950dfccd627d36dc699ee0034645e51dbde3980f",
+    "https://bcr.bazel.build/modules/gazelle/0.46.0/MODULE.bazel": "3dec215dacf2427df87b524a2c99da387882a18d753f0b1b38675992bd0a99c6",
+    "https://bcr.bazel.build/modules/gazelle/0.46.0/source.json": "f255441117f6c63a3cbc0d4fd84c09c047e54a9bdaaf6aedf66e3b4218ddebd4",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.4/MODULE.bazel": "c6d54a11dcf64ee63545f42561eda3fd94c1b5f5ebe1357011de63ae33739d5e",
+    "https://bcr.bazel.build/modules/google_benchmark/1.9.4/MODULE.bazel": "3bab7c17c10580f87b647478a72a05621f88abc275afb97b578c828f56e59d45",
     "https://bcr.bazel.build/modules/google_benchmark/1.9.5/MODULE.bazel": "8a85cfd90b1e45e6e68f1aa2aa9efce3c04add57df732571d7fd54c07e7c5143",
     "https://bcr.bazel.build/modules/google_benchmark/1.9.5/source.json": "0bd357fd9db30ee31d5eb4c78b1086ce3d79b4423ce76de19e8a2fa7b2fa2e10",
+    "https://bcr.bazel.build/modules/googleapis-cc/1.0.0/MODULE.bazel": "cf01757e7590c56140a4b81638ff2b3e7074769e6271720bbf738fcda25b6fc2",
+    "https://bcr.bazel.build/modules/googleapis-cc/1.0.0/source.json": "ab0e3a2ee9968a8848f59872fbbfa3e1f768597d71d2229e6caa319d357967c7",
+    "https://bcr.bazel.build/modules/googleapis-go/1.0.0/MODULE.bazel": "0a207a4c49da28c5cc1f7b3aeb23c2f7828c85c14aa8d9db0e30357a8d2250ed",
+    "https://bcr.bazel.build/modules/googleapis-go/1.0.0/source.json": "ef189be4e7853e1ebc6123fe20b71822bf9896bd1f8eed8f68505c4585f72a48",
+    "https://bcr.bazel.build/modules/googleapis-java/1.0.0/MODULE.bazel": "d633989337d069b5a95e6101777319681d7a4af4677e36801f11839d6512095c",
+    "https://bcr.bazel.build/modules/googleapis-java/1.0.0/source.json": "ee59e2de37e4b531172870ac0296afa38f1ea004105ee21b2793c31a9d0ddccd",
+    "https://bcr.bazel.build/modules/googleapis-rules-registry/1.0.0/MODULE.bazel": "97c6a4d413b373d4cc97065da3de1b2166e22cbbb5f4cc9f05760bfa83619e24",
+    "https://bcr.bazel.build/modules/googleapis-rules-registry/1.0.0/source.json": "cf611c836a60e98e2e2ab2de8004f119e9f06878dcf4ea2d95a437b1b7a89fe9",
     "https://bcr.bazel.build/modules/googleapis/0.0.0-20240326-1c8d509c5/MODULE.bazel": "a4b7e46393c1cdcc5a00e6f85524467c48c565256b22b5fae20f84ab4a999a68",
     "https://bcr.bazel.build/modules/googleapis/0.0.0-20240819-fe8ba054a/MODULE.bazel": "117b7c7be7327ed5d6c482274533f2dbd78631313f607094d4625c28203cacdf",
-    "https://bcr.bazel.build/modules/googleapis/0.0.0-20240819-fe8ba054a/source.json": "b31fc7eb283a83f71d2e5bfc3d1c562d2994198fa1278409fbe8caec3afc1d3e",
+    "https://bcr.bazel.build/modules/googleapis/0.0.0-20241220-5e258e33.bcr.1/MODULE.bazel": "ee6c30f82ecd476e61f019fb1151aaab380ea419958ff274ef2f0efca7969f5c",
+    "https://bcr.bazel.build/modules/googleapis/0.0.0-20251003-2193a2bf/MODULE.bazel": "cc9e5ed294ed9ebf42cdbbdddd2df29048519e3797004df1e3f369f31ff4f2d4",
+    "https://bcr.bazel.build/modules/googleapis/0.0.0-20251003-2193a2bf/source.json": "21558a194c519e27262cca9cf031bb166a666a8b7fb89993b700c828f8dc0857",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.16.0/MODULE.bazel": "a175623c69e94fca4ca7acbc12031e637b0c489318cd4805606981d4d7adb34a",
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "827f54f492a3ce549c940106d73de332c2b30cebd0c20c0bc5d786aba7f116cb",
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/grpc-java/1.62.2/MODULE.bazel": "99b8771e8c7cacb130170fed2a10c9e8fed26334a93e73b42d2953250885a158",
     "https://bcr.bazel.build/modules/grpc-java/1.66.0/MODULE.bazel": "86ff26209fac846adb89db11f3714b3dc0090fb2fb81575673cc74880cda4e7e",
-    "https://bcr.bazel.build/modules/grpc-java/1.66.0/source.json": "f841b339ff8516c86c3a5272cd053194dd0cb2fdd63157123835e1157a28328d",
     "https://bcr.bazel.build/modules/grpc-proto/0.0.0-20240627-ec30f58/MODULE.bazel": "88de79051e668a04726e9ea94a481ec6f1692086735fd6f488ab908b3b909238",
-    "https://bcr.bazel.build/modules/grpc-proto/0.0.0-20240627-ec30f58/source.json": "5035d379c61042930244ab59e750106d893ec440add92ec0df6a0098ca7f131d",
     "https://bcr.bazel.build/modules/grpc/1.41.0/MODULE.bazel": "5bcbfc2b274dabea628f0649dc50c90cf36543b1cfc31624832538644ad1aae8",
     "https://bcr.bazel.build/modules/grpc/1.56.3.bcr.1/MODULE.bazel": "cd5b1eb276b806ec5ab85032921f24acc51735a69ace781be586880af20ab33f",
     "https://bcr.bazel.build/modules/grpc/1.62.1/MODULE.bazel": "2998211594b8a79a6b459c4e797cfa19f0fb8b3be3149760ec7b8c99abfd426f",
+    "https://bcr.bazel.build/modules/grpc/1.63.1.bcr.1/MODULE.bazel": "d7b9fef03bd175e6825237b521b18a3c29f1ac15f8aa52c8a1a0f3bd8f33d54b",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.2/MODULE.bazel": "0fa2b0fd028ce354febf0fe90f1ed8fecfbfc33118cddd95ac0418cc283333a0",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.3/MODULE.bazel": "f6047e89faf488f5e3e65cb2594c6f5e86992abec7487163ff6b623526e543b0",
     "https://bcr.bazel.build/modules/grpc/1.70.1/MODULE.bazel": "b800cd8e3e7555c1e61cba2e02d3a2fcf0e91f66e800db286d965d3b7a6a721a",
-    "https://bcr.bazel.build/modules/grpc/1.70.1/source.json": "e2977ea6cf9f2755418934d4ae134a6569713dd200fd7aded86a4b7f1b86efc9",
+    "https://bcr.bazel.build/modules/grpc/1.71.0/MODULE.bazel": "7fcab2c05530373f1a442c362b17740dd0c75b6a2a975eec8f5bf4c70a37928a",
+    "https://bcr.bazel.build/modules/grpc/1.74.1/MODULE.bazel": "09523be10ba2bfd999683671d0f8f22fb5b20ec77ad89b05ef58ff19a1b65c82",
+    "https://bcr.bazel.build/modules/grpc/1.76.0/MODULE.bazel": "7373bd407fcb183b8bf379fa35dfe29feebdc6d8ec1bc40004cec6c7b2544be0",
+    "https://bcr.bazel.build/modules/grpc/1.76.0/source.json": "5c1deef5b02cb7dd52df9cb628d956e02db3ec40bd165a465bc10b7bf47aa16a",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
     "https://bcr.bazel.build/modules/jq.bzl/0.6.0/MODULE.bazel": "26ec5118e66a55fef36f8ea39d6415d55fc966671fe4d61a6b9ef0cd6bc7b6a1",
     "https://bcr.bazel.build/modules/jq.bzl/0.6.0/source.json": "2ed4e35b9fa9505495784114f7637fbde5846ec14af917841b6c045d877f20eb",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "e5362dadc90aab6724c83a2cc1e67cbed9c89a05d97fb1f90053c8deb1e445c8",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/source.json": "0646414d9037f8aad148781dd760bec90b0b25ac12fda5e03f8aadbd6b9c61e6",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -227,22 +263,28 @@
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/MODULE.bazel": "87023db2f55fc3a9949c7b08dc711fae4d4be339a80a99d04453c4bb3998eefc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/source.json": "296c63a90c6813e53b3812d24245711981fc7e563d98fe15625f55181494488a",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/opencensus-cpp/0.0.0-20230502-50eb5de.bcr.2/MODULE.bazel": "cc18734138dd18c912c6ce2a59186db28f85d8058c99c9f21b46ca3e0aba0ebe",
+    "https://bcr.bazel.build/modules/opencensus-cpp/0.0.0-20230502-50eb5de.bcr.2/source.json": "7c135f9d42bb3b045669c3c6ab3bb3c208e00b46aca4422eea64c29811a5b240",
     "https://bcr.bazel.build/modules/opencensus-cpp/0.0.0-20230502-50eb5de/MODULE.bazel": "02201d2921dadb4ec90c4980eca4b2a02904eddcf6fa02f3da7594fb7b0d821c",
-    "https://bcr.bazel.build/modules/opencensus-cpp/0.0.0-20230502-50eb5de/source.json": "f50efc07822f5425bd1d3e40e977484f9c0142463052717d40ec85cd6744243e",
+    "https://bcr.bazel.build/modules/opencensus-proto/0.4.1.bcr.2/MODULE.bazel": "789706a714855f92c5c8cfcf1ef32bbb64dcd3b7c9066756ad7986ec59709d29",
+    "https://bcr.bazel.build/modules/opencensus-proto/0.4.1.bcr.2/source.json": "aadf3f53e08b72376506b7c4ea3d167010c9efb160d7d6e1e304ed646bac1b36",
     "https://bcr.bazel.build/modules/opencensus-proto/0.4.1/MODULE.bazel": "4a2e8b4d0b544002502474d611a5a183aa282251e14f6a01afe841c0c1b10372",
-    "https://bcr.bazel.build/modules/opencensus-proto/0.4.1/source.json": "a7d956700a85b833c43fc61455c0e111ab75bab40768ed17a206ee18a2bbe38f",
+    "https://bcr.bazel.build/modules/openssl/3.3.1.bcr.1/MODULE.bazel": "49c0c07e8fb87b480bccb842cfee1b32617f11dac590f732573c69058699a3d1",
     "https://bcr.bazel.build/modules/openssl/3.5.5.bcr.4/MODULE.bazel": "b3f35b53c6c73bd3a7c8efbf9b7e79e92566d189e64d313aede69f608ac6dd77",
     "https://bcr.bazel.build/modules/openssl/3.5.5.bcr.4/source.json": "662d68be9227e60ef65fed83c6820564bda4af0efe6a40dc62dd9aee288fe9cf",
     "https://bcr.bazel.build/modules/opentelemetry-cpp/1.14.2/MODULE.bazel": "089a5613c2a159c7dfde098dabfc61e966889c7d6a81a98422a84c51535ed17d",
     "https://bcr.bazel.build/modules/opentelemetry-cpp/1.16.0/MODULE.bazel": "b7379a140f538cea3f749179a2d481ed81942cc6f7b05a6113723eb34ac3b3e7",
-    "https://bcr.bazel.build/modules/opentelemetry-cpp/1.16.0/source.json": "da0cf667713b1e48d7f8912b100b4e0a8284c8a95717af5eb8c830d699e61cf5",
+    "https://bcr.bazel.build/modules/opentelemetry-cpp/1.19.0/MODULE.bazel": "3455326c08b28415648a3d60d8e3c811847ebdbe64474f75b25878f25585aea1",
+    "https://bcr.bazel.build/modules/opentelemetry-cpp/1.19.0/source.json": "4e48137e4c3ecb99401ff99876df8fa330598d7da051869bec643446e8a8ff95",
     "https://bcr.bazel.build/modules/opentelemetry-proto/1.1.0/MODULE.bazel": "a49f406e99bf05ab43ed4f5b3322fbd33adfd484b6546948929d1316299b68bf",
     "https://bcr.bazel.build/modules/opentelemetry-proto/1.3.1/MODULE.bazel": "0141a50e989576ee064c11ce8dd5ec89993525bd9f9a09c5618e4dacc8df9352",
     "https://bcr.bazel.build/modules/opentelemetry-proto/1.4.0.bcr.1/MODULE.bazel": "5ceaf25e11170d22eded4c8032728b4a3f273765fccda32f9e94f463755c4167",
-    "https://bcr.bazel.build/modules/opentelemetry-proto/1.4.0.bcr.1/source.json": "fb9e01517460cfad8bafab082f2e1508d3cc2b7ed700cff19f3c7c84b146e5eb",
+    "https://bcr.bazel.build/modules/opentelemetry-proto/1.5.0/MODULE.bazel": "7543d91a53b98e7b5b37c5a0865b93bff12c1ee022b1e322cd236b968894b030",
+    "https://bcr.bazel.build/modules/opentelemetry-proto/1.5.0/source.json": "046b721ce203e88cdaad44d7dd17a86b7200eab9388b663b234e72e13ff7b143",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/MODULE.bazel": "b3925269f63561b8b880ae7cf62ccf81f6ece55b62cd791eda9925147ae116ec",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
     "https://bcr.bazel.build/modules/package_metadata/0.0.6/MODULE.bazel": "341dab6f417197494517d54c8e557c0baee1de7aec83543a4fbefe57900acb7e",
     "https://bcr.bazel.build/modules/package_metadata/0.0.6/source.json": "9581d8b22db43550ac75ecc314ee4fa0a33400bfdc77d1317d8af6b18dca7756",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
@@ -256,28 +298,38 @@
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
     "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.2.4/MODULE.bazel": "0fbe5dcff66311947a3f6b86ebc6a6d9328e31a28413ca864debc4a043f371e5",
+    "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/MODULE.bazel": "116ad46e97c1d2aeb020fe2899a342a7e703574ce7c0faf7e4810f938c974a9a",
+    "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/source.json": "e813cce2d450708cfcb26e309c5172583a7440776edf354e83e6788c768e5cca",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/MODULE.bazel": "ce82e086bbc0b60267e970f6a54b2ca6d0f22d3eb6633e00e2cc2899c700f3d8",
-    "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0/source.json": "8cb66b4e535afc718e9d104a3db96ccb71a42ee816a100e50fd0d5ac843c0606",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
+    "https://bcr.bazel.build/modules/protobuf/25.6/MODULE.bazel": "fc0ae073b47c7ede88b825ff79e64f1c058967c7a87a86cdf4abecd9e0516625",
     "https://bcr.bazel.build/modules/protobuf/26.0.bcr.1/MODULE.bazel": "8f04d38c2da40a3715ff6bdce4d32c5981e6432557571482d43a62c31a24c2cf",
     "https://bcr.bazel.build/modules/protobuf/26.0.bcr.2/MODULE.bazel": "62e0b84ca727bdeb55a6fe1ef180e6b191bbe548a58305ea1426c158067be534",
     "https://bcr.bazel.build/modules/protobuf/26.0/MODULE.bazel": "8402da964092af40097f4a205eec2a33fd4a7748dc43632b7d1629bfd9a2b856",
     "https://bcr.bazel.build/modules/protobuf/27.0-rc2/MODULE.bazel": "b2b0dbafd57b6bec0ca9b251da02e628c357dab53a097570aa7d79d020f107cf",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
     "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
-    "https://bcr.bazel.build/modules/protobuf/29.1/source.json": "04cca85dce26b895ed037d98336d860367fe09919208f2ad383f0df1aff63199",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/protobuf/30.0/MODULE.bazel": "0e736de5d52ad7824113f47e65256a26ee74b689ba859c5447a0663e5a075409",
+    "https://bcr.bazel.build/modules/protobuf/31.1/MODULE.bazel": "379a389bb330b7b8c1cdf331cc90bf3e13de5614799b3b52cdb7c6f389f6b38e",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/33.0/MODULE.bazel": "c5270efb4aad37a2f893536076518793f409ea7df07a06df995d848d1690f21c",
+    "https://bcr.bazel.build/modules/protobuf/33.0/source.json": "cd7ac80ad863190b9151281a85acc11d77b5bde2ba56443a7215da2d4ace6da3",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "c4bd2c850211ff5b7dadf9d2d0496c1c922fdedc303c775b01dfd3b3efc907ed",
-    "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/source.json": "4cc97f70b521890798058600a927ce4b0def8ee84ff2a5aa632aabcb4234aa0b",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "b8913c154b16177990f6126d2d2477d187f9ddc568e95ee3e2d50fc65d2c494a",
+    "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1.bcr.1/MODULE.bazel": "4bf09676b62fa587ae07e073420a76ec8766dcce7545e5f8c68cfa8e484b5120",
+    "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1.bcr.2/MODULE.bazel": "3bd4b14a8e7c78dbef973280deabaa139db1fe350aa92da03730a31f59082068",
+    "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1.bcr.2/source.json": "14c28a5527fcd699f5efbf83a046666efabed3384364bd48428de89dfdc8110e",
+    "https://bcr.bazel.build/modules/protoc-gen-validate/1.2.1/MODULE.bazel": "52b51f50533ec4fbd5d613cd093773f979ac2e035d954e02ca11de383f502505",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/MODULE.bazel": "2d746fda559464b253b2b2e6073cb51643a2ac79009ca02100ebbc44b4548656",
@@ -293,9 +345,11 @@
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/source.json": "a8ae7c09533bf67f9f6e5122d884d5741600b09d78dca6fc0f2f8d2ee0c2d957",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/MODULE.bazel": "b4559a2c6281ca3165275bb36c1f0ac74666632adc5bdb680e366de7ce845f43",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
-    "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
     "https://bcr.bazel.build/modules/rules_apple/3.5.1/MODULE.bazel": "3d1bbf65ad3692003d36d8a29eff54d4e5c1c5f4bfb60f79e28646a924d9101c",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
     "https://bcr.bazel.build/modules/rules_buf/0.5.2/MODULE.bazel": "5f2492d284ab9bedf2668178303abf5f3cd7d8cdf85d768951008e88456e9c6a",
     "https://bcr.bazel.build/modules/rules_buf/0.5.2/source.json": "41876d4834c0832de4b393de6e55dfd1cb3b25d3109e4ba90eb7fb57c560e0d9",
@@ -312,8 +366,11 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.4/MODULE.bazel": "bb03a452a7527ac25a7518fb86a946ef63df860b9657d8323a0c50f8504fb0b9",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
@@ -324,7 +381,6 @@
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
-    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_go/0.33.0/MODULE.bazel": "a2b11b64cd24bf94f57454f53288a5dacfe6cb86453eee7761b7637728c1910c",
     "https://bcr.bazel.build/modules/rules_go/0.38.1/MODULE.bazel": "fb8e73dd3b6fc4ff9d260ceacd830114891d49904f5bda1c16bc147bcc254f71",
     "https://bcr.bazel.build/modules/rules_go/0.39.1/MODULE.bazel": "d34fb2a249403a5f4339c754f1e63dc9e5ad70b47c5e97faee1441fc6636cd61",
@@ -334,7 +390,9 @@
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
     "https://bcr.bazel.build/modules/rules_go/0.48.0/MODULE.bazel": "d00ebcae0908ee3f5e6d53f68677a303d6d59a77beef879598700049c3980a03",
     "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
-    "https://bcr.bazel.build/modules/rules_go/0.50.1/source.json": "205765fd30216c70321f84c9a967267684bdc74350af3f3c46c857d9f80a4fa2",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
+    "https://bcr.bazel.build/modules/rules_go/0.58.3/MODULE.bazel": "5582119a4a39558d8d1b1634bcae46043d4f43a31415e861c3551b2860040b5e",
+    "https://bcr.bazel.build/modules/rules_go/0.58.3/source.json": "0bacbf5ee9eefb089b03fbd4691dd8f63b4e630515b160731e417ffeb3bd0fdb",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.1.0/MODULE.bazel": "324b6478b0343a3ce7a9add8586ad75d24076d6d43d2f622990b9c1cfd8a1b15",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
@@ -351,13 +409,16 @@
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.4.0/MODULE.bazel": "a592852f8a3dd539e82ee6542013bf2cadfc4c6946be8941e189d224500a8934",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
     "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
     "https://bcr.bazel.build/modules/rules_java/8.13.0/MODULE.bazel": "0444ebf737d144cf2bb2ccb368e7f1cce735264285f2a3711785827c1686625e",
     "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
     "https://bcr.bazel.build/modules/rules_java/8.15.1/MODULE.bazel": "5071eebf0fd602ab0617f846e0e0d8f388d66c961513c736e0ac4a1dcde3ff2c",
-    "https://bcr.bazel.build/modules/rules_java/8.15.1/source.json": "e48286d5819767bc5b3d457539ae7f94e28a9b3e55d092d5c47176cb6a2a289b",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/MODULE.bazel": "0f20b1cecaa8e52f60a8f071e59a20b4e3b9a67f6c56c802ea256f6face692d3",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/source.json": "072f8d11264edc499621be2dc9ea01d6395db5aa6f8799c034ae01a3e857f2e4",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
@@ -366,12 +427,14 @@
     "https://bcr.bazel.build/modules/rules_jvm_external/6.0/MODULE.bazel": "37c93a5a78d32e895d52f86a8d0416176e915daabd029ccb5594db422e87c495",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/0.0.8/MODULE.bazel": "5669c6fe49b5134dbf534db681ad3d67a2d49cfc197e4a95f1ca2fd7f3aebe96",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_multirun/0.9.0/MODULE.bazel": "32d628ef586b5b23f67e55886b7bc38913ea4160420d66ae90521dda2ff37df0",
@@ -390,6 +453,7 @@
     "https://bcr.bazel.build/modules/rules_nodejs/6.5.2/source.json": "6a6ca0940914d55c550d1417cad13a56c9900e23f651a762d8ccc5a64adcf661",
     "https://bcr.bazel.build/modules/rules_oci/2.3.0/MODULE.bazel": "49075197960c924c0a4d759b7c765c3d00a41d2fdd4a943b42823c1d016ab4ec",
     "https://bcr.bazel.build/modules/rules_oci/2.3.0/source.json": "47710c28446211b5e61a24015a4669c50c6862d5f91e6bdbc710de8d750cf613",
+    "https://bcr.bazel.build/modules/rules_perl/0.2.4/MODULE.bazel": "5f5af7be4bf5fb88d91af7469518f0fd2161718aefc606188f7cd51f436ca938",
     "https://bcr.bazel.build/modules/rules_perl/1.1.0/MODULE.bazel": "22138e75bb8f1ee6c21f609b90d2c24b0c9b796ccf55cc04c1c9190b699f7e9d",
     "https://bcr.bazel.build/modules/rules_perl/1.1.0/source.json": "896fe7707a38c5b229c6f5fa77134209874c4d57fecda5f756c1f23e4d25aae2",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
@@ -417,17 +481,22 @@
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.29.0/MODULE.bazel": "2ac8cd70524b4b9ec49a0b8284c79e4cd86199296f82f6e0d5da3f783d660c82",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.32.2/MODULE.bazel": "01052470fc30b49de91fb8483d26bea6f664500cfad0b078d4605b03e3a83ed4",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.34.0/MODULE.bazel": "1d623d026e075b78c9fde483a889cda7996f5da4f36dffb24c246ab30f06513a",
+    "https://bcr.bazel.build/modules/rules_python/0.35.0/MODULE.bazel": "c3657951764cdcdb5a7370d5e885fad5e8c1583320aad18d46f9f110d2c22755",
     "https://bcr.bazel.build/modules/rules_python/0.37.1/MODULE.bazel": "3faeb2d9fa0a81f8980643ee33f212308f4d93eea4b9ce6f36d0b742e71e9500",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
+    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
     "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
     "https://bcr.bazel.build/modules/rules_python/1.5.1/MODULE.bazel": "acfe65880942d44a69129d4c5c3122d57baaf3edf58ae5a6bd4edea114906bf5",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/1.8.3/MODULE.bazel": "f343e159b59701334be3914416b9f1b72845801ba47920fcb288af4ce8c5cce3",
     "https://bcr.bazel.build/modules/rules_python/1.8.5/MODULE.bazel": "28b2d79ed8368d7d45b34bacc220e3c0b99cbcd9392641961b849e4c3f55dd30",
     "https://bcr.bazel.build/modules/rules_python/1.8.5/source.json": "e261b03c8804f2582c9536013f987e1ea105a2b38c238aa2ac8f98fc34c8b18a",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/MODULE.bazel": "2b6d1617ac8503bfdcc0e4520c20539d4bba3a691100bee01afe193ceb0310f9",
     "https://bcr.bazel.build/modules/rules_rust/0.56.0/MODULE.bazel": "3295b00757db397122092322fe1e920be7f5c9fbfb8619138977e820f2cbbbae",
     "https://bcr.bazel.build/modules/rules_rust/0.61.0/MODULE.bazel": "0318a95777b9114c8740f34b60d6d68f9cfef61e2f4b52424ca626213d33787b",
     "https://bcr.bazel.build/modules/rules_rust/0.67.0/MODULE.bazel": "87c3816c4321352dcfd9e9e26b58e84efc5b21351ae3ef8fb5d0d57bde7237f5",
@@ -441,7 +510,9 @@
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/1.18.0/MODULE.bazel": "a6aba73625d0dc64c7b4a1e831549b6e375fbddb9d2dde9d80c9de6ec45b24c9",
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
-    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
+    "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
@@ -453,7 +524,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
     "https://bcr.bazel.build/modules/tar.bzl/0.7.0/MODULE.bazel": "cc1acd85da33c80e430b65219a620d54d114628df24a618c3a5fa0b65e988da9",
@@ -490,17 +562,26 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20240116.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20240116.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20240722.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250127.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250127.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250512.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250512.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250814.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/abseil-cpp/20250814.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/ape/1.0.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.11.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.13.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.15.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.17.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.21.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.21.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.22.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.23.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.24.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/apple_support/1.24.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/2.11.0/MODULE.bazel": "not found",
@@ -516,6 +597,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_bazel_lib/2.9.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_esbuild/0.21.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_js/1.33.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_js/1.39.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_js/1.40.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_js/2.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/aspect_rules_js/2.3.8/MODULE.bazel": "not found",
@@ -545,11 +627,13 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.19.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.2.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.21.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.23.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.27.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.28.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.3.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.30.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.32.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.33.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.34.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.9.0/MODULE.bazel": "not found",
@@ -602,14 +686,20 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/buildifier_prebuilt/8.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/buildozer/7.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/c-ares/1.15.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/c-ares/1.19.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/c-ares/1.34.5.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/cel-spec/0.15.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/cel-spec/0.24.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/civetweb/1.16/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/curl/8.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/curl/8.7.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/curl/8.8.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/cython/3.0.11-1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/download_utils/1.0.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/download_utils/1.2.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/envoy_api/0.0.0-20241214-918efc9/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/envoy_api/0.0.0-20250128-4de3c74/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/envoy_api/0.0.0-20251105-4a2b9a3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/flatbuffers/25.12.19/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/flatbuffers/25.9.23/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "not found",
@@ -619,15 +709,26 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.33.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.34.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.36.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.37.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.39.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/gazelle/0.46.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/google_benchmark/1.8.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/google_benchmark/1.8.4/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/google_benchmark/1.9.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/google_benchmark/1.9.5/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis-cc/1.0.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis-go/1.0.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis-java/1.0.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis-rules-registry/1.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis/0.0.0-20240326-1c8d509c5/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis/0.0.0-20240819-fe8ba054a/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis/0.0.0-20241220-5e258e33.bcr.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googleapis/0.0.0-20251003-2193a2bf/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.11.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.14.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.15.2/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/googletest/1.17.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc-java/1.62.2/MODULE.bazel": "not found",
@@ -636,28 +737,39 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.41.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.56.3.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.62.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.63.1.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.66.0.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.66.0.bcr.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.70.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.71.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.74.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/grpc/1.76.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/jq.bzl/0.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/jq.bzl/0.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/jq.bzl/0.6.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/jsoncpp/1.9.5/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/jsoncpp/1.9.6/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/libpfm/4.11.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/mbedtls/3.6.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/nlohmann_json/3.11.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/nlohmann_json/3.6.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opencensus-cpp/0.0.0-20230502-50eb5de.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opencensus-cpp/0.0.0-20230502-50eb5de/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opencensus-proto/0.4.1.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opencensus-proto/0.4.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/openssl/3.3.1.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/openssl/3.5.5.bcr.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-cpp/1.14.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-cpp/1.16.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-cpp/1.19.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-proto/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-proto/1.3.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-proto/1.4.0.bcr.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentelemetry-proto/1.5.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/opentracing-cpp/1.6.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/package_metadata/0.0.2/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/package_metadata/0.0.5/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/package_metadata/0.0.6/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/platforms/0.0.10/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/platforms/0.0.11/MODULE.bazel": "not found",
@@ -669,16 +781,19 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/platforms/0.0.9/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/platforms/1.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/prometheus-cpp/1.2.4/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/prometheus-cpp/1.3.0.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/prometheus-cpp/1.3.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/21.7/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/23.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/24.4/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/25.6/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/26.0.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/26.0.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/26.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/27.0-rc2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/27.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/27.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/29.0-rc2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/29.0-rc3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/29.0/MODULE.bazel": "not found",
@@ -686,8 +801,15 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/3.19.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/3.19.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/3.19.6/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/30.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/31.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/32.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protobuf/33.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protoc-gen-validate/1.2.1.bcr.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protoc-gen-validate/1.2.1.bcr.2/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/protoc-gen-validate/1.2.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/pybind11_bazel/2.11.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/pybind11_bazel/2.12.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/pybind11_bazel/2.13.6/MODULE.bazel": "not found",
@@ -699,8 +821,10 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/re2/2024-07-02/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/re2/2025-08-12.bcr.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_android/0.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_apple/3.13.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_apple/3.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_apple/3.5.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_apple/4.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_buf/0.1.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_buf/0.5.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.0.1/MODULE.bazel": "not found",
@@ -716,8 +840,11 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.0.8/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.0.9/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.5/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.13/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.14/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.17/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.4/MODULE.bazel": "not found",
@@ -735,6 +862,8 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_go/0.46.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_go/0.48.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_go/0.50.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_go/0.53.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_go/0.58.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/4.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/5.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/5.3.5/MODULE.bazel": "not found",
@@ -751,12 +880,15 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/7.3.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/7.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/7.6.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/7.6.5/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.11.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.13.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.14.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.15.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.16.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.3.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.5.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.6.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_java/8.6.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/4.4.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/5.1/MODULE.bazel": "not found",
@@ -765,10 +897,12 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/6.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/6.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/6.3/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_jvm_external/6.7/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_kotlin/1.9.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_kotlin/1.9.6/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_license/0.0.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_license/0.0.7/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_license/0.0.8/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_license/1.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_multirun/0.9.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_multitool/0.11.0/MODULE.bazel": "not found",
@@ -782,6 +916,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_nodejs/6.3.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_nodejs/6.5.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_oci/2.3.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_perl/0.2.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_perl/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/0.7.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/1.0.1/MODULE.bazel": "not found",
@@ -806,16 +941,21 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.28.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.29.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.31.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.32.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.33.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.34.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.35.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.37.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/0.40.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.0.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.3.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.5.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.6.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.8.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_python/1.8.5/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_rust/0.51.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_rust/0.56.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_rust/0.61.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_rust/0.67.0/MODULE.bazel": "not found",
@@ -831,8 +971,8 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.18.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/2.1.1/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs/0.2.9/MODULE.bazel": "2f95cc2e07c5ed9df69e6af35a98843235ce43a96d0aef8c55398ebe6813b58a",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_baselibs/0.2.9/source.json": "b94fa0e611e51d35c4742e2e49e6ee09750d68d79dc61b6028e758f08f58f849",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/2.4.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/3.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.4/MODULE.bazel": "5f14457f9b708302db05b5dc3c07bd41ae19b91cabf98a0dbffdca622bd6ac91",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.4/source.json": "2946be24c6b978aa788c934643aa7ec68aac4a926bea4eaa81d512fd48e9f4a8",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_platforms/0.0.3/MODULE.bazel": "14c96e378c08705a46abe0799d6236fe3095c342c34f83f8d1b3f6046ce00651",
@@ -906,6 +1046,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.7.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.7.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.2.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.7.0/MODULE.bazel": "not found",
@@ -1383,203 +1524,6 @@
             "aspect_tools_telemetry+",
             "bazel_skylib",
             "bazel_skylib+"
-          ]
-        ]
-      }
-    },
-    "@@cel-spec+//:extensions.bzl%non_module_dependencies": {
-      "general": {
-        "bzlTransitiveDigest": "49v9UE4eBOMtW8ATb+3VHdFaCc//dFbCS+ZQW0HIKNE=",
-        "usagesDigest": "HFQJtQrL9nKaFZEjgwaHVMHALMW+cafu696xy7J4ueM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "com_google_googleapis": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "sha256": "bd8e735d881fb829751ecb1a77038dda4a8d274c45490cb9fcf004583ee10571",
-              "strip_prefix": "googleapis-07c27163ac591955d736f3057b1619ece66f5b99",
-              "urls": [
-                "https://github.com/googleapis/googleapis/archive/07c27163ac591955d736f3057b1619ece66f5b99.tar.gz"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "cel-spec+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@cel-spec+//:googleapis_ext.bzl%googleapis_ext": {
-      "general": {
-        "bzlTransitiveDigest": "yun2jmsomFi3bs5bjQWXApBzqQf66zBJ39JEBYigzdc=",
-        "usagesDigest": "Ek7VfZ+tuyRBx/1h5wcmtnW9EGpOb0dkXUwBluZbD8k=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "com_google_googleapis_imports": {
-            "repoRuleId": "@@cel-spec++non_module_dependencies+com_google_googleapis//:repository_rules.bzl%switched_rules",
-            "attributes": {
-              "rules": {
-                "proto_library_with_info": [
-                  "",
-                  ""
-                ],
-                "moved_proto_library": [
-                  "",
-                  ""
-                ],
-                "java_proto_library": [
-                  "",
-                  ""
-                ],
-                "java_grpc_library": [
-                  "",
-                  ""
-                ],
-                "java_gapic_library": [
-                  "",
-                  ""
-                ],
-                "java_gapic_test": [
-                  "",
-                  ""
-                ],
-                "java_gapic_assembly_gradle_pkg": [
-                  "",
-                  ""
-                ],
-                "py_proto_library": [
-                  "",
-                  ""
-                ],
-                "py_grpc_library": [
-                  "",
-                  ""
-                ],
-                "py_gapic_library": [
-                  "",
-                  ""
-                ],
-                "py_test": [
-                  "",
-                  ""
-                ],
-                "py_gapic_assembly_pkg": [
-                  "",
-                  ""
-                ],
-                "py_import": [
-                  "",
-                  ""
-                ],
-                "go_proto_library": [
-                  "",
-                  ""
-                ],
-                "go_library": [
-                  "",
-                  ""
-                ],
-                "go_test": [
-                  "",
-                  ""
-                ],
-                "go_gapic_library": [
-                  "",
-                  ""
-                ],
-                "go_gapic_assembly_pkg": [
-                  "",
-                  ""
-                ],
-                "cc_proto_library": [
-                  "native.cc_proto_library",
-                  ""
-                ],
-                "cc_grpc_library": [
-                  "",
-                  ""
-                ],
-                "cc_gapic_library": [
-                  "",
-                  ""
-                ],
-                "php_proto_library": [
-                  "",
-                  "php_proto_library"
-                ],
-                "php_grpc_library": [
-                  "",
-                  "php_grpc_library"
-                ],
-                "php_gapic_library": [
-                  "",
-                  "php_gapic_library"
-                ],
-                "php_gapic_assembly_pkg": [
-                  "",
-                  "php_gapic_assembly_pkg"
-                ],
-                "nodejs_gapic_library": [
-                  "",
-                  "typescript_gapic_library"
-                ],
-                "nodejs_gapic_assembly_pkg": [
-                  "",
-                  "typescript_gapic_assembly_pkg"
-                ],
-                "ruby_proto_library": [
-                  "",
-                  ""
-                ],
-                "ruby_grpc_library": [
-                  "",
-                  ""
-                ],
-                "ruby_ads_gapic_library": [
-                  "",
-                  ""
-                ],
-                "ruby_cloud_gapic_library": [
-                  "",
-                  ""
-                ],
-                "ruby_gapic_assembly_pkg": [
-                  "",
-                  ""
-                ],
-                "csharp_proto_library": [
-                  "",
-                  ""
-                ],
-                "csharp_grpc_library": [
-                  "",
-                  ""
-                ],
-                "csharp_gapic_library": [
-                  "",
-                  ""
-                ],
-                "csharp_gapic_assembly_pkg": [
-                  "",
-                  ""
-                ]
-              }
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "cel-spec+",
-            "com_google_googleapis",
-            "cel-spec++non_module_dependencies+com_google_googleapis"
           ]
         ]
       }
@@ -9283,165 +9227,6 @@
             "rules_rust+",
             "rules_rust",
             "rules_rust+"
-          ]
-        ]
-      }
-    },
-    "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
-      "general": {
-        "bzlTransitiveDigest": "6axDCXf6fQoPav8hojnUBxGA0FAMqLvtpC1cRsisCdw=",
-        "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "com_github_apple_swift_protobuf": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
-              ],
-              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
-              "strip_prefix": "swift-protobuf-1.20.2/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
-            }
-          },
-          "com_github_grpc_grpc_swift": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
-              ],
-              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
-              "strip_prefix": "grpc-swift-1.16.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_docc_symbolkit": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-docc-symbolkit/archive/refs/tags/swift-5.10-RELEASE.tar.gz"
-              ],
-              "sha256": "de1d4b6940468ddb53b89df7aa1a81323b9712775b0e33e8254fa0f6f7469a97",
-              "strip_prefix": "swift-docc-symbolkit-swift-5.10-RELEASE",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_nio": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
-              ],
-              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
-              "strip_prefix": "swift-nio-2.42.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_nio_http2": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
-              ],
-              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
-              "strip_prefix": "swift-nio-http2-1.26.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_nio_transport_services": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
-              ],
-              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
-              "strip_prefix": "swift-nio-transport-services-1.15.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_nio_extras": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
-              ],
-              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
-              "strip_prefix": "swift-nio-extras-1.4.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_log": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
-              ],
-              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
-              "strip_prefix": "swift-log-1.4.4/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_log/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_nio_ssl": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
-              ],
-              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
-              "strip_prefix": "swift-nio-ssl-2.23.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_collections": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
-              ],
-              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
-              "strip_prefix": "swift-collections-1.0.4/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_collections/BUILD.overlay"
-            }
-          },
-          "com_github_apple_swift_atomics": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
-              ],
-              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
-              "strip_prefix": "swift-atomics-1.1.0/",
-              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_atomics/BUILD.overlay"
-            }
-          },
-          "build_bazel_rules_swift_index_import": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "build_file": "@@rules_swift+//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
-              "canonical_id": "index-import-5.8",
-              "urls": [
-                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
-              ],
-              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
-            }
-          },
-          "build_bazel_rules_swift_local_config": {
-            "repoRuleId": "@@rules_swift+//swift/internal:swift_autoconfiguration.bzl%swift_autoconfiguration",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_swift+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_swift+",
-            "build_bazel_rules_swift",
-            "rules_swift+"
           ]
         ]
       }

--- a/score/health_monitor/src/Cargo.toml
+++ b/score/health_monitor/src/Cargo.toml
@@ -19,6 +19,8 @@ score_log.workspace = true
 score_testing_macros.workspace = true
 containers.workspace = true
 alive_rs = { workspace = true, optional = true }
+allocator.workspace = true
+sync.workspace = true
 
 [dev-dependencies]
 stdout_logger.workspace = true

--- a/score/health_monitor/src/cpp/health_monitor.cpp
+++ b/score/health_monitor/src/cpp/health_monitor.cpp
@@ -26,6 +26,7 @@ using namespace score::mw::health::logic;
 FFICode health_monitor_builder_create(FFIHandle* health_monitor_builder_handle_out);
 FFICode health_monitor_builder_destroy(FFIHandle health_monitor_builder_handle);
 FFICode health_monitor_builder_build(FFIHandle health_monitor_builder_handle,
+                                     const size_t* allocator_capacity,
                                      const uint64_t* supervisor_cycle_ms,
                                      const uint64_t* internal_cycle_ms,
                                      FFIHandle thread_parameters_handle,
@@ -114,6 +115,12 @@ HealthMonitorBuilder HealthMonitorBuilder::add_logic_monitor(const MonitorTag& m
     return std::move(*this);
 }
 
+HealthMonitorBuilder HealthMonitorBuilder::allocator_capacity(size_t allocator_capacity) &&
+{
+    allocator_capacity_ = allocator_capacity;
+    return std::move(*this);
+}
+
 HealthMonitorBuilder HealthMonitorBuilder::with_internal_processing_cycle(std::chrono::milliseconds cycle_duration) &&
 {
     auto count{cycle_duration.count()};
@@ -142,8 +149,13 @@ score::cpp::expected<HealthMonitor, Error> HealthMonitorBuilder::build() &&
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION(health_monitor_builder_handle.has_value());
 
     // Handle optional parameters.
+    const size_t* allocator_capacity{nullptr};
     const uint64_t* supervisor_api_cycle_ms{nullptr};
     const uint64_t* internal_processing_cycle_ms{nullptr};
+    if (allocator_capacity_.has_value())
+    {
+        allocator_capacity = &allocator_capacity_.value();
+    }
     if (supervisor_api_cycle_ms_.has_value())
     {
         supervisor_api_cycle_ms = &supervisor_api_cycle_ms_.value();
@@ -164,6 +176,7 @@ score::cpp::expected<HealthMonitor, Error> HealthMonitorBuilder::build() &&
 
     FFIHandle health_monitor_handle{nullptr};
     auto result{health_monitor_builder_build(health_monitor_builder_handle.value(),
+                                             allocator_capacity,
                                              supervisor_api_cycle_ms,
                                              internal_processing_cycle_ms,
                                              thread_parameters_handle,

--- a/score/health_monitor/src/cpp/health_monitor.h
+++ b/score/health_monitor/src/cpp/health_monitor.h
@@ -52,6 +52,9 @@ class HealthMonitorBuilder final
     /// Adds a logic monitor for a specific identifier tag.
     HealthMonitorBuilder add_logic_monitor(const MonitorTag& monitor_tag, logic::LogicMonitorBuilder&& monitor) &&;
 
+    /// Set protected memory allocator capacity.
+    HealthMonitorBuilder allocator_capacity(size_t allocator_capacity) &&;
+
     /// Sets the cycle duration for supervisor API notifications.
     /// This duration determines how often the health monitor notifies the supervisor that the system is alive.
     HealthMonitorBuilder with_supervisor_api_cycle(std::chrono::milliseconds cycle_duration) &&;
@@ -69,6 +72,7 @@ class HealthMonitorBuilder final
   private:
     internal::DroppableFFIHandle health_monitor_builder_handle_;
 
+    std::optional<size_t> allocator_capacity_;
     std::optional<uint64_t> supervisor_api_cycle_ms_;
     std::optional<uint64_t> internal_processing_cycle_ms_;
     std::optional<ThreadParameters> thread_parameters_;

--- a/score/health_monitor/src/rust/BUILD
+++ b/score/health_monitor/src/rust/BUILD
@@ -14,14 +14,16 @@
 load("@rules_rust//rust:defs.bzl", "miri_test", "rust_library", "rust_static_library", "rust_test")
 
 COMMON_RUST_DEPS = [
-    "@score_baselibs//src/containers:containers",
-    "@score_baselibs//src/thread:thread",
-    "@score_baselibs//src/log/score_log:score_log",
+    "@score_baselibs//score/containers_rust:containers",
+    "@score_baselibs//score/thread",
+    "@score_baselibs//score/log_rust/score_log",
+    "@score_baselibs//score/allocator",
+    "@score_baselibs//score/sync",
     "//score/launch_manager:alive_rust",
 ]
 
 PROC_MACRO_DEPS = [
-    "@score_baselibs//src/testing_macros:score_testing_macros",
+    "@score_baselibs//score/testing_macros:score_testing_macros",
 ]
 
 rust_library(
@@ -73,7 +75,7 @@ rust_test(
         "no-asan",
         "skip_local",  # see https://github.com/eclipse-score/lifecycle/issues/272
     ],
-    deps = ["@score_baselibs//src/log/stdout_logger"],
+    deps = ["@score_baselibs//score/log_rust/stdout_logger"],
 )
 
 rust_test(
@@ -100,7 +102,7 @@ rust_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
-        "@score_baselibs//src/log/stdout_logger",
+        "@score_baselibs//score/log_rust/stdout_logger",
         "@score_crates//:loom",
     ],
 )

--- a/score/health_monitor/src/rust/common.rs
+++ b/score/health_monitor/src/rust/common.rs
@@ -15,13 +15,15 @@ use crate::deadline::DeadlineEvaluationError;
 use crate::heartbeat::HeartbeatEvaluationError;
 use crate::log::ScoreDebug;
 use crate::logic::LogicEvaluationError;
+use crate::protected_memory::ProtectedArcIn;
 use crate::tag::MonitorTag;
 use core::cell::Cell;
 use core::hash::Hash;
 use core::marker::PhantomData;
+use core::ptr::NonNull;
 use core::time::Duration;
-use std::sync::Arc;
 use std::time::Instant;
+use sync::ArcInner;
 
 /// Range of accepted time: `<min; max>`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -119,11 +121,17 @@ pub(crate) trait MonitorEvaluator {
 
 /// Handle to a monitor evaluator, allowing for dynamic dispatch.
 pub(crate) struct MonitorEvalHandle {
-    inner: Arc<dyn MonitorEvaluator + Send + Sync>,
+    inner: ProtectedArcIn<dyn MonitorEvaluator + Send + Sync>,
 }
 
 impl MonitorEvalHandle {
-    pub(crate) fn new<T: MonitorEvaluator + Send + Sync + 'static>(inner: Arc<T>) -> Self {
+    pub(crate) fn new<T: MonitorEvaluator + Send + Sync + 'static>(inner: ProtectedArcIn<T>) -> Self {
+        // SAFETY:
+        // `ptr` and `alloc` come from a single `into_raw_parts` call, and are reassembled into unsized `ArcIn` using `from_raw_parts`.
+        // Unsizing is done with unsized coercion on raw pointer (`T` -> `dyn MonitorEvaluator`).
+        let (ptr, alloc) = ProtectedArcIn::into_raw_parts(inner);
+        let ptr: NonNull<ArcInner<dyn MonitorEvaluator + Send + Sync>> = ptr;
+        let inner = unsafe { ProtectedArcIn::from_raw_parts(ptr, alloc) };
         Self { inner }
     }
 }

--- a/score/health_monitor/src/rust/deadline/deadline_monitor.rs
+++ b/score/health_monitor/src/rust/deadline/deadline_monitor.rs
@@ -14,11 +14,11 @@ use crate::common::{duration_to_int, Monitor, MonitorEvalHandle, MonitorEvaluati
 use crate::deadline::common::{DeadlineTemplate, StateIndex};
 use crate::deadline::deadline_state::{DeadlineState, DeadlineStateSnapshot};
 use crate::log::{error, warn, ScoreDebug};
-use crate::protected_memory::ProtectedMemoryAllocator;
+use crate::protected_memory::{ProtectedArcIn, ProtectedMemoryAllocator};
 use crate::tag::{DeadlineTag, MonitorTag};
+use containers::fixed_capacity::FixedCapacityVecIn;
 use core::hash::Hash;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Instant;
 
 /// Deadline evaluation errors.
@@ -70,8 +70,11 @@ impl DeadlineMonitorBuilder {
     }
 
     /// Builds the DeadlineMonitor with the configured deadlines.
-    pub(crate) fn build(self, monitor_tag: MonitorTag, _allocator: &ProtectedMemoryAllocator) -> DeadlineMonitor {
-        let inner = Arc::new(DeadlineMonitorInner::new(monitor_tag, self.deadlines));
+    pub(crate) fn build(self, monitor_tag: MonitorTag, allocator: ProtectedMemoryAllocator) -> DeadlineMonitor {
+        let inner = ProtectedArcIn::new_in(
+            DeadlineMonitorInner::new(monitor_tag, self.deadlines, allocator.clone()),
+            allocator,
+        );
         DeadlineMonitor::new(inner)
     }
 
@@ -84,12 +87,12 @@ impl DeadlineMonitorBuilder {
 
 /// Deadline monitor.
 pub struct DeadlineMonitor {
-    inner: Arc<DeadlineMonitorInner>,
+    inner: ProtectedArcIn<DeadlineMonitorInner>,
 }
 
 impl DeadlineMonitor {
     /// Create a new [`DeadlineMonitor`] instance.
-    fn new(inner: Arc<DeadlineMonitorInner>) -> Self {
+    fn new(inner: ProtectedArcIn<DeadlineMonitorInner>) -> Self {
         Self { inner }
     }
 
@@ -99,13 +102,13 @@ impl DeadlineMonitor {
     ///  - Err(DeadlineMonitorError::DeadlineInUse) - if the deadline is already in use
     ///  - Err(DeadlineMonitorError::DeadlineNotFound) - if the deadline tag is not registered
     pub fn get_deadline(&self, deadline_tag: DeadlineTag) -> Result<Deadline, DeadlineMonitorError> {
-        self.inner.get_deadline(deadline_tag)
+        get_deadline_inner(&self.inner, deadline_tag)
     }
 }
 
 impl Monitor for DeadlineMonitor {
     fn get_eval_handle(&self) -> MonitorEvalHandle {
-        MonitorEvalHandle::new(Arc::clone(&self.inner))
+        MonitorEvalHandle::new(ProtectedArcIn::clone(&self.inner))
     }
 }
 
@@ -114,7 +117,7 @@ pub struct Deadline {
     range: TimeRange,
     deadline_tag: DeadlineTag,
     state_index: StateIndex,
-    monitor: Arc<DeadlineMonitorInner>,
+    monitor: ProtectedArcIn<DeadlineMonitorInner>,
 }
 
 /// A handle representing a started deadline. When dropped, it stops the deadline.
@@ -257,7 +260,7 @@ struct DeadlineMonitorInner {
     // This is shared state. Each deadline template has assigned index into this array.
     // Each deadline instance updates its state (under given index) and the deadline pointing to a state is Single-Producer
     // On the other side there is background thread evaluating all deadlines states - this is Single-Consumer for each given state.
-    active_deadlines: Arc<[(DeadlineTag, DeadlineState)]>,
+    active_deadlines: FixedCapacityVecIn<(DeadlineTag, DeadlineState), ProtectedMemoryAllocator>,
 }
 
 impl MonitorEvaluator for DeadlineMonitorInner {
@@ -294,14 +297,20 @@ impl MonitorEvaluator for DeadlineMonitorInner {
 }
 
 impl DeadlineMonitorInner {
-    fn new(monitor_tag: MonitorTag, deadlines: HashMap<DeadlineTag, TimeRange>) -> Self {
-        let mut active_deadlines = vec![];
+    fn new(
+        monitor_tag: MonitorTag,
+        deadlines: HashMap<DeadlineTag, TimeRange>,
+        allocator: ProtectedMemoryAllocator,
+    ) -> Self {
+        let mut active_deadlines = FixedCapacityVecIn::new(deadlines.len(), allocator);
 
         let deadlines = deadlines
             .into_iter()
             .enumerate()
             .map(|(index, (deadline_tag, range))| {
-                active_deadlines.push((deadline_tag, DeadlineState::new()));
+                active_deadlines
+                    .push((deadline_tag, DeadlineState::new()))
+                    .expect("failed to push active deadline");
                 (deadline_tag, DeadlineTemplate::new(range, StateIndex::new(index)))
             })
             .collect();
@@ -309,7 +318,7 @@ impl DeadlineMonitorInner {
         Self {
             monitor_tag,
             deadlines,
-            active_deadlines: active_deadlines.into(),
+            active_deadlines,
             monitor_starting_point: Instant::now(),
         }
     }
@@ -321,31 +330,41 @@ impl DeadlineMonitorInner {
             unreachable!("Releasing unknown deadline tag: {:?}", deadline_tag);
         }
     }
+}
 
-    pub(crate) fn get_deadline(self: &Arc<Self>, deadline_tag: DeadlineTag) -> Result<Deadline, DeadlineMonitorError> {
-        if let Some(template) = self.deadlines.get(&deadline_tag) {
-            match template.acquire_deadline() {
-                Some(range) => Ok(Deadline {
-                    range,
-                    deadline_tag,
-                    monitor: self.clone(),
-                    state_index: template.assigned_state_index,
-                }),
-                None => Err(DeadlineMonitorError::DeadlineInUse),
-            }
-        } else {
-            Err(DeadlineMonitorError::DeadlineNotFound)
+// TODO: make part of `DeadlineMonitorInner` once `sync::ArcIn` can implement `Receiver` trait.
+fn get_deadline_inner(
+    this: &ProtectedArcIn<DeadlineMonitorInner>,
+    deadline_tag: DeadlineTag,
+) -> Result<Deadline, DeadlineMonitorError> {
+    if let Some(template) = this.deadlines.get(&deadline_tag) {
+        match template.acquire_deadline() {
+            Some(range) => Ok(Deadline {
+                range,
+                deadline_tag,
+                monitor: this.clone(),
+                state_index: template.assigned_state_index,
+            }),
+            None => Err(DeadlineMonitorError::DeadlineInUse),
         }
+    } else {
+        Err(DeadlineMonitorError::DeadlineNotFound)
     }
 }
 
 #[score_testing_macros::test_mod_with_log]
 #[cfg(all(test, not(loom)))]
 mod tests {
-    use super::*;
+    use crate::common::{MonitorEvaluator, TimeRange};
+    use crate::deadline::{
+        DeadlineError, DeadlineEvaluationError, DeadlineMonitor, DeadlineMonitorBuilder, DeadlineMonitorError,
+    };
+    use crate::protected_memory::ProtectedMemoryAllocator;
+    use crate::tag::{DeadlineTag, MonitorTag};
+    use std::time::Instant;
 
     fn create_monitor_with_deadlines() -> DeadlineMonitor {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("deadline_monitor");
         DeadlineMonitorBuilder::new()
             .add_deadline(
@@ -359,11 +378,11 @@ mod tests {
                     core::time::Duration::from_millis(50),
                 ),
             )
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
     }
 
     fn create_monitor_with_multiple_running_deadlines() -> DeadlineMonitor {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("deadline_monitor");
         DeadlineMonitorBuilder::new()
             .add_deadline(
@@ -391,7 +410,7 @@ mod tests {
                     core::time::Duration::from_millis(10),
                 ),
             )
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
     }
 
     #[test]

--- a/score/health_monitor/src/rust/deadline/ffi.rs
+++ b/score/health_monitor/src/rust/deadline/ffi.rs
@@ -337,6 +337,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_deadline_monitor(
@@ -384,6 +385,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -444,6 +446,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_deadline_monitor(
@@ -488,6 +491,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -542,6 +546,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_deadline_monitor(
@@ -589,6 +594,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -646,6 +652,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),

--- a/score/health_monitor/src/rust/ffi.rs
+++ b/score/health_monitor/src/rust/ffi.rs
@@ -110,6 +110,7 @@ pub extern "C" fn health_monitor_builder_destroy(health_monitor_builder_handle: 
 #[unsafe(no_mangle)]
 pub extern "C" fn health_monitor_builder_build(
     health_monitor_builder_handle: FFIHandle,
+    allocator_capacity: *const usize,
     supervisor_cycle_ms: *const u64,
     internal_cycle_ms: *const u64,
     thread_parameters_handle: FFIHandle,
@@ -127,8 +128,12 @@ pub extern "C" fn health_monitor_builder_build(
         unsafe { Box::from_raw(health_monitor_builder_handle as *mut HealthMonitorBuilder) };
 
     // SAFETY:
-    // `supervisor_cycle_ms` and `internal_cycle_ms` must be a valid pointer when non-null.
+    // `allocator_capacity`, `supervisor_cycle_ms` and `internal_cycle_ms` must be a valid pointer when non-null.
     // Values are considered unset on null.
+    if !allocator_capacity.is_null() {
+        let allocator_capacity = unsafe { *allocator_capacity };
+        health_monitor_builder.allocator_capacity_internal(allocator_capacity);
+    }
     if !internal_cycle_ms.is_null() {
         let internal_cycle_ms = Duration::from_millis(unsafe { *internal_cycle_ms });
         health_monitor_builder.with_internal_processing_cycle_internal(internal_cycle_ms);
@@ -480,6 +485,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         assert!(!health_monitor_handle.is_null());
@@ -510,6 +516,7 @@ mod tests {
         let internal_cycle_ms = 100u64;
         let health_monitor_builder_build_result = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             &supervisor_cycle_ms as *const _,
             &internal_cycle_ms as *const _,
             null_mut(),
@@ -525,6 +532,36 @@ mod tests {
     }
 
     #[test]
+    fn health_monitor_builder_build_invalid_allocator_capacity() {
+        let mut health_monitor_builder_handle: FFIHandle = null_mut();
+        let mut health_monitor_handle: FFIHandle = null_mut();
+        let mut deadline_monitor_builder_handle = null_mut();
+
+        let _ = health_monitor_builder_create(&mut health_monitor_builder_handle as *mut FFIHandle);
+        let deadline_monitor_tag = MonitorTag::from("deadline_monitor");
+        let _ = deadline_monitor_builder_create(&mut deadline_monitor_builder_handle as *mut FFIHandle);
+        let _ = health_monitor_builder_add_deadline_monitor(
+            health_monitor_builder_handle,
+            &deadline_monitor_tag as *const MonitorTag,
+            deadline_monitor_builder_handle,
+        );
+
+        let allocator_capacity = 0usize;
+        let health_monitor_builder_build_result = health_monitor_builder_build(
+            health_monitor_builder_handle,
+            &allocator_capacity as *const _,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            &mut health_monitor_handle as *mut FFIHandle,
+        );
+        assert!(health_monitor_handle.is_null());
+        assert_eq!(health_monitor_builder_build_result, FFICode::InvalidArgument);
+
+        // Clean-up not needed - health monitor builder was already consumed by the `build`.
+    }
+
+    #[test]
     fn health_monitor_builder_build_invalid_cycle_intervals() {
         let mut health_monitor_builder_handle: FFIHandle = null_mut();
         let mut health_monitor_handle: FFIHandle = null_mut();
@@ -535,6 +572,7 @@ mod tests {
         let internal_cycle_ms = 100u64;
         let health_monitor_builder_build_result = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             &supervisor_cycle_ms as *const _,
             &internal_cycle_ms as *const _,
             null_mut(),
@@ -558,6 +596,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         assert_eq!(health_monitor_builder_build_result, FFICode::WrongState);
@@ -570,6 +609,7 @@ mod tests {
         let mut health_monitor_handle: FFIHandle = null_mut();
 
         let health_monitor_builder_build_result = health_monitor_builder_build(
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -588,6 +628,7 @@ mod tests {
 
         let health_monitor_builder_build_result = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -619,6 +660,7 @@ mod tests {
 
         let health_monitor_builder_build_result = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             thread_parameters_handle,
@@ -912,6 +954,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -946,6 +989,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -995,6 +1039,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1027,6 +1072,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1064,6 +1110,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1095,6 +1142,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1132,6 +1180,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1181,6 +1230,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1213,6 +1263,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1250,6 +1301,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1280,6 +1332,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1316,6 +1369,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1364,6 +1418,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1398,6 +1453,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1428,6 +1484,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -1466,6 +1523,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
 
@@ -1499,6 +1557,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),

--- a/score/health_monitor/src/rust/health_monitor.rs
+++ b/score/health_monitor/src/rust/health_monitor.rs
@@ -42,6 +42,7 @@ pub struct HealthMonitorBuilder {
     deadline_monitor_builders: HashMap<MonitorTag, DeadlineMonitorBuilder>,
     heartbeat_monitor_builders: HashMap<MonitorTag, HeartbeatMonitorBuilder>,
     logic_monitor_builders: HashMap<MonitorTag, LogicMonitorBuilder>,
+    allocator_capacity: usize,
     supervisor_api_cycle: Duration,
     internal_processing_cycle: Duration,
     thread_parameters: ThreadParameters,
@@ -54,6 +55,7 @@ impl HealthMonitorBuilder {
             deadline_monitor_builders: HashMap::new(),
             heartbeat_monitor_builders: HashMap::new(),
             logic_monitor_builders: HashMap::new(),
+            allocator_capacity: 1024 * 1024,
             supervisor_api_cycle: Duration::from_millis(500),
             internal_processing_cycle: Duration::from_millis(100),
             thread_parameters: ThreadParameters::default(),
@@ -96,6 +98,14 @@ impl HealthMonitorBuilder {
     /// If a logic monitor with the same tag already exists, it will be overwritten.
     pub fn add_logic_monitor(mut self, monitor_tag: MonitorTag, monitor_builder: LogicMonitorBuilder) -> Self {
         self.add_logic_monitor_internal(monitor_tag, monitor_builder);
+        self
+    }
+
+    /// Set protected memory allocator capacity.
+    ///
+    /// - `allocator_capacity` - allocator capacity, rounded up to a page size.
+    pub fn allocator_capacity(mut self, allocator_capacity: usize) -> Self {
+        self.allocator_capacity_internal(allocator_capacity);
         self
     }
 
@@ -148,26 +158,32 @@ impl HealthMonitorBuilder {
         }
 
         // Create allocator.
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = match ProtectedMemoryAllocator::new(self.allocator_capacity) {
+            Ok(allocator) => allocator,
+            Err(e) => {
+                error!("Failed to create allocator: {:?}", e);
+                return Err(HealthMonitorError::InvalidArgument);
+            },
+        };
 
         // Create deadline monitors.
         let mut deadline_monitors = HashMap::new();
         for (tag, builder) in self.deadline_monitor_builders {
-            let monitor = builder.build(tag, &allocator);
+            let monitor = builder.build(tag, allocator.clone());
             deadline_monitors.insert(tag, Some(MonitorState::Available(monitor)));
         }
 
         // Create heartbeat monitors.
         let mut heartbeat_monitors = HashMap::new();
         for (tag, builder) in self.heartbeat_monitor_builders {
-            let monitor = builder.build(tag, self.internal_processing_cycle, &allocator)?;
+            let monitor = builder.build(tag, self.internal_processing_cycle, allocator.clone())?;
             heartbeat_monitors.insert(tag, Some(MonitorState::Available(monitor)));
         }
 
         // Create logic monitors.
         let mut logic_monitors = HashMap::new();
         for (tag, builder) in self.logic_monitor_builders {
-            let monitor = builder.build(tag, &allocator)?;
+            let monitor = builder.build(tag, allocator.clone())?;
             logic_monitors.insert(tag, Some(MonitorState::Available(monitor)));
         }
 
@@ -200,6 +216,10 @@ impl HealthMonitorBuilder {
 
     pub(crate) fn add_logic_monitor_internal(&mut self, monitor_tag: MonitorTag, monitor_builder: LogicMonitorBuilder) {
         self.logic_monitor_builders.insert(monitor_tag, monitor_builder);
+    }
+
+    pub(crate) fn allocator_capacity_internal(&mut self, allocator_capacity: usize) {
+        self.allocator_capacity = allocator_capacity;
     }
 
     pub(crate) fn with_supervisor_api_cycle_internal(&mut self, cycle_duration: Duration) {
@@ -395,6 +415,7 @@ mod tests {
         assert!(health_monitor_builder.deadline_monitor_builders.is_empty());
         assert!(health_monitor_builder.heartbeat_monitor_builders.is_empty());
         assert!(health_monitor_builder.logic_monitor_builders.is_empty());
+        assert_eq!(health_monitor_builder.allocator_capacity, 1024 * 1024);
         assert_eq!(health_monitor_builder.supervisor_api_cycle, Duration::from_millis(500));
         assert_eq!(
             health_monitor_builder.internal_processing_cycle,
@@ -432,6 +453,40 @@ mod tests {
     fn health_monitor_builder_build_no_monitors() {
         let result = HealthMonitorBuilder::new().build();
         assert!(result.is_err_and(|e| e == HealthMonitorError::WrongState));
+    }
+
+    #[test]
+    fn health_monitor_builder_allocator_capacity_sets() {
+        let deadline_monitor_tag = MonitorTag::from("deadline_monitor");
+        let deadline_monitor_builder = DeadlineMonitorBuilder::new();
+        let capacity = 4 * 1024 * 1024;
+
+        // Check set internally.
+        let builder = HealthMonitorBuilder::new()
+            .add_deadline_monitor(deadline_monitor_tag, deadline_monitor_builder)
+            .allocator_capacity(capacity);
+        assert_eq!(builder.allocator_capacity, capacity);
+
+        // Check builds.
+        let result = builder.build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn health_monitor_builder_allocator_capacity_invalid() {
+        let deadline_monitor_tag = MonitorTag::from("deadline_monitor");
+        let deadline_monitor_builder = DeadlineMonitorBuilder::new();
+        let capacity = 0;
+
+        // Check set internally.
+        let builder = HealthMonitorBuilder::new()
+            .add_deadline_monitor(deadline_monitor_tag, deadline_monitor_builder)
+            .allocator_capacity(capacity);
+        assert_eq!(builder.allocator_capacity, capacity);
+
+        // Check error propagates.
+        let result = builder.build();
+        assert!(result.is_err_and(|e| e == HealthMonitorError::InvalidArgument));
     }
 
     #[test]

--- a/score/health_monitor/src/rust/heartbeat/ffi.rs
+++ b/score/health_monitor/src/rust/heartbeat/ffi.rs
@@ -166,6 +166,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_heartbeat_monitor(

--- a/score/health_monitor/src/rust/heartbeat/heartbeat_monitor.rs
+++ b/score/health_monitor/src/rust/heartbeat/heartbeat_monitor.rs
@@ -17,12 +17,11 @@ use crate::common::{
 use crate::health_monitor::HealthMonitorError;
 use crate::heartbeat::heartbeat_state::HeartbeatState;
 use crate::log::{error, warn};
-use crate::protected_memory::ProtectedMemoryAllocator;
+use crate::protected_memory::{ProtectedArcIn, ProtectedMemoryAllocator};
 use crate::tag::MonitorTag;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::time::Duration;
 use score_log::ScoreDebug;
-use std::sync::Arc;
 use std::time::Instant;
 
 /// Heartbeat evaluation errors.
@@ -55,12 +54,12 @@ impl HeartbeatMonitorBuilder {
     ///
     /// - `monitor_tag` - tag of this monitor.
     /// - `internal_processing_cycle` - health monitor processing cycle.
-    /// - `_allocator` - protected memory allocator.
+    /// - `allocator` - protected memory allocator.
     pub(crate) fn build(
         self,
         monitor_tag: MonitorTag,
         internal_processing_cycle: Duration,
-        _allocator: &ProtectedMemoryAllocator,
+        allocator: ProtectedMemoryAllocator,
     ) -> Result<HeartbeatMonitor, HealthMonitorError> {
         // Check range is valid.
         let range_min_ms = self.range.min.as_millis() as u64;
@@ -73,19 +72,19 @@ impl HeartbeatMonitorBuilder {
             return Err(HealthMonitorError::InvalidArgument);
         }
 
-        let inner = Arc::new(HeartbeatMonitorInner::new(monitor_tag, self.range));
+        let inner = ProtectedArcIn::new_in(HeartbeatMonitorInner::new(monitor_tag, self.range), allocator);
         Ok(HeartbeatMonitor::new(inner))
     }
 }
 
 /// Heartbeat monitor.
 pub struct HeartbeatMonitor {
-    inner: Arc<HeartbeatMonitorInner>,
+    inner: ProtectedArcIn<HeartbeatMonitorInner>,
 }
 
 impl HeartbeatMonitor {
     /// Create a new [`HeartbeatMonitor`] instance.
-    fn new(inner: Arc<HeartbeatMonitorInner>) -> Self {
+    fn new(inner: ProtectedArcIn<HeartbeatMonitorInner>) -> Self {
         Self { inner }
     }
 
@@ -97,7 +96,7 @@ impl HeartbeatMonitor {
 
 impl Monitor for HeartbeatMonitor {
     fn get_eval_handle(&self) -> MonitorEvalHandle {
-        MonitorEvalHandle::new(Arc::clone(&self.inner))
+        MonitorEvalHandle::new(ProtectedArcIn::clone(&self.inner))
     }
 }
 
@@ -291,8 +290,8 @@ mod tests {
         let range = TimeRange::new(Duration::from_millis(500), Duration::from_millis(1000));
         let monitor_tag = MonitorTag::from("heartbeat_monitor");
         let internal_processing_cycle = Duration::from_millis(100);
-        let allocator = ProtectedMemoryAllocator {};
-        let result = HeartbeatMonitorBuilder::new(range).build(monitor_tag, internal_processing_cycle, &allocator);
+        let allocator = ProtectedMemoryAllocator::default();
+        let result = HeartbeatMonitorBuilder::new(range).build(monitor_tag, internal_processing_cycle, allocator);
         assert!(result.is_ok());
     }
 
@@ -301,17 +300,17 @@ mod tests {
         let range = TimeRange::new(Duration::from_millis(500), Duration::from_millis(1000));
         let monitor_tag = MonitorTag::from("heartbeat_monitor");
         let internal_processing_cycle = Duration::from_millis(1000);
-        let allocator = ProtectedMemoryAllocator {};
-        let result = HeartbeatMonitorBuilder::new(range).build(monitor_tag, internal_processing_cycle, &allocator);
+        let allocator = ProtectedMemoryAllocator::default();
+        let result = HeartbeatMonitorBuilder::new(range).build(monitor_tag, internal_processing_cycle, allocator);
         assert!(result.is_err_and(|e| e == HealthMonitorError::InvalidArgument));
     }
 
     fn create_monitor_single_cycle(range: TimeRange) -> HeartbeatMonitor {
         let monitor_tag = MonitorTag::from(TAG);
         let internal_processing_cycle = Duration::from_millis(1);
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         HeartbeatMonitorBuilder::new(range)
-            .build(monitor_tag, internal_processing_cycle, &allocator)
+            .build(monitor_tag, internal_processing_cycle, allocator)
             .unwrap()
     }
 
@@ -488,9 +487,9 @@ mod tests {
     fn create_monitor_multiple_cycles(cycle: Duration) -> Arc<HeartbeatMonitor> {
         let range = range_from_ms(80, 120);
         let monitor_tag = MonitorTag::from(TAG);
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor = HeartbeatMonitorBuilder::new(range)
-            .build(monitor_tag, cycle, &allocator)
+            .build(monitor_tag, cycle, allocator)
             .unwrap();
         Arc::new(monitor)
     }
@@ -689,9 +688,9 @@ mod loom_tests {
     fn create_monitor_single_cycle(range: TimeRange) -> Arc<HeartbeatMonitor> {
         let monitor_tag = MonitorTag::from(TAG);
         let internal_processing_cycle = Duration::from_millis(1);
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor = HeartbeatMonitorBuilder::new(range)
-            .build(monitor_tag, internal_processing_cycle, &allocator)
+            .build(monitor_tag, internal_processing_cycle, allocator)
             .unwrap();
         Arc::new(monitor)
     }

--- a/score/health_monitor/src/rust/logic/ffi.rs
+++ b/score/health_monitor/src/rust/logic/ffi.rs
@@ -353,6 +353,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_logic_monitor(
@@ -399,6 +400,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -459,6 +461,7 @@ mod tests {
             null_mut(),
             null_mut(),
             null_mut(),
+            null_mut(),
             &mut health_monitor_handle as *mut FFIHandle,
         );
         let _ = health_monitor_get_logic_monitor(
@@ -505,6 +508,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -556,6 +560,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),
@@ -616,6 +621,7 @@ mod tests {
         );
         let _ = health_monitor_builder_build(
             health_monitor_builder_handle,
+            null_mut(),
             null_mut(),
             null_mut(),
             null_mut(),

--- a/score/health_monitor/src/rust/logic/logic_monitor.rs
+++ b/score/health_monitor/src/rust/logic/logic_monitor.rs
@@ -15,12 +15,11 @@ use crate::common::{Monitor, MonitorEvalHandle, MonitorEvaluationError, MonitorE
 use crate::health_monitor::HealthMonitorError;
 use crate::log::{error, warn, ScoreDebug};
 use crate::logic::logic_state::LogicState;
-use crate::protected_memory::ProtectedMemoryAllocator;
+use crate::protected_memory::{ProtectedArcIn, ProtectedMemoryAllocator};
 use crate::tag::{MonitorTag, StateTag};
 use core::hash::Hash;
 use core::marker::PhantomData;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Instant;
 
 /// Internal OK state representation.
@@ -98,11 +97,11 @@ impl LogicMonitorBuilder {
     /// Build the [`LogicMonitor`].
     ///
     /// - `monitor_tag` - tag of this monitor.
-    /// - `_allocator` - protected memory allocator.
+    /// - `allocator` - protected memory allocator.
     pub(crate) fn build(
         self,
         monitor_tag: MonitorTag,
-        _allocator: &ProtectedMemoryAllocator,
+        allocator: ProtectedMemoryAllocator,
     ) -> Result<LogicMonitor, HealthMonitorError> {
         // Check number of states.
         if self.state_graph.is_empty() {
@@ -148,11 +147,10 @@ impl LogicMonitorBuilder {
             },
         };
 
-        let inner = Arc::new(LogicMonitorInner::new(
-            monitor_tag,
-            initial_state_index,
-            state_graph_vec,
-        ));
+        let inner = ProtectedArcIn::new_in(
+            LogicMonitorInner::new(monitor_tag, initial_state_index, state_graph_vec),
+            allocator,
+        );
         Ok(LogicMonitor::new(inner))
     }
 
@@ -165,13 +163,13 @@ impl LogicMonitorBuilder {
 
 /// Logic monitor.
 pub struct LogicMonitor {
-    inner: Arc<LogicMonitorInner>,
+    inner: ProtectedArcIn<LogicMonitorInner>,
     _unsync: PhantomUnsync,
 }
 
 impl LogicMonitor {
     /// Create a new [`LogicMonitor`] instance.
-    fn new(inner: Arc<LogicMonitorInner>) -> Self {
+    fn new(inner: ProtectedArcIn<LogicMonitorInner>) -> Self {
         Self {
             inner,
             _unsync: PhantomData,
@@ -192,7 +190,7 @@ impl LogicMonitor {
 
 impl Monitor for LogicMonitor {
     fn get_eval_handle(&self) -> MonitorEvalHandle {
-        MonitorEvalHandle::new(Arc::clone(&self.inner))
+        MonitorEvalHandle::new(ProtectedArcIn::clone(&self.inner))
     }
 }
 
@@ -317,41 +315,41 @@ mod tests {
 
     #[test]
     fn logic_monitor_builder_build_succeeds() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let result = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator);
+            .build(monitor_tag, allocator);
         assert!(result.is_ok());
     }
 
     #[test]
     fn logic_monitor_builder_build_no_states() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let initial_state = StateTag::from("initial");
-        let result = LogicMonitorBuilder::new(initial_state).build(monitor_tag, &allocator);
+        let result = LogicMonitorBuilder::new(initial_state).build(monitor_tag, allocator);
         assert!(result.is_err_and(|e| e == HealthMonitorError::WrongState));
     }
 
     #[test]
     fn logic_monitor_builder_build_undefined_target() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let result = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
-            .build(monitor_tag, &allocator);
+            .build(monitor_tag, allocator);
         assert!(result.is_err_and(|e| e == HealthMonitorError::InvalidArgument));
     }
 
     #[test]
     fn logic_monitor_builder_build_undefined_initial_state() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let initial_state = StateTag::from("initial");
         let from_state = StateTag::from("from");
@@ -359,20 +357,20 @@ mod tests {
         let result = LogicMonitorBuilder::new(initial_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator);
+            .build(monitor_tag, allocator);
         assert!(result.is_err_and(|e| e == HealthMonitorError::InvalidArgument));
     }
 
     #[test]
     fn logic_monitor_transition_succeeds() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         let result = monitor.transition(to_state);
@@ -381,14 +379,14 @@ mod tests {
 
     #[test]
     fn logic_monitor_transition_unknown_node() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         let result = monitor.transition(StateTag::from("unknown"));
@@ -397,14 +395,14 @@ mod tests {
 
     #[test]
     fn logic_monitor_transition_indeterminate_current_state() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         // Trying to transition into unknown state causes monitor to move into indeterminate state.
@@ -417,7 +415,7 @@ mod tests {
 
     #[test]
     fn logic_monitor_transition_invalid_transition() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let state1 = StateTag::from("state1");
         let state2: StateTag = StateTag::from("state2");
@@ -426,7 +424,7 @@ mod tests {
             .add_state(state1, &[state2])
             .add_state(state2, &[state3])
             .add_state(state3, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         let result = monitor.transition(state3);
@@ -435,7 +433,7 @@ mod tests {
 
     #[test]
     fn logic_monitor_state_succeeds() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let state1 = StateTag::from("state1");
         let state2: StateTag = StateTag::from("state2");
@@ -444,7 +442,7 @@ mod tests {
             .add_state(state1, &[state2])
             .add_state(state2, &[state3])
             .add_state(state3, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         // Check state, perform transition to the next one.
@@ -462,14 +460,14 @@ mod tests {
 
     #[test]
     fn logic_monitor_state_indeterminate_current_state() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
 
         // Trying to transition into unknown state causes monitor to move into indeterminate state.
@@ -482,14 +480,14 @@ mod tests {
 
     #[test]
     fn logic_monitor_evaluate_succeeds() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
         let hmon_starting_point = Instant::now();
 
@@ -506,14 +504,14 @@ mod tests {
 
     #[test]
     fn logic_monitor_evaluate_invalid_state() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let from_state = StateTag::from("from");
         let to_state = StateTag::from("to");
         let monitor = LogicMonitorBuilder::new(from_state)
             .add_state(from_state, &[to_state])
             .add_state(to_state, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
         let hmon_starting_point = Instant::now();
 
@@ -536,7 +534,7 @@ mod tests {
 
     #[test]
     fn logic_monitor_evaluate_invalid_transition() {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("logic_monitor");
         let state1 = StateTag::from("state1");
         let state2: StateTag = StateTag::from("state2");
@@ -545,7 +543,7 @@ mod tests {
             .add_state(state1, &[state2])
             .add_state(state2, &[state3])
             .add_state(state3, &[])
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
             .unwrap();
         let hmon_starting_point = Instant::now();
 

--- a/score/health_monitor/src/rust/protected_memory.rs
+++ b/score/health_monitor/src/rust/protected_memory.rs
@@ -10,9 +10,47 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
-#![allow(dead_code)]
 
-///
+use allocator::{AllocationError, ArenaAllocator, BasicAllocator, MmapMemoryRegion};
+use core::alloc::Layout;
+use core::ptr::NonNull;
+
+/// Alias to [`sync::ArcIn`] using [`ProtectedMemoryAllocator`].
+pub type ProtectedArcIn<T> = sync::ArcIn<T, ProtectedMemoryAllocator>;
+
 /// A memory allocator that provides protected memory regions for health monitoring data structures.
-/// TODO: Implement the protected memory allocation logic.
-pub struct ProtectedMemoryAllocator {}
+pub struct ProtectedMemoryAllocator(ArenaAllocator<MmapMemoryRegion>);
+
+impl ProtectedMemoryAllocator {
+    /// Create a new allocator.
+    ///
+    /// - `capacity` - allocator capacity in bytes.
+    pub fn new(capacity: usize) -> Result<Self, AllocationError> {
+        let memory_region = MmapMemoryRegion::new(capacity)?;
+        let allocator = ArenaAllocator::new(memory_region)?;
+        Ok(Self(allocator))
+    }
+}
+
+impl BasicAllocator for ProtectedMemoryAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocationError> {
+        self.0.allocate(layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        self.0.deallocate(ptr, layout);
+    }
+}
+
+impl Default for ProtectedMemoryAllocator {
+    fn default() -> Self {
+        const DEFAULT_CAPACITY: usize = 1024 * 1024;
+        Self::new(DEFAULT_CAPACITY).expect("failed to create allocator with default capacity")
+    }
+}
+
+impl Clone for ProtectedMemoryAllocator {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}

--- a/score/health_monitor/src/rust/worker.rs
+++ b/score/health_monitor/src/rust/worker.rs
@@ -211,7 +211,7 @@ mod tests {
     }
 
     fn create_monitor_with_deadlines() -> DeadlineMonitor {
-        let allocator = ProtectedMemoryAllocator {};
+        let allocator = ProtectedMemoryAllocator::default();
         let monitor_tag = MonitorTag::from("deadline_monitor");
         DeadlineMonitorBuilder::new()
             .add_deadline(
@@ -222,7 +222,7 @@ mod tests {
                 DeadlineTag::from("deadline_fast"),
                 TimeRange::new(Duration::from_millis(0), Duration::from_millis(50)),
             )
-            .build(monitor_tag, &allocator)
+            .build(monitor_tag, allocator)
     }
 
     #[test]


### PR DESCRIPTION
- Provide `ProtectedMemoryAllocator` - an arena allocator working on mmap-provided memory region.
- Add `allocator_capacity` builder parameter.
- Replace `std::sync::Arc` with `sync::ArcIn` from `baselibs`.
- Use `FixedCapacityVec` for active deadlines in deadline monitor.
- Update deprecated target names in Bazel files.

WIP: awaits for changes to `baselibs` to be merged, update build system files once done. This prevents CI workflows from working.
- https://github.com/eclipse-score/baselibs/pull/366
- https://github.com/eclipse-score/baselibs/pull/373
- https://github.com/eclipse-score/baselibs/pull/374

Resolves #117 