### PR TITLE
Fixing log message spam

### DIFF
--- a/score/launch_manager/src/daemon/src/control/BUILD
+++ b/score/launch_manager/src/daemon/src/control/BUILD
@@ -27,6 +27,7 @@ cc_library(
         "//score/launch_manager/src/daemon/src/common:constants",
         "//score/launch_manager/src/daemon/src/common:log",
         "//score/launch_manager/src/daemon/src/common:process_group_state_id",
+        "//score/launch_manager/src/daemon/src/common:signal_safe_log",
         "//score/launch_manager/src/daemon/src/osal:ipc_comms",
         "@score_baselibs//score/language/futurecpp",
     ],

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -20,6 +20,7 @@
 #include "control_client_channel.hpp"
 #include "score/mw/launch_manager/common/constants.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
+#include "score/mw/launch_manager/common/signal_safe_log.hpp"
 
 namespace score
 {
@@ -29,6 +30,28 @@ namespace lcm
 
 namespace internal
 {
+
+bool ControlClientChannel::loadControlNudge()
+{
+    if (nudgeControlClientHandler_ != nullptr)
+    {
+        LM_LOG_ERROR() << "Semaphore was already mapped!";
+        return false;
+    }
+
+    void* nudgeBuf = mmap(
+        NULL, sizeof(osal::Semaphore), PROT_WRITE, MAP_SHARED, osal::IpcCommsSync::control_client_handler_nudge_fd, 0);
+
+    if (nudgeBuf == MAP_FAILED)
+    {
+        LM_LOG_ERROR() << "mmap of nudge semaphore failed in initializeControlClientChannel:"
+                       << std::string_view{std::strerror(errno)};
+        return false;
+    }
+
+    nudgeControlClientHandler_ = static_cast<osal::Semaphore*>(nudgeBuf);
+    return true;
+}
 
 void ControlClientChannel::initialize()
 {
@@ -81,6 +104,8 @@ bool ControlClientChannel::getResponse(ControlClientMessage& msg)
         LM_LOG_DEBUG() << "Response retrieved.";
     }
 
+    nudgeControlClientHandler();
+
     return result;
 }
 
@@ -89,25 +114,7 @@ void ControlClientChannel::sendRequest(ControlClientMessage& msg)
     request_.msg_ = msg;
     request_.empty_ = false;
 
-    // now map the semaphore and post on it
-    // Attempt to map the semaphore
-    auto* nudgeLM = mmap(
-        NULL, sizeof(osal::Semaphore), PROT_WRITE, MAP_SHARED, osal::IpcCommsSync::control_client_handler_nudge_fd, 0);
-
-    // RULECHECKER_comment(1, 1, check_c_style_cast, "This is the definition provided by the OS and does a C-style
-    // cast.", true)
-    if (nudgeLM != MAP_FAILED)
-    {
-        LM_LOG_DEBUG() << "Request sent. Waiting for acknowledgment...";
-        auto* semaphore = static_cast<osal::Semaphore*>(nudgeLM);
-
-        // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if statement.
-        const auto result = semaphore->post();
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
-            result == osal::OsalReturnType::kSuccess, "ControlClientChannel semaphore post failed");
-
-        munmap(nudgeLM, sizeof(osal::Semaphore));  // Unmap the semaphore
-    }
+    nudgeControlClientHandler();
 
     const auto result = nudge_LM_Handler_.wait();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
@@ -197,6 +204,9 @@ ControlClientChannelP ControlClientChannel::initializeControlClientChannel(int f
         lock.unlock();
         init_cv_.notify_all();
     }
+
+    loadControlNudge();
+
     return result;
 }
 
@@ -240,14 +250,16 @@ ControlClientChannelP ControlClientChannel::getControlClientChannel(osal::IpcCom
 
 void ControlClientChannel::nudgeControlClientHandler()
 {
-    if (nudgeControlClientHandler_)
+    if (nudgeControlClientHandler_ != nullptr)
     {
-        const auto result = nudgeControlClientHandler_->post();
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
-            result == osal::OsalReturnType::kSuccess, "ControlClientChannel semaphore post failed");
-
-        LM_LOG_DEBUG() << "Control Client handler nudged";
+        if (nudgeControlClientHandler_->post() != osal::OsalReturnType::kSuccess)
+        {
+            static_cast<void>(signal_safe_log("ControlClientChannel semaphore post failed"));
+            exit(EXIT_FAILURE);
+        }
     }
+
+    LM_LOG_DEBUG() << "Control Client handler nudged";
 }
 
 void ControlClientChannel::nudgeLMHandler()

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -22,13 +22,7 @@
 #include "score/mw/launch_manager/common/log.hpp"
 #include "score/mw/launch_manager/common/signal_safe_log.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::lcm::internal
 {
 
 bool ControlClientChannel::loadControlNudge()
@@ -258,15 +252,16 @@ void ControlClientChannel::nudgeControlClientHandler()
             exit(EXIT_FAILURE);
         }
     }
-
-    LM_LOG_DEBUG() << "Control Client handler nudged";
 }
 
 void ControlClientChannel::nudgeLMHandler()
 {
     const auto result = nudge_LM_Handler_.post();
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
-        result == osal::OsalReturnType::kSuccess, "ControlClientChannel semaphore post failed");
+    if (result != osal::OsalReturnType::kSuccess)
+    {
+        static_cast<void>(signal_safe_log("ControlClientChannel semaphore post failed"));
+        exit(EXIT_FAILURE);
+    }
 }
 
 void ControlClientChannel::releaseParentMapping()
@@ -292,8 +287,4 @@ bool ControlClientChannel::is_initialized_ = false;
 std::condition_variable ControlClientChannel::init_cv_{};
 std::mutex ControlClientChannel::init_mutex_{};
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::lcm::internal

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
@@ -171,6 +171,9 @@ class ControlClientChannel final
     /// @brief Desctructor, deleted. We cannot create or delete objects of this type in the normal ways.
     ~ControlClientChannel() = delete;
 
+    /// @brief loads the control channel's nudge semaphore.
+    static bool loadControlNudge();
+
     /// @brief Initialise the comms channels
     /// called when the shared memory is initially created by Launch Manager
     void initialize();

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
@@ -31,6 +31,7 @@ static std::atomic_bool em_cancelled{false};
 static void my_signal_handler(int)
 {
     em_cancelled.store(true);
+    ControlClientChannel::nudgeControlClientHandler();
 }
 
 void ProcessGroupManager::cancel()
@@ -508,27 +509,23 @@ bool ProcessGroupManager::sendResponse(ControlClientMessage msg)
 {
     auto pin = getProcessInfoNode(
         msg.originating_control_client_.process_group_index_, msg.originating_control_client_.process_index_);
-    bool ret = true;
 
-    if (pin)
+    if (pin == nullptr)
     {
-        auto scc = pin->getControlClientChannel();
+        return false;
+    }
+    auto scc = pin->getControlClientChannel();
 
-        if (scc)
-        {
-            LM_LOG_DEBUG() << "ProcessGroupManager::ControlClientHandler: Sending"
-                           << scc->toString(msg.request_or_response_) << "("
-                           << static_cast<int>(msg.request_or_response_) << ") re state"
-                           << msg.process_group_state_.pg_state_name_ << "of PG" << msg.process_group_state_.pg_name_;
-            ret = scc->sendResponse(msg);
-            if (!ret)
-            {
-                ControlClientChannel::nudgeControlClientHandler();
-            }
-        }
+    if (scc == nullptr)
+    {
+        return false;
     }
 
-    return ret;
+    LM_LOG_DEBUG() << "ProcessGroupManager::ControlClientHandler: Sending" << scc->toString(msg.request_or_response_)
+                   << "(" << static_cast<int>(msg.request_or_response_) << ") re state"
+                   << msg.process_group_state_.pg_state_name_ << "of PG" << msg.process_group_state_.pg_name_;
+
+    return scc->sendResponse(msg);
 }
 
 inline void ProcessGroupManager::controlClientRequests(Graph& pg)

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager.cpp
@@ -164,60 +164,56 @@ void ProcessGroupManager::deinitialize()
 
 inline bool ProcessGroupManager::initializeControlClientHandler()
 {
-    bool result = false;
-
     // Create shared memory for the nudge semaphore, using the specific
     // file descriptor osal::Comms::control_client_handler_nudge_fd, and a random name.
     // The name is removed from the file system after creation, memory
     // is mapped and a pointer stored, the FD is kept open.
     ControlClientChannel::nudgeControlClientHandler_ = nullptr;
-    char shm_name[static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize)];
+    constexpr static std::string_view shm_name{"/_nudge~._.~me_"};
 
-    static_cast<void>(snprintf(
-        shm_name,
-        static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize),
-        "/_nudge~._.~me_"));  // random name
-    int fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0U);
-
-    if (fd >= 0)
+    int fd = shm_open(shm_name.begin(), O_CREAT | O_EXCL | O_RDWR, 0U);
+    if (fd <= 0)
     {
-        shm_unlink(shm_name);
+        return false;
+    }
+    shm_unlink(shm_name.begin());
 
-        if (0 == ftruncate(fd, static_cast<off_t>(sizeof(osal::Semaphore))))
-        {
-            int fd2 =
-                dup2(fd, osal::IpcCommsSync::control_client_handler_nudge_fd);  // always make sure we are using fd=4
-            close(fd);
-
-            // dup2 clears the O_CLOEXEC flag so this needs to be set again
-            if (fcntl(fd2, F_SETFD, FD_CLOEXEC) != 0)
-            {
-                ::close(fd2);
-                return false;
-            }
-
-            if (osal::IpcCommsSync::control_client_handler_nudge_fd == fd2)
-            {
-                void* buf = mmap(NULL, sizeof(osal::Semaphore), PROT_WRITE, MAP_SHARED, fd2, 0);
-
-                // RULECHECKER_comment(1, 1, check_c_style_cast, "This is the definition provided by the OS and does a
-                // C-style cast.", true)
-                if (MAP_FAILED != buf)
-                {
-                    ControlClientChannel::nudgeControlClientHandler_ = static_cast<osal::Semaphore*>(buf);
-                    // coverity[cert_mem52_cpp_violation:FALSE] The allocated memory is checked by the containing if
-                    // statement.
-                    const auto osal_result = ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
-                    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
-                        osal_result == OsalReturnType::kSuccess, "ControlClientChannel semaphore init failed");
-
-                    result = true;
-                }
-            }
-        }
+    if (0 != ftruncate(fd, static_cast<off_t>(sizeof(osal::Semaphore))))
+    {
+        ::close(fd);
+        return false;
     }
 
-    return result;
+    int fd2 = dup2(fd, osal::IpcCommsSync::control_client_handler_nudge_fd);  // always make sure we are using fd=4
+    ::close(fd);
+
+    // dup2 clears the O_CLOEXEC flag so this needs to be set again
+    if (fcntl(fd2, F_SETFD, FD_CLOEXEC) != 0)
+    {
+        ::close(fd2);
+        return false;
+    }
+
+    if (osal::IpcCommsSync::control_client_handler_nudge_fd != fd2)
+    {
+        ::close(fd2);
+        return false;
+    }
+
+    void* buf = mmap(NULL, sizeof(osal::Semaphore), PROT_WRITE, MAP_SHARED, fd2, 0);
+
+    if (MAP_FAILED == buf)
+    {
+        ::close(fd2);
+        return false;
+    }
+
+    ControlClientChannel::nudgeControlClientHandler_ = static_cast<osal::Semaphore*>(buf);
+    const auto osal_result = ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        osal_result == OsalReturnType::kSuccess, "ControlClientChannel semaphore init failed");
+
+    return true;
 }
 
 inline bool ProcessGroupManager::initializeProcessGroups()


### PR DESCRIPTION
Fixes unlimited polling on the control channel for a response to be available causing the spam of info messages:
```
[2026-07-29 11:57:46.662] [INFO] [launch_manager] 2026/07/29 11:57:46.6266501 184502847 000 ECU1 LM LM log debug verbose 1 Failed to send response: response is not empty.
[2026-07-29 11:57:46.662] [INFO] [launch_manager] 2026/07/29 11:57:46.6266501 184502847 000 ECU1 LM LM log debug verbose 1 Control Client handler nudged
[2026-07-29 11:57:46.662] [INFO] [launch_manager] 2026/07/29 11:57:46.6266501 184502847 000 ECU1 LM LM log debug verbose 8 ProcessGroupManager::ControlClientHandler: Sending kSetStateSuccess ( 20 ) re state MainPG/fallback_run_target of PG MainPG
```

Also some small cleanup of `mmap`s