### PR TITLE
Fix a flaky failure in `//tests/integration/process_complex_rep_failure`

### DIFF
--- a/tests/utils/testing_utils/run_until_file_deployed.py
+++ b/tests/utils/testing_utils/run_until_file_deployed.py
@@ -64,12 +64,11 @@ def run_until_file_deployed(
             # run their cleanup code before exiting.
             kill_cmd = f"kill -15 -{proc.pid()}"
             res, _ = target.execute(kill_cmd)
-            time.sleep(0.5)
-            assert proc.is_running() == False, "LCM still running"
-            assert proc.get_exit_code() == 0, (
-                f"LCM did not exit cleanly, it died with code {proc.get_exit_code()}"
-            )
             assert res == 0, "Couldn't kill lcm"
+            exit_code = proc.wait()  # Raises RuntimeError if it does not stop
+            assert exit_code == 0, (
+                f"LCM did not exit cleanly, it died with code {exit_code}"
+            )
             return proc
         logger.debug(f"Waiting for {file_path}")
 


### PR DESCRIPTION
This fixes one of the two common failures, where it says "LCM is still running", by simply increasing the timeout.

`process.wait()` has a default timeout of 15 seconds, and returns early if the process stops within the timeout, so this does not slow down the tests unless it genuinely takes longer to stop.

For reference the other flaky failure is caused by #331.