### PR TITLE
Introduce watchdog into ProcessGroupManager [2/N]: Update watchdog namespace and include paths

### DIFF
--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -18,7 +18,7 @@
 #include <score/assert.hpp>
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/WatchdogImpl.hpp"
+#include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
 namespace score
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -26,11 +26,11 @@ namespace lcm {
 
 class IRecoveryClient;
 
-namespace saf {
-
 namespace watchdog {
 class IWatchdogIf;
 }
+
+namespace saf {
 
 namespace daemon {
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -25,7 +25,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessStateReader.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimer.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IWatchdogIf.hpp"
+#include "score/mw/launch_manager/watchdog/IWatchdogIf.hpp"
 #ifdef USE_NEW_CONFIGURATION
 #include "score/mw/launch_manager/configuration/config.hpp"
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/MachineConfigFactory.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include "score/mw/launch_manager/alive_monitor/details/factory/StaticConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IDeviceConfigFactory.hpp"
+#include "score/mw/launch_manager/watchdog/IDeviceConfigFactory.hpp"
 #ifdef USE_NEW_CONFIGURATION
 #include "score/mw/launch_manager/configuration/config.hpp"
 #else

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
@@ -18,7 +18,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/DataStructures.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IDeviceConfigFactory.hpp"
+#include "score/mw/launch_manager/watchdog/IDeviceConfigFactory.hpp"
 
 namespace score
 {

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -21,7 +21,7 @@
 #include "score/mw/launch_manager/common/log.hpp"
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/WatchdogImpl.hpp"
+#include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 #include "score/mw/launch_manager/process_group_manager/alive_monitor_thread.hpp"
 #include "score/mw/launch_manager/process_group_manager/process_group_manager.hpp"
 #include "score/mw/launch_manager/process_state_client/process_state_notifier.hpp"

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -205,8 +205,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
 #endif
         LM_LOG_DEBUG() << "Launch Manager Started !!!!";
         std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient{std::make_shared<score::lcm::RecoveryClient>()};
-        std::unique_ptr<score::lcm::saf::watchdog::IWatchdogIf> watchdog{
-            std::make_unique<score::lcm::saf::watchdog::WatchdogImpl>()};
+        std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog{
+            std::make_unique<score::lcm::watchdog::WatchdogImpl>()};
         auto process_state_notifier = std::make_unique<score::lcm::internal::ProcessStateNotifier>();
         std::unique_ptr<score::lcm::saf::daemon::IAliveMonitor> healthMonitor{
             std::make_unique<score::lcm::saf::daemon::AliveMonitorImpl>(

--- a/score/launch_manager/src/daemon/src/watchdog/BUILD
+++ b/score/launch_manager/src/daemon/src/watchdog/BUILD
@@ -15,7 +15,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "i_device_config_factory",
     hdrs = ["IDeviceConfigFactory.hpp"],
-    include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
+    include_prefix = "score/mw/launch_manager/watchdog",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/watchdog",
     visibility = ["//score:__subpackages__"],
 )
@@ -23,7 +23,7 @@ cc_library(
 cc_library(
     name = "i_watchdog_if",
     hdrs = ["IWatchdogIf.hpp"],
-    include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
+    include_prefix = "score/mw/launch_manager/watchdog",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/watchdog",
     visibility = ["//score:__subpackages__"],
     deps = [":i_device_config_factory"],

--- a/score/launch_manager/src/daemon/src/watchdog/IDeviceConfigFactory.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IDeviceConfigFactory.hpp
@@ -25,8 +25,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 namespace watchdog
 {
 
@@ -87,7 +85,6 @@ protected:
 };
 
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -23,8 +23,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 namespace watchdog
 {
 
@@ -126,7 +124,6 @@ protected:
 };
 
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IDeviceConfigFactory.hpp"
+#include "score/mw/launch_manager/watchdog/IDeviceConfigFactory.hpp"
 
 namespace score
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/BUILD
+++ b/score/launch_manager/src/daemon/src/watchdog/details/BUILD
@@ -15,7 +15,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "watchdog",
     hdrs = ["Watchdog.hpp"],
-    include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
+    include_prefix = "score/mw/launch_manager/watchdog/details",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/watchdog/details",
     visibility = ["//score:__subpackages__"],
 )
@@ -24,7 +24,7 @@ cc_library(
     name = "device_if",
     srcs = ["DeviceIf.cpp"],
     hdrs = ["DeviceIf.hpp"],
-    include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
+    include_prefix = "score/mw/launch_manager/watchdog/details",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/watchdog/details",
     visibility = ["//score:__subpackages__"],
     deps = ["@score_baselibs//score/language/futurecpp"],
@@ -34,7 +34,7 @@ cc_library(
     name = "watchdog_impl",
     srcs = ["WatchdogImpl.cpp"],
     hdrs = ["WatchdogImpl.hpp"],
-    include_prefix = "score/mw/launch_manager/alive_monitor/details/watchdog",
+    include_prefix = "score/mw/launch_manager/watchdog/details",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/watchdog/details",
     visibility = ["//score:__subpackages__"],
     deps = [

--- a/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.cpp
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/DeviceIf.hpp"
+#include "score/mw/launch_manager/watchdog/details/DeviceIf.hpp"
 
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.cpp
@@ -24,8 +24,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 namespace watchdog
 {
 
@@ -58,6 +56,5 @@ std::int32_t DeviceIf::close(std::int32_t f_fd) noexcept
 }
 
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/DeviceIf.hpp
@@ -22,8 +22,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 namespace watchdog
 {
 
@@ -70,7 +68,6 @@ public:
 };
 
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/Watchdog.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/Watchdog.hpp
@@ -30,30 +30,30 @@ constexpr std::int32_t WDIOS_DISABLECARD{0x0001};
 
 /* RULECHECKER_comment(0,4, check_underlying_narrowing_conversion, "No narrowing conversion", false) */
 /* RULECHECKER_comment(0,3, check_c_style_cast, "Use of POSIX header functionality", false) */
-constexpr score::lcm::saf::watchdog::DeviceIf::IoctlRequestType WDIOC_SETOPTIONS{
+constexpr score::lcm::watchdog::DeviceIf::IoctlRequestType WDIOC_SETOPTIONS{
     _IOW(WATCHDOG_IOCTL_BASE, 4, int32_t)};
 
 /* RULECHECKER_comment(0,4, check_underlying_narrowing_conversion, "No narrowing conversion", false) */
 /* RULECHECKER_comment(0,3, check_c_style_cast, "Use of POSIX header functionality", false) */
 // coverity[autosar_cpp14_m3_4_1_violation] definition in header is intended to replicate the linux/watchdog.h
-constexpr score::lcm::saf::watchdog::DeviceIf::IoctlRequestType WDIOC_KEEPALIVE{_IOR(WATCHDOG_IOCTL_BASE, 5, int32_t)};
+constexpr score::lcm::watchdog::DeviceIf::IoctlRequestType WDIOC_KEEPALIVE{_IOR(WATCHDOG_IOCTL_BASE, 5, int32_t)};
 
 /* RULECHECKER_comment(0,5, check_underlying_narrowing_conversion, "No narrowing conversion", false) */
 /* RULECHECKER_comment(0,4, check_c_style_cast, "Use of POSIX header functionality", false) */
 // coverity[autosar_cpp14_m3_4_1_violation] definition in header is intended to replicate the linux/watchdog.h
-constexpr score::lcm::saf::watchdog::DeviceIf::IoctlRequestType WDIOC_SETTIMEOUT{
+constexpr score::lcm::watchdog::DeviceIf::IoctlRequestType WDIOC_SETTIMEOUT{
     _IOWR(WATCHDOG_IOCTL_BASE, 6, int32_t)};
 
 /* RULECHECKER_comment(0,5, check_underlying_narrowing_conversion, "No narrowing conversion", false) */
 /* RULECHECKER_comment(0,4, check_c_style_cast, "Use of POSIX header functionality", false) */
 // coverity[autosar_cpp14_m3_4_1_violation] definition in header is intended to replicate the linux/watchdog.h
-constexpr score::lcm::saf::watchdog::DeviceIf::IoctlRequestType WDIOC_GETTIMEOUT{
+constexpr score::lcm::watchdog::DeviceIf::IoctlRequestType WDIOC_GETTIMEOUT{
     _IOR(WATCHDOG_IOCTL_BASE, 7, int32_t)};
 
 /* RULECHECKER_comment(0,5, check_underlying_narrowing_conversion, "No narrowing conversion", false) */
 /* RULECHECKER_comment(0,4, check_c_style_cast, "Use of POSIX header functionality", false) */
 // coverity[autosar_cpp14_m3_4_1_violation] definition in header is intended to replicate the linux/watchdog.h
-constexpr score::lcm::saf::watchdog::DeviceIf::IoctlRequestType WDIOC_GETTIMELEFT{
+constexpr score::lcm::watchdog::DeviceIf::IoctlRequestType WDIOC_GETTIMELEFT{
     _IOR(WATCHDOG_IOCTL_BASE, 10, int32_t)};
 #endif
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -27,8 +27,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 namespace watchdog
 {
 
@@ -470,7 +468,7 @@ bool WatchdogImpl::validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, co
 void WatchdogImpl::waitForever() const noexcept
 {
     // This code cannot be covered in tests, as it blocks execution forever
-    const timers::OsClockInterface clock{};
+    const score::lcm::saf::timers::OsClockInterface clock{};
     struct timespec sleeptime = {};
     sleeptime.tv_sec = 1;
     sleeptime.tv_nsec = 0;
@@ -484,6 +482,5 @@ void WatchdogImpl::waitForever() const noexcept
 #pragma CTC ENDSKIP
 #endif
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/WatchdogImpl.hpp"
+#include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 
 #include <fcntl.h>
@@ -20,8 +20,8 @@
 #include <unistd.h>
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/OsClockInterface.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/DeviceIf.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/Watchdog.hpp"
+#include "score/mw/launch_manager/watchdog/details/DeviceIf.hpp"
+#include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
 
 namespace score
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -25,8 +25,6 @@ namespace score
 {
 namespace lcm
 {
-namespace saf
-{
 
 namespace watchdog
 {
@@ -194,7 +192,6 @@ class WatchdogImpl : public IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace saf
 }  // namespace lcm
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -17,8 +17,8 @@
 #include <cstdint>
 #include <memory>
 
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IDeviceConfigFactory.hpp"
-#include "score/mw/launch_manager/alive_monitor/details/watchdog/IWatchdogIf.hpp"
+#include "score/mw/launch_manager/watchdog/IDeviceConfigFactory.hpp"
+#include "score/mw/launch_manager/watchdog/IWatchdogIf.hpp"
 #include <vector>
 
 namespace score


### PR DESCRIPTION
#330

This is part 2 of a number of PRs, to move the watchdog ownership to `ProcessGroupManager`.

This PR is purely a renaming of the watchdog namespace, and updating the include paths to reflect the new folder introduced in /pull/334. The following steps have been performed:
1.  The watchdog namespace is now `score::lcm::watchdog`, with all references consistent (The "saf" portion of the namespace is legacy, and does not reflect the current software design).
2. Update `include_prefix` in both watchdog `BUILD` files to reflect the new folder structure.
3. All `#include` lines across the repository have been rewritten to match the new folder structure.

