### PR TITLE
ci: bump coverage workflow refs for --build_tests_only fix

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   cpp:
-    uses: eclipse-score/cicd-workflows/.github/workflows/cpp-coverage.yml@ea19fcae9aeeb4ac678b750c6c197eaf75414f39 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/cpp-coverage.yml@4c20f0d9509e3a8ac81a7d2d4c493ce2d0cba3c0 # v0.0.0
     with:
       bazel-target: "//score/..."
       bazel-config: "x86_64-linux"
@@ -33,7 +33,7 @@ jobs:
       retention-days: 10
       min-coverage: 76
   rust:
-    uses: eclipse-score/cicd-workflows/.github/workflows/rust-coverage.yml@ea19fcae9aeeb4ac678b750c6c197eaf75414f39 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/rust-coverage.yml@4c20f0d9509e3a8ac81a7d2d4c493ce2d0cba3c0 # v0.0.0
     with:
       bazel-test-targets: "//score/..."
       bazel-test-config-flags: "--config=x86_64-linux --config=ferrocene-coverage --lockfile_mode=error --test_lang_filters=-cc,-miri"


### PR DESCRIPTION
Bumps the `cpp-coverage.yml` / `rust-coverage.yml` refs to cicd-workflows `4c20f0d9` (eclipse-score/cicd-workflows#165, fixes eclipse-score/cicd-workflows#164).

**Why:** the coverage workflows ran `bazel coverage`/`bazel test` without `--build_tests_only`, so test language/tag filters only affected which tests *run* — wildcard patterns still **built** filtered-out tests. That builds the Miri test targets, whose Miri-sysroot compiles fail under coverage instrumentation (`error[E0463]: can't find crate for 'profiler_builtins'`) once score_toolchains_rust ≥ 0.9.2 enables Rust coverage — this is what breaks the C++ Coverage job on #369.

**Verification:** reproduced locally on the #369 toolchain bump — without the fix the coverage invocation aborts (16/19 tests); with `--build_tests_only`, exit 0 and 19/19 tests pass. The same bump has also been pushed onto #369 directly to re-run its CI.

Merging this first means #369 (and any future toolchain bumps) stay green.