### PR TITLE
hmon: Define configuration schema

### DIFF
--- a/score/health_monitor/configuration/health_monitor_config.example.json
+++ b/score/health_monitor/configuration/health_monitor_config.example.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "supervisor_api_cycle_ms": 100,
+  "internal_processing_cycle_ms": 50,
+  "thread_parameters": {
+    "policy": "POSIX_FIFO",
+    "priority": 20,
+    "affinity": [
+      0,
+      1
+    ],
+    "stack_size_bytes": 262144
+  },
+  "deadline_monitors": {
+    "control_loop_deadlines": {
+      "read_inputs": {
+        "min_ms": 1,
+        "max_ms": 5
+      },
+      "publish_outputs": {
+        "min_ms": 2,
+        "max_ms": 10
+      }
+    },
+    "communication_deadlines": {
+      "receive": {
+        "min_ms": 1,
+        "max_ms": 3
+      },
+      "transmit": {
+        "min_ms": 2,
+        "max_ms": 8
+      }
+    }
+  },
+  "heartbeat_monitors": {
+    "planner_heartbeat": {
+      "min_ms": 90,
+      "max_ms": 110
+    },
+    "worker_heartbeat": {
+      "min_ms": 40,
+      "max_ms": 60
+    }
+  },
+  "logic_monitors": {
+    "operation_mode_flow": {
+      "initial_state": "init",
+      "states": [
+        {
+          "init": [
+            "run",
+            "deinit"
+          ]
+        },
+        {
+          "run": [
+            "deinit"
+          ]
+        },
+        {
+          "deinit": []
+        }
+      ]
+    }
+  }
+}

--- a/score/health_monitor/configuration/health_monitor_config.fbs
+++ b/score/health_monitor/configuration/health_monitor_config.fbs
@@ -1,0 +1,82 @@
+// ********************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// ********************************************************************************
+
+namespace score.mw.health.config;
+
+file_identifier "HMCF";
+file_extension "bin";
+
+/// Scheduler policy for the monitoring thread.
+enum SchedulerPolicy : byte {
+  POSIX_OTHER = 0,
+  POSIX_FIFO = 1,
+  POSIX_RR = 2
+}
+
+/// Thread parameters for the monitoring thread.
+table ThreadParameters {
+  policy: SchedulerPolicy = null;
+  priority: int32 = null;
+  affinity: [uint32];
+  stack_size: uint32 = null;
+}
+
+/// A time range with minimum and maximum durations in milliseconds.
+table TimeRange {
+  min_ms: uint32;
+  max_ms: uint32;
+}
+
+/// A single deadline entry within a deadline monitor.
+table DeadlineEntry {
+  deadline_tag: string (required);
+  range: TimeRange (required);
+}
+
+/// Configuration for a deadline monitor.
+table DeadlineMonitor {
+  monitor_tag: string (required);
+  deadlines: [DeadlineEntry] (required);
+}
+
+/// Configuration for a heartbeat monitor.
+table HeartbeatMonitor {
+  monitor_tag: string (required);
+  range: TimeRange (required);
+}
+
+/// A state and its allowed transitions in a logic monitor.
+table StateNode {
+  state: string (required);
+  allowed_transitions: [string] (required);
+}
+
+/// Configuration for a logic monitor.
+table LogicMonitor {
+  monitor_tag: string (required);
+  initial_state: string (required);
+  states: [StateNode] (required);
+}
+
+/// Root configuration for a HealthMonitor instance.
+table HealthMonitorConfig {
+  schema_version: uint32 (required);
+  supervisor_api_cycle_ms: uint32 (required);
+  internal_processing_cycle_ms: uint32 (required);
+  thread_parameters: ThreadParameters;
+  deadline_monitors: [DeadlineMonitor];
+  heartbeat_monitors: [HeartbeatMonitor];
+  logic_monitors: [LogicMonitor];
+}
+
+root_type HealthMonitorConfig;

--- a/score/health_monitor/configuration/health_monitor_config.schema.json
+++ b/score/health_monitor/configuration/health_monitor_config.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "health_monitor_config.schema.json",
+  "title": "HealthMonitorConfig",
+  "description": "Configuration schema for HealthMonitor (compatible with health_monitor_config.fbs)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "supervisor_api_cycle_ms",
+    "internal_processing_cycle_ms"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "description": "Schema version",
+      "enum": [
+        1
+      ]
+    },
+    "supervisor_api_cycle_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Cycle duration in ms for supervisor API notifications"
+    },
+    "internal_processing_cycle_ms": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Cycle duration in ms for internal deadline checks"
+    },
+    "thread_parameters": {
+      "$ref": "#/$defs/ThreadParameters"
+    },
+    "deadline_monitors": {
+      "$ref": "#/$defs/DeadlineMonitors",
+      "description": "Map of deadline monitor groups"
+    },
+    "heartbeat_monitors": {
+      "$ref": "#/$defs/HeartbeatMonitors",
+      "description": "Map of heartbeat monitors"
+    },
+    "logic_monitors": {
+      "$ref": "#/$defs/LogicMonitors",
+      "description": "Map of logic monitors"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "SchedulerPolicy": {
+      "type": "string",
+      "enum": [
+        "POSIX_OTHER",
+        "POSIX_FIFO",
+        "POSIX_RR"
+      ],
+      "description": "Scheduler policy for the monitoring thread"
+    },
+    "ThreadParameters": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/$defs/SchedulerPolicy",
+          "description": "Scheduler policy for the monitoring thread"
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Thread priority"
+        },
+        "affinity": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "description": "CPU core IDs the thread can run on"
+        },
+        "stack_size_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Stack size in bytes"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimeRange": {
+      "type": "object",
+      "required": [
+        "min_ms",
+        "max_ms"
+      ],
+      "properties": {
+        "min_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum duration in milliseconds"
+        },
+        "max_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum duration in milliseconds"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DeadlineEntry": {
+      "type": "object",
+      "required": [
+        "min_ms",
+        "max_ms"
+      ],
+      "properties": {
+        "min_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum duration in milliseconds"
+        },
+        "max_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum duration in milliseconds"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DeadlineMonitorEntryMap": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/TimeRange"
+      }
+    },
+    "DeadlineMonitors": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/DeadlineMonitorEntryMap"
+      }
+    },
+    "HeartbeatMonitors": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/TimeRange"
+      }
+    },
+    "StateTransitions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "List of states reachable from this state"
+    },
+    "StateNode": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/StateTransitions"
+      }
+    },
+    "LogicMonitor": {
+      "type": "object",
+      "required": [
+        "initial_state",
+        "states"
+      ],
+      "properties": {
+        "initial_state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Starting state of the logic monitor"
+        },
+        "states": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StateNode"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "LogicMonitors": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/LogicMonitor"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Example JSON configuration:
```json
{
  "schema_version": 1,
  "supervisor_api_cycle_ms": 100,
  "internal_processing_cycle_ms": 50,
  "thread_parameters": {
    "policy": "POSIX_FIFO",
    "priority": 20,
    "affinity": [0, 1],
    "stack_size": 262144
  },
  "deadline_monitors": [
    {
      "monitor_tag": "control_loop_deadlines",
      "deadlines": [
        {
          "deadline_tag": "read_inputs",
          "range": {
            "min_ms": 1,
            "max_ms": 5
          }
        },
        {
          "deadline_tag": "publish_outputs",
          "range": {
            "min_ms": 2,
            "max_ms": 10
          }
        }
      ]
    }
  ],
  "heartbeat_monitors": [
    {
      "monitor_tag": "planner_heartbeat",
      "range": {
        "min_ms": 90,
        "max_ms": 110
      }
    }
  ],
  "logic_monitors": [
    {
      "monitor_tag": "operation_mode_flow",
      "initial_state": "initializing",
      "states": [
        {
          "state": "initializing",
          "allowed_transitions": ["running", "fault"]
        },
        {
          "state": "running",
          "allowed_transitions": ["degraded", "fault"]
        },
        {
          "state": "degraded",
          "allowed_transitions": ["running", "fault"]
        },
        {
          "state": "fault",
          "allowed_transitions": []
        }
      ]
    }
  ]
}
```