### PR TITLE
fix(lifecycle_client): link lifecycle_mock against lifecyclemanager t…

### DIFF
--- a/score/launch_manager/src/lifecycle_client/BUILD
+++ b/score/launch_manager/src/lifecycle_client/BUILD
@@ -186,6 +186,7 @@ cc_library(
     visibility = ["//score/launch_manager:__subpackages__"],
     deps = [
         ":applicationcontext_mock",
+        ":lifecyclemanager",
         "@googletest//:gtest",
         "@score_baselibs//score/os/utils:signal",
         "@score_baselibs//score/os/utils/mocklib:signal_mock",


### PR DESCRIPTION
…o resolve vtable

lifecycle_mock provides a mock implementation of LifeCycleManager, which inherits from the concrete class defined in lifecyclemanager.cpp. Without linking against the :lifecyclemanager target, the vtable symbol is undefined when building lifecycle_mock as a shared library (--no-allow-shlib-undefined).

Add :lifecyclemanager to lifecycle_mock's deps to provide the vtable.