### PR TITLE
[launch_manager] use score::Result instead of score::cpp::expected

### DIFF
--- a/score/launch_manager/src/daemon/src/common/concurrency/BUILD
+++ b/score/launch_manager/src/daemon/src/common/concurrency/BUILD
@@ -44,8 +44,8 @@ cc_library(
         "//score/launch_manager/src/daemon/src/common/concurrency/details:helgrind_annotations",
         "//score/launch_manager/src/daemon/src/osal:return_types",
         "//score/launch_manager/src/daemon/src/osal:semaphore",
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/result",
     ],
 )
 
@@ -69,6 +69,7 @@ cc_library(
     visibility = ["//score:__subpackages__"],
     deps = [
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/result",
     ],
 )
 

--- a/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
@@ -14,13 +14,18 @@
 #ifndef CONCURRENCY_ERROR_DOMAIN_HPP_INCLUDED
 #define CONCURRENCY_ERROR_DOMAIN_HPP_INCLUDED
 
+#include "score/result/result.h"
+
 #include <cstdint>
 #include <ostream>
+#include <string_view>
 
 namespace score::lcm::internal
 {
 
-enum class ConcurrencyErrc : std::uint8_t
+/// @brief Error codes must use score::result::ErrorCode as their underlying type so that they can be
+///        wrapped into a score::result::Error (see MakeError() below and ConcurrencyErrorDomain::MessageFor()).
+enum class ConcurrencyErrc : score::result::ErrorCode
 {
     /// @brief An OS call returned an error.
     kOsError = 1,
@@ -43,8 +48,40 @@ inline std::ostream& operator<<(std::ostream& os, ConcurrencyErrc errc) noexcept
         case ConcurrencyErrc::kOverflow: return os << "kOverflow";
         case ConcurrencyErrc::kStopped:  return os << "kStopped";
         case ConcurrencyErrc::kTimeout:  return os << "kTimeout";
-        default:                         return os << static_cast<std::uint8_t>(errc);
+        default:                         return os << static_cast<score::result::ErrorCode>(errc);
     }
+}
+
+/// @brief Error domain translating ConcurrencyErrc values into human readable messages, as required by
+///        score::Result / score::result::Error.
+class ConcurrencyErrorDomain final : public score::result::ErrorDomain
+{
+  public:
+    [[nodiscard]] std::string_view MessageFor(const score::result::ErrorCode& code) const noexcept override
+    {
+        switch (static_cast<ConcurrencyErrc>(code))
+        {
+            case ConcurrencyErrc::kOsError:
+                return "An OS call returned an error";
+            case ConcurrencyErrc::kOverflow:
+                return "The container has overflowed";
+            case ConcurrencyErrc::kStopped:
+                return "The container has stopped";
+            case ConcurrencyErrc::kTimeout:
+                return "A timeout was triggered";
+            default:
+                return "Unknown error";
+        }
+    }
+};
+
+constexpr ConcurrencyErrorDomain g_ConcurrencyErrorDomain{};
+
+/// @brief Constructs a score::result::Error from a ConcurrencyErrc. Found via ADL from score::result::Error's
+///        constructor and from score::MakeUnexpected().
+constexpr score::result::Error MakeError(ConcurrencyErrc code, const std::string_view user_message = "") noexcept
+{
+    return score::result::Error{static_cast<score::result::ErrorCode>(code), g_ConcurrencyErrorDomain, user_message};
 }
 
 }  // namespace score::lcm::internal

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
@@ -25,7 +25,7 @@
 #include <thread>
 
 #include "concurrency_error_domain.hpp"
-#include <score/expected.hpp>
+#include "score/result/result.h"
 #include "score/mw/launch_manager/common/concurrency/details/helgrind_annotations.hpp"
 #include "score/mw/launch_manager/osal/return_types.hpp"
 #include "score/mw/launch_manager/osal/semaphore.hpp"
@@ -112,7 +112,7 @@ class MPMCConcurrentQueue
     /// @return Success if item was pushed, Error otherwise.
     ///         Note: If the push returns false, the object is still valid for
     ///         the user.
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push(
+    [[nodiscard]] score::Result<void> push(
         T&& item, std::chrono::milliseconds timeout = std::chrono::milliseconds{0})
     {
         return push_impl(std::move(item), timeout);
@@ -125,29 +125,29 @@ class MPMCConcurrentQueue
     ///          previous consumer has finished reading it.
     /// @param timeout Maximum time to wait for a free slot. Zero means wait forever.
     /// @return Success if item was pushed, Error otherwise.
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push(
+    [[nodiscard]] score::Result<void> push(
         const T& item, std::chrono::milliseconds timeout = std::chrono::milliseconds{0})
     {
         return push_impl(item, timeout);
     }
 
     /// @brief Signals all blocked pop() callers to return with a stopped error.
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> stop() noexcept
+    [[nodiscard]] score::Result<void> stop() noexcept
     {
         m_stopped.store(true, std::memory_order_release);
 
         // signal to consumers and publishers to wakeup
         if (m_items.post() != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
         if (m_spaces.post() != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
-        return score::cpp::blank{};
+        return {};
     }
 
     /// @brief Blocks until an item is available or stop() is called.
@@ -156,7 +156,7 @@ class MPMCConcurrentQueue
     ///          When stopped returns std::nullopt.
     /// @param timeout Maximum time to wait for an item. Zero means wait forever.
     /// @return The next item, or error.
-    [[nodiscard]] score::cpp::expected<T, ConcurrencyErrc> pop(
+    [[nodiscard]] score::Result<T> pop(
         std::chrono::milliseconds timeout = std::chrono::milliseconds{0})
     {
         const auto wait_result =
@@ -164,24 +164,24 @@ class MPMCConcurrentQueue
 
         if(wait_result == osal::OsalReturnType::kTimeout)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kTimeout);
+            return score::MakeUnexpected(ConcurrencyErrc::kTimeout);
         }
         else if (wait_result != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
         if (m_stopped.load(std::memory_order_acquire))
         {
             static_cast<void>(m_items.post());
-            return score::cpp::make_unexpected(ConcurrencyErrc::kStopped);
+            return score::MakeUnexpected(ConcurrencyErrc::kStopped);
         }
 
         T item = consume_slot(m_head.fetch_add(1, std::memory_order_relaxed));
 
         if (m_spaces.post() != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
         return item;
@@ -220,25 +220,25 @@ class MPMCConcurrentQueue
     }
 
     template <class U>
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push_impl(U&& item, std::chrono::milliseconds timeout)
+    [[nodiscard]] score::Result<void> push_impl(U&& item, std::chrono::milliseconds timeout)
     {
         const auto wait_result =
             (timeout == std::chrono::milliseconds{0}) ? m_spaces.wait() : m_spaces.timedWait(timeout);
 
         if(wait_result == osal::OsalReturnType::kTimeout)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kTimeout);
+            return score::MakeUnexpected(ConcurrencyErrc::kTimeout);
         }
         else if (wait_result != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
         if (m_stopped.load(std::memory_order_acquire))
         {
             // chain-wake the next blocked producer then discard the item
             static_cast<void>(m_spaces.post());
-            return score::cpp::make_unexpected(ConcurrencyErrc::kStopped);
+            return score::MakeUnexpected(ConcurrencyErrc::kStopped);
         }
 
         const auto tail = m_tail.fetch_add(1, std::memory_order_relaxed);
@@ -267,10 +267,10 @@ class MPMCConcurrentQueue
 
         if (m_items.post() != osal::OsalReturnType::kSuccess)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+            return score::MakeUnexpected(ConcurrencyErrc::kOsError);
         }
 
-        return score::cpp::blank{};
+        return {};
     }
 
     /// @brief Underlying storage.

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
@@ -95,7 +95,7 @@ TEST_F(MPMCConcurrentQueueTest_Basic, PopReturnsNulloptOnSemaphoreWaitFailure)
     sa.sa_flags = 0;
     sigaction(SIGUSR1, &sa, nullptr);
 
-    score::cpp::expected<int, ConcurrencyErrc> result = score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+    score::Result<int> result = score::MakeUnexpected(ConcurrencyErrc::kOsError);
     std::atomic<bool> tid_ready{false};
 
     std::thread consumer([&] {
@@ -192,7 +192,7 @@ class MPMCConcurrentQueueTest_Blocking : public ::testing::Test
 TEST_F(MPMCConcurrentQueueTest_Blocking, PopBlocksUntilItemAvailable)
 {
     RecordProperty("Description", "Verify that pop blocks on an empty queue until a producer pushes an item.");
-    score::cpp::expected<int, ConcurrencyErrc> result = score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+    score::Result<int> result = score::MakeUnexpected(ConcurrencyErrc::kOsError);
 
     std::thread consumer([&] {
         result = queue8_.pop();
@@ -216,7 +216,7 @@ TEST_F(MPMCConcurrentQueueTest_Blocking, PushBlocksWhenFull)
     }
 
     std::atomic<bool> push_completed{false};
-    score::cpp::expected_blank<ConcurrencyErrc> pushed = score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+    score::Result<void> pushed = score::MakeUnexpected(ConcurrencyErrc::kOsError);
     std::thread producer([&] {
         pushed = queue4_.push(99);
         push_completed.store(true, std::memory_order_release);
@@ -233,7 +233,7 @@ TEST_F(MPMCConcurrentQueueTest_Blocking, PushBlocksWhenFull)
 TEST_F(MPMCConcurrentQueueTest_Blocking, StopUnblocksBlockedConsumer)
 {
     RecordProperty("Description", "Verify that stop() unblocks a consumer thread waiting on an empty queue.");
-    score::cpp::expected<int, ConcurrencyErrc> result = score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+    score::Result<int> result = score::MakeUnexpected(ConcurrencyErrc::kOsError);
 
     std::thread consumer([&] {
         result = queue8_.pop();
@@ -254,7 +254,7 @@ TEST_F(MPMCConcurrentQueueTest_Blocking, StopUnblocksBlockedProducer)
         ASSERT_TRUE(queue4_.push(i));
     }
 
-    score::cpp::expected_blank<ConcurrencyErrc> pushed = score::cpp::make_unexpected(ConcurrencyErrc::kOsError);
+    score::Result<void> pushed = score::MakeUnexpected(ConcurrencyErrc::kOsError);
     std::thread producer([&] {
         pushed = queue4_.push(99);
     });

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
@@ -25,8 +25,9 @@
 
 #include "concurrency_error_domain.hpp"
 
+#include "score/result/result.h"
+
 #include <score/assert.hpp>
-#include <score/expected.hpp>
 
 namespace score::lcm::internal
 {
@@ -57,12 +58,12 @@ class MpscBoundedQueue
     /// @brief Enqueues an item.
     /// @return blank on success; ConcurrencyErrc::kOverflow if the queue is full, or
     ///         ConcurrencyErrc::kStopped if the queue has been stopped.
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push(T&& item)
+    [[nodiscard]] score::Result<void> push(T&& item)
     {
         return push_impl(std::move(item));
     }
 
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push(const T& item)
+    [[nodiscard]] score::Result<void> push(const T& item)
     {
         return push_impl(item);
     }
@@ -72,7 +73,7 @@ class MpscBoundedQueue
     /// @return blank if an item is available (caller should drain via tryPop());
     ///         ConcurrencyErrc::kTimeout if the timeout elapsed with none available, or
     ///         ConcurrencyErrc::kStopped if the queue has been stopped.
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> wait(std::chrono::milliseconds timeout)
+    [[nodiscard]] score::Result<void> wait(std::chrono::milliseconds timeout)
     {
         std::unique_lock lock(mutex_);
         SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(ensure_single_consumer(), "Only a single consumer thread is allowed.");
@@ -83,11 +84,11 @@ class MpscBoundedQueue
 
         if (stopped_)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kStopped);
+            return score::MakeUnexpected(ConcurrencyErrc::kStopped);
         }
         if (!has_item)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kTimeout);
+            return score::MakeUnexpected(ConcurrencyErrc::kTimeout);
         }
         return {};
     }
@@ -144,18 +145,18 @@ class MpscBoundedQueue
     }
 
     template <typename U>
-    [[nodiscard]] score::cpp::expected_blank<ConcurrencyErrc> push_impl(U&& item)
+    [[nodiscard]] score::Result<void> push_impl(U&& item)
     {
         std::unique_lock lock(mutex_);
 
         if (stopped_)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kStopped);
+            return score::MakeUnexpected(ConcurrencyErrc::kStopped);
         }
 
         if (count_ >= Capacity)
         {
-            return score::cpp::make_unexpected(ConcurrencyErrc::kOverflow);
+            return score::MakeUnexpected(ConcurrencyErrc::kOverflow);
         }
 
         slots_[tail_].emplace(std::forward<U>(item));


### PR DESCRIPTION
## Summary
Closes #338.

This issue is a "spin off from review comment" auto-generated from a review exchange on #333, about the newly-added `MpscBoundedQueue`/`MPMCConcurrentQueue` classes using `score::cpp::expected_blank<ConcurrencyErrc>`.

## Scope
Scoped this to exactly the concurrency queue subsystem rather than every `score::cpp::expected` usage under `launch_manager/`, which also includes an unrelated `configuration/flatbuffer_*` subsystem using its own `IConfigLoader::Error` enum across ~20 functions, and a test file mocking a third-party `score::os` API signature that must not change. Widening the scope to those would have been a much larger, speculative change not discussed in this issue.

## Files changed (5)
- `score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp` -- new `ConcurrencyErrorDomain` (`score::result::ErrorDomain` subclass) and an ADL-visible `MakeError(ConcurrencyErrc, ...)`, mirroring the existing `ExecErrorDomain` pattern in `execution_error.h`. Also changed `ConcurrencyErrc`'s underlying type from `uint8_t` to `score::result::ErrorCode` (int32_t) -- required by `score::result::Error`'s constructor constraint (`IsValidErrorCodeEnum`).
- `mpsc_bounded_queue.hpp`, `mpmc_concurrent_queue.hpp` -- all `score::cpp::expected_blank<ConcurrencyErrc>`/`score::cpp::expected<T, ConcurrencyErrc>` return types converted to `score::Result<void>`/`score::Result<T>`; `score::cpp::make_unexpected(...)` -> `score::MakeUnexpected(...)`; `score::cpp::blank{}` -> `{}`.
- `mpmc_concurrent_queue_test.cpp` -- updated 5 local variable declarations to match.
- `BUILD` -- added `@score_baselibs//score/result` dep to both queue targets; dropped the now-fully-unused `@score_baselibs//score/language/futurecpp` dep from `mpmc_concurrent_queue` (kept it for `mpsc_bounded_queue`, which still needs `score/assert.hpp` from that package).

`mpsc_bounded_queue_test.cpp`, `workerthread.hpp`, `mpmc_concurrent_queue_benchmark.cpp`, and the two external callers (`graph.cpp`, `process_info_node.cpp`) needed no changes -- they consume results via `auto`/`.has_value()`/`.error()`/`operator bool()`, all API-identical between `score::cpp::expected` and `score::Result`.

## How I tested this
No Bazel binary was available in the environment I worked in, so a build wasn't feasible. Verified by evidence-based code review instead:
- Fetched and read the actual `score::Result`/`score::result::Error`/`ErrorDomain` implementations from `eclipse-score/baselibs` to confirm API compatibility (`has_value()`, `error()`, `operator bool()`, implicit construction from `unexpected<E>`, and the `LogStream& operator<<(LogStream&, const Error&)` overload that keeps existing `LM_LOG_ERROR() << ... << foo.error()` call sites compiling unchanged).
- Traced every call site of the two migrated queues across the module to confirm no other file needed edits.
- Cross-checked the `ExecErrorDomain`/`ExecErrc` pattern already used elsewhere in this codebase and replicated it exactly for `ConcurrencyErrc`.
- Repeated greps for leftover `score::cpp::expected`/`expected_blank`/`score/expected.hpp` references in the touched scope -- none remain.

Given I couldn't build, a CI run / maintainer build check would be very welcome on this one.

Commits are DCO-signed (`git commit -s`).