### PR TITLE
Unset ANDROID_HOME

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,11 @@ common --http_connector_attempts=10
 common --http_connector_retry_max_timeout=1s
 common --http_timeout_scaling=2.0
 
+# Unset ANDROID_HOME to prevent rules_android from searching for the Android SDK.
+# rules_android is a transitive dependency, and on GitHub runners the Android SDK
+# directory is often deleted while the ANDROID_HOME environment variable remains set.
+common --action_env=ANDROID_HOME=""
+
 build --java_language_version=17
 build --tool_java_language_version=17
 build --java_runtime_version=remotejdk_17


### PR DESCRIPTION
Unset ANDROID_HOME to prevent rules_android from searching for the Android SDK.
rules_android is a transitive dependency, and on GitHub runners the Android SDK
directory is often deleted while the ANDROID_HOME environment variable remains set.