### PR TITLE
Add missing Bazel imports

### DIFF
--- a/examples/cpp_lifecycle_app/BUILD
+++ b/examples/cpp_lifecycle_app/BUILD
@@ -10,6 +10,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "cpp_lifecycle_app",
     srcs = [

--- a/externals/acl/acl.BUILD
+++ b/externals/acl/acl.BUILD
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "acl",
     srcs = select({

--- a/externals/ipc_dropin/BUILD
+++ b/externals/ipc_dropin/BUILD
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "ipc_dropin_internal",
     hdrs = glob(["include/ipc_dropin/*.hpp"]),

--- a/score/health_monitor/BUILD
+++ b/score/health_monitor/BUILD
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 alias(
     name = "health_monitoring_cc",
     actual = "//score/health_monitor/src/cpp:health_monitoring_cc",

--- a/score/launch_manager/src/daemon/src/configuration/config_schema/BUILD
+++ b/score/launch_manager/src/daemon/src/configuration/config_schema/BUILD
@@ -10,8 +10,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@score_baselibs//score/flatbuffers/bazel:codegen.bzl", "generate_cpp")
 
 exports_files(
     [

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/BUILD
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/BUILD
@@ -10,7 +10,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_cc//cc:defs.bzl", "cc_library")
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//tests/utils/bazel:unit_test.bzl", "lm_cc_test")
 
 cc_library(

--- a/scripts/config_mapping/BUILD
+++ b/scripts/config_mapping/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@score_lifecycle_pip//:requirements.bzl", "requirement")
 
 exports_files([

--- a/scripts/config_mapping/config.bzl
+++ b/scripts/config_mapping/config.bzl
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@score_baselibs//score/flatbuffers/bazel:tools.bzl", "serialize_buffer")
 
 def _lm_config_generator_impl(ctx):

--- a/tests/utils/test_helper/BUILD
+++ b/tests/utils/test_helper/BUILD
@@ -10,6 +10,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 exports_files(
     # Export these to allow us to rename the binary if desired
     [


### PR DESCRIPTION
Using these without importing them is deprecated, and in newer versions of Bazel, they have been completely removed.

```
find . -type f \( -name BUILD -or -name '*.BUILD' -or -name '*.bzl' -or -name '*.bazel' \) -exec buildifier -lint fix {} \;
```