### PR TITLE
Fixing flaky fd leak test

### DIFF
--- a/tests/integration/process_fd_leak/BUILD
+++ b/tests/integration/process_fd_leak/BUILD
@@ -16,6 +16,7 @@ load("//tests/utils/bazel:integration.bzl", "integration_test")
 cc_binary(
     name = "native",
     srcs = [
+        "common.hpp",
         "get_fds.hpp",
         "native.cpp",
     ],
@@ -29,6 +30,7 @@ cc_binary(
 cc_binary(
     name = "reporting",
     srcs = [
+        "common.hpp",
         "get_fds.hpp",
         "reporting.cpp",
     ],
@@ -42,6 +44,7 @@ cc_binary(
 cc_binary(
     name = "control_client",
     srcs = [
+        "common.hpp",
         "control_client.cpp",
         "get_fds.hpp",
     ],

--- a/tests/integration/process_fd_leak/common.hpp
+++ b/tests/integration/process_fd_leak/common.hpp
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#ifndef PROCESS_FD_LEAK_HPP_
+#define PROCESS_FD_LEAK_HPP_
+
+#include <string_view>
+
+// Macros for consistent, constexpr names of marker files across test processes
+
+#define PROC_FILES(x)                                               \
+    constexpr std::string_view x##_terminating = "proc_" #x "_terminating";
+
+PROC_FILES(native)
+PROC_FILES(reporting)
+
+#undef PROC_FILES
+
+#endif  // PROCESS_FD_LEAK_HPP_

--- a/tests/integration/process_fd_leak/control_client.cpp
+++ b/tests/integration/process_fd_leak/control_client.cpp
@@ -12,8 +12,12 @@
  ********************************************************************************/
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <ios>
 #include <sstream>
+#include <thread>
 
+#include "common.hpp"
 #include "get_fds.hpp"
 #include "tests/utils/test_helper/test_helper.hpp"
 #include <score/mw/lifecycle/control_client.h>
@@ -58,6 +62,16 @@ TEST(ControlClientFDs, FindOpenFDs)
         oss << open_fds;
         EXPECT_TRUE(open_fds.empty()) << "Found open files!\n" << oss.str();
     }
+
+    TEST_STEP("Wait for other procs to finish")
+    {
+        while (!std::filesystem::exists(reporting_terminating) || !std::filesystem::exists(native_terminating))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        ASSERT_TRUE(touch_file(test_end_location));
+    }
 }
 
 int main(int argc, char** argv)
@@ -65,7 +79,11 @@ int main(int argc, char** argv)
     g_argc = argc;
     g_argv = argv;
 
-    TestRunner runner{__FILE__, TerminationBehavior::kContinue, TerminationNotification::kTestEnd};
+    // test end file is made in the test so that we block to wait for other
+    // procs to finish
+    TestRunner runner{__FILE__, TerminationBehavior::kWait, TerminationNotification::kNone};
 
-    return runner.RunTests();
+    auto result = runner.RunTests();
+
+    return result;
 }

--- a/tests/integration/process_fd_leak/get_fds.hpp
+++ b/tests/integration/process_fd_leak/get_fds.hpp
@@ -20,12 +20,14 @@
 #include <cstring>
 #include <iostream>
 #include <ostream>
-#include <sstream>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#ifndef GET_FDS_HPP_
+#define GET_FDS_HPP_
 
 inline std::ostream& operator<<(std::ostream& outstream, const std::vector<std::pair<std::uint32_t, std::string>>& data)
 {
@@ -35,7 +37,6 @@ inline std::ostream& operator<<(std::ostream& outstream, const std::vector<std::
     }
     return outstream;
 }
-
 
 /// @brief Given the list of FDs and their paths, removes entries whose path
 ///        matches the regex.
@@ -172,5 +173,7 @@ inline std::vector<std::pair<std::uint32_t, std::string>> get_fds()
 
     ::closedir(fd_dir);
     return out_vector;
-#endif
+#endif  //__QNXNTO__
 }
+
+#endif  // GET_FDS_HPP_

--- a/tests/integration/process_fd_leak/native.cpp
+++ b/tests/integration/process_fd_leak/native.cpp
@@ -15,6 +15,7 @@
 #include <sstream>
 
 #include "get_fds.hpp"
+#include "common.hpp"
 #include "tests/utils/test_helper/test_helper.hpp"
 
 int g_argc;
@@ -26,6 +27,8 @@ TEST(NativeFDs, FindOpenFDs)
     std::ostringstream oss;
     oss << open_fds;
     EXPECT_TRUE(open_fds.empty()) << "Found open files!\n" << oss.str();
+
+    ASSERT_TRUE(touch_file(native_terminating));
 }
 
 int main(int argc, char** argv)

--- a/tests/integration/process_fd_leak/process_fd_leak.json
+++ b/tests/integration/process_fd_leak/process_fd_leak.json
@@ -28,7 +28,10 @@
         "component_properties": {
             "application_profile": {
                 "application_type": "Native",
-                "is_self_terminating": true
+                "is_self_terminating": true,
+                "alive_supervision": {
+                    "min_indications": 0
+                    }
             },
             "ready_condition": {
                 "process_state": "Running"

--- a/tests/integration/process_fd_leak/reporting.cpp
+++ b/tests/integration/process_fd_leak/reporting.cpp
@@ -15,6 +15,7 @@
 #include <sstream>
 
 #include "get_fds.hpp"
+#include "common.hpp"
 #include "tests/utils/test_helper/test_helper.hpp"
 #include <score/mw/lifecycle/report_running.h>
 
@@ -41,6 +42,8 @@ TEST(ReportingProcessFDs, FindOpenFDs)
         oss << open_fds;
         EXPECT_TRUE(open_fds.empty()) << "Found open files!\n" << oss.str();
     }
+
+    ASSERT_TRUE(touch_file(reporting_terminating));
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Previously the test relied on the control client to finish last, this was changed so it now waits at the end for others to finish.