### PR TITLE
Rename the C and Rust report running APIs to match the C++ API

### DIFF
--- a/examples/c_supervised_app/main.c
+++ b/examples/c_supervised_app/main.c
@@ -41,7 +41,7 @@ int main(void)
         return EXIT_FAILURE;
     }
 
-    if (score_lcm_report_running() != 0)
+    if (score_mw_lifecycle_report_running() != 0)
     {
         fprintf(stderr, "Failed to report running state\n");
         score_lcm_alive_deinitialize(alive);

--- a/examples/rust_supervised_app/src/main.rs
+++ b/examples/rust_supervised_app/src/main.rs
@@ -77,7 +77,7 @@ fn main_logic(args: &Args, stop: Arc<AtomicBool>) -> Result<(), Box<dyn std::err
 
     hm.start();
 
-    if !lifecycle_client_rs::report_execution_state_running() {
+    if !lifecycle_client_rs::report_running() {
         error!("Rust app FAILED to report execution state!");
         return Err("Failed to report execution state".into());
     }

--- a/score/launch_manager/src/lifecycle_client/src/report_running.cpp
+++ b/score/launch_manager/src/lifecycle_client/src/report_running.cpp
@@ -22,7 +22,7 @@ void score::mw::lifecycle::report_running() noexcept {
 extern "C" {
 #endif
 
-int8_t score_lcm_report_running(void) {
+int8_t score_mw_lifecycle_report_running(void) {
     // RULECHECKER_comment(1, 2, check_static_object_dynamic_initialization, "static variable is in function scope so this initialization is safe", false)
     static score::mw::lifecycle::ReportRunningImpl g_impl{};
     const auto result = g_impl.ReportRunningState();

--- a/score/launch_manager/src/lifecycle_client/src/report_running.h
+++ b/score/launch_manager/src/lifecycle_client/src/report_running.h
@@ -54,7 +54,7 @@ extern "C" {
 
 /// @brief Signals to the Launch Manager that this process has finished initialization and is now running.
 /// @return 0 on success, -1 on failure
-int8_t score_lcm_report_running(void);
+int8_t score_mw_lifecycle_report_running(void);
 
 #ifdef __cplusplus
 }

--- a/score/launch_manager/src/lifecycle_client/src/rust/src/lib.rs
+++ b/score/launch_manager/src/lifecycle_client/src/rust/src/lib.rs
@@ -12,4 +12,4 @@
 // *******************************************************************************
 pub mod lifecycle;
 
-pub use lifecycle::report_execution_state_running;
+pub use lifecycle::report_running;

--- a/score/launch_manager/src/lifecycle_client/src/rust/src/lifecycle.rs
+++ b/score/launch_manager/src/lifecycle_client/src/rust/src/lifecycle.rs
@@ -14,9 +14,9 @@ use libc::c_int;
 
 #[link(name = "report_running")]
 unsafe extern "C" {
-    fn score_lcm_report_running() -> c_int;
+    fn score_mw_lifecycle_report_running() -> c_int;
 }
 
-pub fn report_execution_state_running() -> bool {
-    unsafe { score_lcm_report_running() == 0 }
+pub fn report_running() -> bool {
+    unsafe { score_mw_lifecycle_report_running() == 0 }
 }


### PR DESCRIPTION
This PR updates the C and Rust "report running" API names to match the C++ API name.
We would like the API names to be consistent to they are easier to work with.