### PR TITLE
Add unit tests for watchdog code

### DIFF
--- a/score/launch_manager/src/daemon/src/watchdog/BUILD
+++ b/score/launch_manager/src/daemon/src/watchdog/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tests/utils/bazel:unit_test.bzl", "lm_cc_test")
 
 cc_library(
     name = "i_watchdog_if",
@@ -33,5 +34,15 @@ cc_library(
     deps = [
         ":i_watchdog_if",
         "//score/launch_manager/src/daemon/src/watchdog/details:watchdog_impl",
+    ],
+)
+
+lm_cc_test(
+    name = "watchdog_factory_UT",
+    srcs = ["WatchdogFactory_UT.cpp"],
+    deps = [
+        ":watchdog_factory",
+        "//score/launch_manager/src/daemon/src/watchdog/details:watchdog_impl",
+        "@googletest//:gtest_main",
     ],
 )

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -64,14 +64,15 @@ class IWatchdogIf
     virtual ~IWatchdogIf() noexcept = default;
 
     /// @brief Initialize the watchdog library
-    /// @details Checks if the provided configuration is valid. 
-    /// A configuration is only taken over if the library is in the state "idle".
-    /// A valid configuration means: The file name of the device file is unique and device file is accessible,
-    /// timeout values are in the allowed range [kTimeoutMinMillis, kTimeoutMaxMillis] and min timeout value <= max
-    /// timeout value.
+    /// @details Checks if the provided configuration is valid.
+    /// A configuration is only taken over if the library is in the state "idle" and no watchdog device has been
+    /// configured yet.
+    /// A valid configuration means: The device file is accessible, timeout values are in the allowed range
+    /// [kTimeoutMinMillis, kTimeoutMaxMillis] and min timeout value <= max timeout value.
     /// @note Method is not reentrant safe.
     /// @note Only simple watchdogs are supported as of now, no windows watchdog (i.e. the min timeout value is always
     /// assumed 0).
+    /// @note Only a single watchdog device is supported. Calling this method more than once always fails.
     /// @param[in] watchdog_config The configuration for the watchdog
     /// @param[in] cycle_time_ns The period in nanoseconds at which serviceWatchdog() is called; used to validate
     ///            that the configured watchdog timeout is long enough to be serviced in time.
@@ -81,31 +82,29 @@ class IWatchdogIf
         const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept = 0;
 
-    /// @brief Activate the watchdogs.
-    /// @details Initialize and activate all watchdogs which are configured for use by the Watchdog Interface library.
-    /// If the processing of the watchdog control requests is done by a dedicated thread this method is creating and
-    /// starting the thread. After successfully activation of at least one watchdog the library state is set to
-    /// "activated". If no watchdog can be activated successfully the possibly created thread is stopped and joined and
-    /// library state remains "idle".
+    /// @brief Activate the watchdog.
+    /// @details Initialize and activate the watchdog device which is configured for use by the Watchdog Interface
+    /// library. After successful activation of the watchdog the library state is set to
+    /// "activated". If the watchdog cannot be activated successfully library state remains "idle".
     /// @note Method is not reentrant safe.
-    /// @return Status of activating the watchdogs. True if all configured watchdogs have been successfully activated
+    /// @return Status of activating the watchdog. True if the configured watchdog has been successfully activated
     /// and thread is up and running, false otherwise.
     virtual bool enable(void) noexcept = 0;
 
-    /// @brief Deactivate the watchdogs.
-    /// @details Deactivate all watchdogs which are configured for use by the Watchdog Interface library. Any watchdog
-    /// which cannot be deactivated once it has been activated is silently ignored. If the library state is not
+    /// @brief Deactivate the watchdog.
+    /// @details Deactivate the watchdog device which is configured for use by the Watchdog Interface library. If the
+    /// watchdog cannot be deactivated once it has been activated it is silently ignored. If the library state is not
     /// "activated" nothing is done.
     /// If the processing of the watchdog control requests is done by a dedicated thread this method is
     /// stopping and joining the thread.
     /// @note Method is not reentrant safe.
     virtual void disable(void) noexcept = 0;
 
-    /// @brief Services the watchdogs. Aka as pinging, triggering or kicking the watchdog.
+    /// @brief Services the watchdog. Aka as pinging, triggering or kicking the watchdog.
     /// @note Method is not reentrant safe.
     virtual void serviceWatchdog(void) noexcept = 0;
 
-    /// @brief Timeout watchdogs as fast as possible.
+    /// @brief Timeout the watchdog as fast as possible.
     /// @note Before this interface is called the callee should protocol the
     /// reason for the call to ease the analyze.
     /// @note Method is not reentrant safe.

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -64,8 +64,8 @@ class IWatchdogIf
     virtual ~IWatchdogIf() noexcept = default;
 
     /// @brief Initialize the watchdog library
-    /// @details Retrieves the configuration of watchdog devices and checks if the configurations are
-    /// valid. A configuration is only taken over if the library is in the state "idle".
+    /// @details Checks if the provided configuration is valid. 
+    /// A configuration is only taken over if the library is in the state "idle".
     /// A valid configuration means: The file name of the device file is unique and device file is accessible,
     /// timeout values are in the allowed range [kTimeoutMinMillis, kTimeoutMaxMillis] and min timeout value <= max
     /// timeout value.
@@ -75,7 +75,7 @@ class IWatchdogIf
     /// @param[in] watchdog_config The configuration for the watchdog
     /// @param[in] cycle_time_ns The period in nanoseconds at which serviceWatchdog() is called; used to validate
     ///            that the configured watchdog timeout is long enough to be serviced in time.
-    /// @return Status of configuration. True all device configurations are valid and has been successfully taken over
+    /// @return Status of configuration. True if watchdog configuration is valid and has been successfully taken over
     /// by the Watchdog Interface library, false otherwise.
     virtual bool init(
         const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
@@ -52,4 +52,3 @@ TEST_F(WatchdogFactoryTest, CreateWatchdogReturnsIndependentInstancesEachCall)
     ASSERT_NE(watchdog2, nullptr);
     EXPECT_NE(watchdog1.get(), watchdog2.get());
 }
-

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
+#include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
+
+using score::lcm::watchdog::createWatchdog;
+using score::lcm::watchdog::IWatchdogIf;
+using score::lcm::watchdog::WatchdogImpl;
+
+class WatchdogFactoryTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        RecordProperty("TestType", "interface-test");
+        RecordProperty("DerivationTechnique", "equivalence-classes");
+    }
+};
+
+TEST_F(WatchdogFactoryTest, CreateWatchdogReturnsNonNullInstance)
+{
+    RecordProperty("Description", "createWatchdog() returns a non-null IWatchdogIf instance.");
+
+    std::unique_ptr<IWatchdogIf> watchdog = createWatchdog();
+
+    ASSERT_NE(watchdog, nullptr);
+}
+
+TEST_F(WatchdogFactoryTest, CreateWatchdogReturnsIndependentInstancesEachCall)
+{
+    RecordProperty("Description", "Each call to createWatchdog() returns a new, independently owned instance.");
+
+    std::unique_ptr<IWatchdogIf> watchdog1 = createWatchdog();
+    std::unique_ptr<IWatchdogIf> watchdog2 = createWatchdog();
+
+    ASSERT_NE(watchdog1, nullptr);
+    ASSERT_NE(watchdog2, nullptr);
+    EXPECT_NE(watchdog1.get(), watchdog2.get());
+}
+

--- a/score/launch_manager/src/daemon/src/watchdog/details/BUILD
+++ b/score/launch_manager/src/daemon/src/watchdog/details/BUILD
@@ -44,7 +44,6 @@ cc_library(
 lm_cc_test(
     name = "watchdog_impl_UT",
     srcs = ["WatchdogImpl_UT.cpp"],
-    copts = ["-D_GNU_SOURCE"],
     deps = [
         ":watchdog",
         ":watchdog_impl",

--- a/score/launch_manager/src/daemon/src/watchdog/details/BUILD
+++ b/score/launch_manager/src/daemon/src/watchdog/details/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tests/utils/bazel:unit_test.bzl", "lm_cc_test")
 
 cc_library(
     name = "watchdog",
@@ -37,5 +38,19 @@ cc_library(
         "@score_baselibs//score/os:fcntl",
         "@score_baselibs//score/os:ioctl",
         "@score_baselibs//score/os:unistd",
+    ],
+)
+
+lm_cc_test(
+    name = "watchdog_impl_UT",
+    srcs = ["WatchdogImpl_UT.cpp"],
+    copts = ["-D_GNU_SOURCE"],
+    deps = [
+        ":watchdog",
+        ":watchdog_impl",
+        "@googletest//:gtest_main",
+        "@score_baselibs//score/os/mocklib:fcntl_mock",
+        "@score_baselibs//score/os/mocklib:ioctl_mock",
+        "@score_baselibs//score/os/mocklib:unistd_mock",
     ],
 )

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -150,17 +150,18 @@ void WatchdogImpl::serviceWatchdog() noexcept
     }
 
     // Cannot be invalid when state_ == ELibState::activated
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
-    
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+
     // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
     /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
-        * true_no_defect) */
+     * true_no_defect) */
     /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
-        * true_no_defect) */
+     * true_no_defect) */
     /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
-        * true_no_defect) */
+     * true_no_defect) */
     /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
-        * interface", true_no_defect) */
+     * interface", true_no_defect) */
     static_cast<void>(
         ioctl_.ioctl(watchdogDevice_->fileDescriptor, static_cast<std::int32_t>(WDIOC_KEEPALIVE), nullptr));
 }
@@ -175,8 +176,9 @@ void WatchdogImpl::fireWatchdogReaction() noexcept
     state_ = ELibState::react;
 
     // Cannot be invalid when state_ was ELibState::activated
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
-    
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+
     // This log message is introduced as a result of FMEA
     LM_LOG_FATAL() << "Watchdog: Trigger RESET for watchdog" << watchdogDevice_->config.fileName;
 
@@ -370,7 +372,8 @@ bool WatchdogImpl::updateTimeout(WatchdogDevice& f_state_r, std::int32_t f_confi
 bool WatchdogImpl::disableDevice(WatchdogDevice& f_watchdogDevice_r) const noexcept
 {
     // Cannot be invalid as this is only called when in state ELibState::activated
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
 
     if (!f_watchdogDevice_r.config.canBeDeactivated)
     {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -115,8 +115,9 @@ bool WatchdogImpl::enable() noexcept
         return false;
     }
 
-    if (!watchdogDevice_.has_value())
+    if (!deviceAlreadyConfigured())
     {
+        // noop if no device is configured
         return true;
     }
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -148,20 +148,20 @@ void WatchdogImpl::serviceWatchdog() noexcept
         return;
     }
 
-    if (watchdogDevice_->fileDescriptor >= 0)
-    {
-        // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
-        /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
-         * true_no_defect) */
-        /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
-         * true_no_defect) */
-        /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
-         * true_no_defect) */
-        /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
-         * interface", true_no_defect) */
-        static_cast<void>(
-            ioctl_.ioctl(watchdogDevice_->fileDescriptor, static_cast<std::int32_t>(WDIOC_KEEPALIVE), nullptr));
-    }
+    // Cannot be invalid when state_ == ELibState::activated
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+    
+    // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
+    /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
+        * true_no_defect) */
+    /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
+        * true_no_defect) */
+    /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+        * true_no_defect) */
+    /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+        * interface", true_no_defect) */
+    static_cast<void>(
+        ioctl_.ioctl(watchdogDevice_->fileDescriptor, static_cast<std::int32_t>(WDIOC_KEEPALIVE), nullptr));
 }
 
 void WatchdogImpl::fireWatchdogReaction() noexcept
@@ -172,15 +172,16 @@ void WatchdogImpl::fireWatchdogReaction() noexcept
     }
 
     state_ = ELibState::react;
-    if (watchdogDevice_->fileDescriptor >= 0)
-    {
-        // This log message is introduced as a result of FMEA
-        LM_LOG_FATAL() << "Watchdog: Trigger RESET for watchdog" << watchdogDevice_->config.fileName;
 
-        std::uint16_t timeout{0U};
-        // Save to ignore return value here. If setting timeout does not work, watchdog will eventually fire
-        static_cast<void>(setTimeout(watchdogDevice_->fileDescriptor, timeout));
-    }
+    // Cannot be invalid when state_ was ELibState::activated
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+    
+    // This log message is introduced as a result of FMEA
+    LM_LOG_FATAL() << "Watchdog: Trigger RESET for watchdog" << watchdogDevice_->config.fileName;
+
+    std::uint16_t timeout{0U};
+    // Save to ignore return value here. If setting timeout does not work, watchdog will eventually fire
+    static_cast<void>(setTimeout(watchdogDevice_->fileDescriptor, timeout));
 
     waitForever();
 }
@@ -367,7 +368,10 @@ bool WatchdogImpl::updateTimeout(WatchdogDevice& f_state_r, std::int32_t f_confi
 
 bool WatchdogImpl::disableDevice(WatchdogDevice& f_watchdogDevice_r) const noexcept
 {
-    if ((f_watchdogDevice_r.fileDescriptor < 0) || (!f_watchdogDevice_r.config.canBeDeactivated))
+    // Cannot be invalid as this is only called when in state ELibState::activated
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(watchdogDevice_->fileDescriptor >= 0, "Watchdog file descriptor is not valid");
+
+    if (!f_watchdogDevice_r.config.canBeDeactivated)
     {
         return false;
     }

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -50,7 +50,7 @@ T secToMs(const T f_timeout)
  * ref",true_no_defect) */
 /* RULECHECKER_comment(0:0,9:0, check_min_instructions, "Constructor with empty body is valid", true_no_defect) */
 WatchdogImpl::WatchdogImpl(score::os::Ioctl& ioctl, score::os::Fcntl& fcntl, score::os::Unistd& unistd) noexcept
-    : IWatchdogIf(), watchdogDevices_(), state_(ELibState::idle), ioctl_(ioctl), fcntl_(fcntl), unistd_(unistd)
+    : IWatchdogIf(), watchdogDevice_(), state_(ELibState::idle), ioctl_(ioctl), fcntl_(fcntl), unistd_(unistd)
 {
 }
 
@@ -86,7 +86,7 @@ bool WatchdogImpl::init(
     catch (const std::exception& e)
     {
         isSuccess = false;
-        watchdogDevices_.clear();
+        watchdogDevice_.reset();
         LM_LOG_ERROR() << "Watchdog: Watchdog initialization failed:" << std::string(e.what());
     }
     return isSuccess;
@@ -104,9 +104,7 @@ bool WatchdogImpl::configureDevice(const DeviceConfig& f_config_r, std::int64_t 
         return false;
     }
 
-    WatchdogDevice watchdogdevice{f_config_r};
-    // Space was reserved during init(), will not throw
-    watchdogDevices_.push_back(watchdogdevice);
+    watchdogDevice_ = WatchdogDevice{f_config_r};
     return true;
 }
 
@@ -117,17 +115,17 @@ bool WatchdogImpl::enable() noexcept
         return false;
     }
 
-    bool result{true};
-    for (auto& watchdogDevice : watchdogDevices_)
+    if (!watchdogDevice_.has_value())
     {
-        const auto wasEnabled{enableDevice(watchdogDevice)};
-        if (wasEnabled)
-        {
-            state_ = ELibState::activated;
-        }
-        result = result && wasEnabled;
+        return true;
     }
-    return result;
+
+    const auto wasEnabled{enableDevice(*watchdogDevice_)};
+    if (wasEnabled)
+    {
+        state_ = ELibState::activated;
+    }
+    return wasEnabled;
 }
 
 void WatchdogImpl::disable() noexcept
@@ -136,13 +134,8 @@ void WatchdogImpl::disable() noexcept
     {
         return;
     }
-    bool allDisabled{true};
-    for (auto& watchdogDevice : watchdogDevices_)
-    {
-        const bool wasDisabled{disableDevice(watchdogDevice)};
-        allDisabled = allDisabled && wasDisabled;
-    }
-    if (allDisabled)
+
+    if (disableDevice(*watchdogDevice_))
     {
         state_ = ELibState::idle;
     }
@@ -155,22 +148,19 @@ void WatchdogImpl::serviceWatchdog() noexcept
         return;
     }
 
-    for (auto& watchdogDevice : watchdogDevices_)
+    if (watchdogDevice_->fileDescriptor >= 0)
     {
-        if (watchdogDevice.fileDescriptor >= 0)
-        {
-            // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
-            /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
-             * true_no_defect) */
-            /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
-             * true_no_defect) */
-            /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
-             * true_no_defect) */
-            /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
-             * interface", true_no_defect) */
-            static_cast<void>(
-                ioctl_.ioctl(watchdogDevice.fileDescriptor, static_cast<std::int32_t>(WDIOC_KEEPALIVE), nullptr));
-        }
+        // save to ignore return value here. If keepalive does not work, watchdog will eventually fire
+        /* RULECHECKER_comment(1:0,5:0, check_bitop_recast, "Linux-only constant from external interface",
+         * true_no_defect) */
+        /* RULECHECKER_comment(1:0,4:0, check_bitop_type, "Linux-only constant from external interface",
+         * true_no_defect) */
+        /* RULECHECKER_comment(1:0,3:0, check_plain_char_operator, "Linux-only constant from external interface",
+         * true_no_defect) */
+        /* RULECHECKER_comment(1:0,2:0, check_underlying_signedness_conversion, "Linux-only constant from external
+         * interface", true_no_defect) */
+        static_cast<void>(
+            ioctl_.ioctl(watchdogDevice_->fileDescriptor, static_cast<std::int32_t>(WDIOC_KEEPALIVE), nullptr));
     }
 }
 
@@ -182,17 +172,14 @@ void WatchdogImpl::fireWatchdogReaction() noexcept
     }
 
     state_ = ELibState::react;
-    for (auto& watchdogDevice : watchdogDevices_)
+    if (watchdogDevice_->fileDescriptor >= 0)
     {
-        if (watchdogDevice.fileDescriptor >= 0)
-        {
-            // This log message is introduced as a result of FMEA
-            LM_LOG_FATAL() << "Watchdog: Trigger RESET for watchdog" << watchdogDevice.config.fileName;
+        // This log message is introduced as a result of FMEA
+        LM_LOG_FATAL() << "Watchdog: Trigger RESET for watchdog" << watchdogDevice_->config.fileName;
 
-            std::uint16_t timeout{0U};
-            // Save to ignore return value here. If setting timeout does not work, watchdog will eventually fire
-            static_cast<void>(setTimeout(watchdogDevice.fileDescriptor, timeout));
-        }
+        std::uint16_t timeout{0U};
+        // Save to ignore return value here. If setting timeout does not work, watchdog will eventually fire
+        static_cast<void>(setTimeout(watchdogDevice_->fileDescriptor, timeout));
     }
 
     waitForever();
@@ -413,21 +400,14 @@ bool WatchdogImpl::hasValidTimeout(const DeviceConfig& f_config_r) noexcept
     return validRange && validResolution;
 }
 
-bool WatchdogImpl::deviceAlreadyConfigured(const DeviceConfig& f_config_r) const noexcept
+bool WatchdogImpl::deviceAlreadyConfigured() const noexcept
 {
-    for (const auto& device : watchdogDevices_)
-    {
-        if (device.config.fileName == f_config_r.fileName)
-        {
-            return true;
-        }
-    }
-    return false;
+    return watchdogDevice_.has_value();
 }
 
 bool WatchdogImpl::isValidDeviceConfig(const DeviceConfig& f_config_r, std::int64_t f_cycleTimeInNs) const noexcept
 {
-    if (deviceAlreadyConfigured(f_config_r))
+    if (deviceAlreadyConfigured())
     {
         return false;
     }

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -20,6 +20,7 @@
 #include "score/os/fcntl.h"
 #include "score/os/ioctl.h"
 #include "score/os/unistd.h"
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -131,10 +132,10 @@ class WatchdogImpl : public IWatchdogIf
         int fileDescriptor{-1};
     };
 
-    /// @brief Registers a new watchdog device for usage if the DeviceConfig is valid
+    /// @brief Registers the watchdog device for usage if the DeviceConfig is valid
     /// @param[in] f_config_r The DeviceConfig to register
     /// @param[in] f_cycleTimeInNs The CycleTime in ns that will be used to notify aliveness
-    /// @throws std::length_error in case of insufficient memory to allocate watchdog device
+    /// @throws std::bad_alloc in case of insufficient memory to store the device configuration
     /// @return True if the given DeviceConfig is valid and has been registered else false
     bool configureDevice(const DeviceConfig& f_config_r, std::int64_t f_cycleTimeInNs) noexcept(false);
 
@@ -197,14 +198,13 @@ class WatchdogImpl : public IWatchdogIf
     /// @return True if the timeout is in a valid range and has valid resolution, else false
     static bool hasValidTimeout(const DeviceConfig& f_config_r) noexcept;
 
-    /// @brief Checks if the given DeviceConfig is already configured
-    /// @param[in] f_config_r The DeviceConfig to check against the configured configs
-    /// @return True if the given DeviceConfig has already been configured, else false
-    bool deviceAlreadyConfigured(const DeviceConfig& f_config_r) const noexcept;
+    /// @brief Checks if a watchdog device has already been configured
+    /// @return True if a watchdog device has already been configured, else false
+    bool deviceAlreadyConfigured() const noexcept;
 
     /// @brief Validates the given DeviceConfig
     /// @details Validation includes the following checks:
-    /// * Checking if the DeviceConfig is already configured
+    /// * Checking if a watchdog device has already been configured
     /// * Checking if the timeout of the DeviceConfig is valid
     /// * Checking if the device file exists
     /// * Checking if the device file is accessible
@@ -222,8 +222,8 @@ class WatchdogImpl : public IWatchdogIf
     /// @return True if cycleTime <= timeout_max, else false
     static bool validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, const DeviceConfig& f_config_r) noexcept;
 
-    /// @brief Keeps track of the state of each configured watchdog device
-    std::vector<WatchdogDevice> watchdogDevices_;
+    /// @brief Keeps track of the state of the configured watchdog device, if any.
+    std::optional<WatchdogDevice> watchdogDevice_;
     /// @brief The internal state of this class
     ELibState state_;
     /// @brief Interface used to issue ioctl calls on watchdog device files.

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -408,8 +408,7 @@ struct EnableFailureCase
     EnableStep failingStep;
 };
 
-class WatchdogImpl_UT_EnableFailure : public WatchdogImplTest,
-                                      public ::testing::WithParamInterface<EnableFailureCase>
+class WatchdogImpl_UT_EnableFailure : public WatchdogImplTest, public ::testing::WithParamInterface<EnableFailureCase>
 {
 };
 
@@ -432,7 +431,9 @@ INSTANTIATE_TEST_SUITE_P(
     WatchdogImpl_UT_EnableFailure,
     ::testing::Values(
         EnableFailureCase{
-            "OpenFails", "enable() fails when opening the configured device file fails.", EnableStep::kOpen},
+            "OpenFails",
+            "enable() fails when opening the configured device file fails.",
+            EnableStep::kOpen},
         EnableFailureCase{
             "GetTimeoutFails",
             "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.",
@@ -446,8 +447,12 @@ INSTANTIATE_TEST_SUITE_P(
             "enable() fails and skips WDIOC_SETOPTIONS when WDIOC_SETTIMEOUT fails.",
             EnableStep::kSetTimeout},
         EnableFailureCase{
-            "EnablecardFails", "enable() fails when the WDIOS_ENABLECARD ioctl fails.", EnableStep::kSetOptions}),
-    [](const ::testing::TestParamInfo<EnableFailureCase>& info) { return info.param.name; });
+            "EnablecardFails",
+            "enable() fails when the WDIOS_ENABLECARD ioctl fails.",
+            EnableStep::kSetOptions}),
+    [](const ::testing::TestParamInfo<EnableFailureCase>& info) {
+        return info.param.name;
+    });
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfTimeoutValueIsAltered)
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -16,6 +16,7 @@
 
 #include <cerrno>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -105,9 +106,10 @@ auto AlterOutParamBy(std::int32_t delta)
 class WatchdogImpl_FireWatchdogMock : public WatchdogImpl
 {
   public:
-    explicit WatchdogImpl_FireWatchdogMock(score::os::Ioctl& ioctl,
-                                           score::os::Fcntl& fcntl,
-                                           score::os::Unistd& unistd) noexcept
+    explicit WatchdogImpl_FireWatchdogMock(
+        score::os::Ioctl& ioctl,
+        score::os::Fcntl& fcntl,
+        score::os::Unistd& unistd) noexcept
         : WatchdogImpl{ioctl, fcntl, unistd}
     {
     }
@@ -125,10 +127,11 @@ class WatchdogImplTest : public ::testing::Test
     }
 
     /// @brief Creates a WatchdogConfig instance with the given parameters.
-    static WatchdogConfig makeCfg(std::string fileName,
-                                  std::uint32_t maxTimeoutMs,
-                                  bool canBeDeactivated = true,
-                                  bool needsMagicClose = false)
+    static WatchdogConfig makeCfg(
+        std::string fileName,
+        std::uint32_t maxTimeoutMs,
+        bool canBeDeactivated = true,
+        bool needsMagicClose = false)
     {
         WatchdogConfig cfg{};
         cfg.device_file_path = std::move(fileName);
@@ -187,36 +190,57 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfNotInIdleState)
 {
     RecordProperty("Description", "init() fails when the watchdog is already in the activated state.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     expectFullEnable(cfg);
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
     ASSERT_TRUE(wdg->enable());
 
-    auto cfg2 = makeCfg("/dev/watchdog_2", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_2", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     EXPECT_FALSE(wdg->init(cfg2, kDefaultCycleTimeNs));
 }
 
 TEST_F(WatchdogImplTest, WdgInit_FailsWatchdogTimeoutSmallerThenCycleTime)
 {
-    RecordProperty("Description",
-                   "init() fails when the configured cycle time is larger than the device's max timeout, since "
-                   "serviceWatchdog() could not be called in time to prevent a reset.");
+    RecordProperty(
+        "Description",
+        "init() fails when the configured cycle time is larger than the device's max timeout, since "
+        "serviceWatchdog() could not be called in time to prevent a reset.");
 
     constexpr std::uint32_t timeoutMs{2000U};
-    constexpr std::uint32_t nanosecPerMillisec =  1'000'000;
+    constexpr std::uint32_t nanosecPerMillisec = 1'000'000;
     const std::int64_t cycleTimeNs{static_cast<std::int64_t>(timeoutMs + 1U) * nanosecPerMillisec};
-    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true, false);
+    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
 
     EXPECT_FALSE(wdg->init(cfg, cycleTimeNs));
+}
+
+TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutExceedsUint16Max)
+{
+    RecordProperty(
+        "Description",
+        "init() fails when the configured max timeout does not fit into uint16_t, before the "
+        "kTimeoutMaxMillis range check is even applied.");
+
+    constexpr std::uint32_t timeoutExceedingUint16Max{
+        static_cast<std::uint32_t>(std::numeric_limits<std::uint16_t>::max()) + 1U};
+    auto cfg =
+        makeCfg("/dev/watchdog", timeoutExceedingUint16Max, true /*canBeDeactivated*/, false /*needsMagicClose*/);
+    auto wdg = makeWatchdog();
+
+    EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
 }
 
 TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutIsTooLarge)
 {
     RecordProperty("Description", "init() fails when the configured timeout exceeds kTimeoutMaxMillis.");
 
-    auto cfg = makeCfg("/dev/watchdog", static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis) + 1U, true, false);
+    auto cfg = makeCfg(
+        "/dev/watchdog",
+        static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis) + 1U,
+        true /*canBeDeactivated*/,
+        false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
 }
@@ -225,7 +249,11 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutIsTooSmall)
 {
     RecordProperty("Description", "init() fails when the configured timeout is below kTimeoutMinMillis.");
 
-    auto cfg = makeCfg("/dev/watchdog", static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis) - 1U, true, false);
+    auto cfg = makeCfg(
+        "/dev/watchdog",
+        static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis) - 1U,
+        true /*canBeDeactivated*/,
+        false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
 }
@@ -233,11 +261,12 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutIsTooSmall)
 #ifndef __QNXNTO__
 TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutResolutionIsWrong)
 {
-    RecordProperty("Description",
-                   "init() fails on Linux when the configured timeout is not a multiple of the 1 second "
-                   "resolution.");
+    RecordProperty(
+        "Description",
+        "init() fails on Linux when the configured timeout is not a multiple of the 1 second "
+        "resolution.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2123U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2123U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
 
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
@@ -246,15 +275,16 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutResolutionIsWrong)
 
 TEST_F(WatchdogImplTest, WdgInit_FailsIfDeviceAlreadyConfigured)
 {
-    RecordProperty("Description",
-                   "init() fails when called a second time, since only a single watchdog device is supported.");
+    RecordProperty(
+        "Description", "init() fails when called a second time, since only a single watchdog device is supported.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
-    EXPECT_FALSE(wdg->init(makeCfg("/dev/watchdog_2", 2000U, true, false), kDefaultCycleTimeNs));
+    EXPECT_FALSE(wdg->init(
+        makeCfg("/dev/watchdog_2", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/), kDefaultCycleTimeNs));
 }
 
 class WatchdogImpl_UT_paramConfigName : public WatchdogImplTest, public ::testing::WithParamInterface<std::uint32_t>
@@ -266,16 +296,18 @@ TEST_P(WatchdogImpl_UT_paramConfigName, WdgInit_SucceedsWithValidDeviceConfigura
     RecordProperty("Description", "init() succeeds for boundary timeout values (min, mid, max).");
 
     const std::uint32_t timeoutMs{GetParam()};
-    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true, false);
+    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     EXPECT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs)) << "Expected init() to succeed for timeout=" << timeoutMs << "ms";
 }
 
-INSTANTIATE_TEST_SUITE_P(Boundary,
-                         WatchdogImpl_UT_paramConfigName,
-                         ::testing::Values(static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis),
-                                            static_cast<std::uint32_t>(2000U),
-                                            static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis)));
+INSTANTIATE_TEST_SUITE_P(
+    Boundary,
+    WatchdogImpl_UT_paramConfigName,
+    ::testing::Values(
+        static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis),
+        static_cast<std::uint32_t>(2000U),
+        static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis)));
 
 // ═══════════════════════════════════════════════════════════
 // enable() tests
@@ -291,10 +323,9 @@ TEST_F(WatchdogImplTest, WdgEnable_SucceedsIfNoDeviceConfigured)
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotInIdleState)
 {
-    RecordProperty("Description",
-                   "enable() fails when called a second time after the watchdog is already activated.");
+    RecordProperty("Description", "enable() fails when called a second time after the watchdog is already activated.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     expectFullEnable(cfg);
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
@@ -307,7 +338,7 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfOpenFails)
 {
     RecordProperty("Description", "enable() fails when opening the configured device file fails.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -319,11 +350,12 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfOpenFails)
 
 TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutAlreadyCorrect)
 {
-    RecordProperty("Description",
-                   "enable() skips WDIOC_GETTIMELEFT and WDIOC_SETTIMEOUT when the device already reports the "
-                   "desired timeout.");
+    RecordProperty(
+        "Description",
+        "enable() skips WDIOC_GETTIMELEFT and WDIOC_SETTIMEOUT when the device already reports the "
+        "desired timeout.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -331,7 +363,7 @@ TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutA
     constexpr std::int32_t kMillisPerSecond = 1000U;
     const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms / kMillisPerSecond)};
 #else
-    constexpr std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms)};
+    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms)};
 #endif
 
     EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
@@ -345,10 +377,9 @@ TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutA
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetTimeoutFails)
 {
-    RecordProperty("Description",
-                   "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.");
+    RecordProperty("Description", "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -363,10 +394,10 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetTimeoutFails)
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetRemainingTimeLeftFails)
 {
-    RecordProperty("Description",
-                   "enable() fails and skips WDIOC_SETTIMEOUT/WDIOC_SETOPTIONS when WDIOC_GETTIMELEFT fails.");
+    RecordProperty(
+        "Description", "enable() fails and skips WDIOC_SETTIMEOUT/WDIOC_SETOPTIONS when WDIOC_GETTIMELEFT fails.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -383,7 +414,7 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfSetTimeoutFails)
 {
     RecordProperty("Description", "enable() fails and skips WDIOC_SETOPTIONS when WDIOC_SETTIMEOUT fails.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -398,10 +429,9 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfSetTimeoutFails)
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfTimeoutValueIsAltered)
 {
-    RecordProperty("Description",
-                   "enable() fails when the device alters the requested timeout to a different value.");
+    RecordProperty("Description", "enable() fails when the device alters the requested timeout to a different value.");
 
-    auto cfg = makeCfg("/dev/watchdog", 30'000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 30'000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -419,7 +449,7 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfEnablecardFails)
 {
     RecordProperty("Description", "enable() fails when the WDIOS_ENABLECARD ioctl fails.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -440,7 +470,7 @@ TEST_F(WatchdogImplTest, WdgServiceWatchdog_NotInActivatedState)
 {
     RecordProperty("Description", "serviceWatchdog() is a no-op when the watchdog has not been enabled.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -463,7 +493,7 @@ TEST_F(WatchdogImplTest, WdgServiceWatchdog_OneDevice)
 {
     RecordProperty("Description", "serviceWatchdog() issues a single WDIOC_KEEPALIVE for one activated device.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
 
     expectFullEnable(cfg);
@@ -480,11 +510,12 @@ TEST_F(WatchdogImplTest, WdgServiceWatchdog_OneDevice)
 
 TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FailsIfNotInActivatedState)
 {
-    RecordProperty("Description",
-                   "fireWatchdogReaction() is a no-op and does not call waitForever() when the watchdog has not "
-                   "been enabled.");
+    RecordProperty(
+        "Description",
+        "fireWatchdogReaction() is a no-op and does not call waitForever() when the watchdog has not "
+        "been enabled.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdogFireMock();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -495,11 +526,12 @@ TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FailsIfNotInActivatedState)
 
 TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OneDevice)
 {
-    RecordProperty("Description",
-                   "fireWatchdogReaction() sets WDIOC_SETTIMEOUT to 0 and calls waitForever() for one activated "
-                   "device.");
+    RecordProperty(
+        "Description",
+        "fireWatchdogReaction() sets WDIOC_SETTIMEOUT to 0 and calls waitForever() for one activated "
+        "device.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdogFireMock();
 
     expectFullEnable(cfg);
@@ -519,7 +551,7 @@ TEST_F(WatchdogImplTest, WdgDisable_FailsIfNotInActivatedState)
 {
     RecordProperty("Description", "disable() is a no-op when the watchdog has not been enabled.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
@@ -532,10 +564,28 @@ TEST_F(WatchdogImplTest, WdgDisable_FailsIfNotInActivatedState)
 
 TEST_F(WatchdogImplTest, WdgDisable_DisablesOneDevice)
 {
-    RecordProperty("Description",
-                   "disable() issues WDIOS_DISABLECARD and closes the device file for a single activated device.");
+    RecordProperty(
+        "Description", "disable() issues WDIOS_DISABLECARD and closes the device file for a single activated device.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
+    auto wdg = makeWatchdog();
+
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    expectDisable(cfg);
+    wdg->disable();
+}
+
+TEST_F(WatchdogImplTest, WdgDisable_WritesMagicCloseCharacterWhenRequired)
+{
+    RecordProperty(
+        "Description",
+        "disable() writes the magic close character before issuing WDIOS_DISABLECARD for a device that "
+        "requires it.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, true /*needsMagicClose*/);
     auto wdg = makeWatchdog();
 
     expectFullEnable(cfg);
@@ -548,10 +598,10 @@ TEST_F(WatchdogImplTest, WdgDisable_DisablesOneDevice)
 
 TEST_F(WatchdogImplTest, WdgDisable_IgnoresDevicesThatCannotBeDisabled)
 {
-    RecordProperty("Description",
-                   "disable() performs no ioctl/write/close calls for a device configured as non-deactivatable.");
+    RecordProperty(
+        "Description", "disable() performs no ioctl/write/close calls for a device configured as non-deactivatable.");
 
-    auto cfg = makeCfg("/dev/watchdog", 2000U, false, true);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, false /*canBeDeactivated*/, true /*needsMagicClose*/);
     auto wdg = makeWatchdog();
 
     expectFullEnable(cfg);

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -1,0 +1,735 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "score/mw/launch_manager/configuration/config.hpp"
+#include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
+#include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
+#include "score/os/errno.h"
+#include "score/os/mocklib/fcntl_mock.h"
+#include "score/os/mocklib/ioctl_mock.h"
+#include "score/os/mocklib/unistdmock.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::StrEq;
+
+using score::lcm::watchdog::IWatchdogIf;
+using score::lcm::watchdog::WatchdogImpl;
+using score::mw::launch_manager::configuration::WatchdogConfig;
+
+namespace
+{
+
+/// @brief Cycle time of 50ms in nanoseconds, used as the default for tests that don't care about the exact value.
+constexpr std::int64_t kDefaultCycleTimeNs{50'000'000};
+
+score::cpp::expected_blank<score::os::Error> IoctlOk()
+{
+    return score::cpp::expected_blank<score::os::Error>{};
+}
+
+score::cpp::expected_blank<score::os::Error> IoctlErr(std::int32_t errnoCode = EIO)
+{
+    return score::cpp::unexpected(score::os::Error::createFromErrno(errnoCode));
+}
+
+score::cpp::expected<std::int32_t, score::os::Error> OpenOk(std::int32_t fd)
+{
+    return fd;
+}
+
+score::cpp::expected<std::int32_t, score::os::Error> OpenErr()
+{
+    return score::cpp::unexpected(score::os::Error::createFromErrno(ENOENT));
+}
+
+score::cpp::expected_blank<score::os::Error> CloseOk()
+{
+    return score::cpp::expected_blank<score::os::Error>{};
+}
+
+score::cpp::expected<ssize_t, score::os::Error> WriteOk(ssize_t n)
+{
+    return n;
+}
+
+/// @brief Writes `value` into the ioctl out-param and reports success. Used for WDIOC_GETTIMEOUT/WDIOC_GETTIMELEFT.
+auto SetOutParam(std::int32_t value)
+{
+    return testing::Invoke([value](std::int32_t, std::int32_t, void* arg) {
+        if (arg != nullptr)
+        {
+            *static_cast<std::int32_t*>(arg) = value;
+        }
+        return score::cpp::expected_blank<score::os::Error>{};
+    });
+}
+
+/// @brief Simulates a device altering the requested WDIOC_SETTIMEOUT value by `delta`.
+auto AlterOutParamBy(std::int32_t delta)
+{
+    return testing::Invoke([delta](std::int32_t, std::int32_t, void* arg) {
+        if (arg != nullptr)
+        {
+            *static_cast<std::int32_t*>(arg) += delta;
+        }
+        return score::cpp::expected_blank<score::os::Error>{};
+    });
+}
+
+/// @brief WatchdogImpl subclass that mocks waitForever() so fireWatchdogReaction() returns for testing.
+class WatchdogImpl_FireWatchdogMock : public WatchdogImpl
+{
+  public:
+    explicit WatchdogImpl_FireWatchdogMock(score::os::Ioctl& ioctl,
+                                           score::os::Fcntl& fcntl,
+                                           score::os::Unistd& unistd) noexcept
+        : WatchdogImpl{ioctl, fcntl, unistd}
+    {
+    }
+
+    MOCK_METHOD(void, waitForever, (), (const, noexcept, override));
+};
+
+class WatchdogImplTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        RecordProperty("TestType", "interface-test");
+        RecordProperty("DerivationTechnique", "equivalence-classes");
+    }
+
+    /// @brief Creates a WatchdogConfig instance with the given parameters.
+    static WatchdogConfig makeCfg(std::string fileName,
+                                  std::uint32_t maxTimeoutMs,
+                                  bool canBeDeactivated = true,
+                                  bool needsMagicClose = false)
+    {
+        WatchdogConfig cfg{};
+        cfg.device_file_path = std::move(fileName);
+        cfg.max_timeout_ms = maxTimeoutMs;
+        cfg.deactivate_on_shutdown = canBeDeactivated;
+        cfg.require_magic_close = needsMagicClose;
+        return cfg;
+    }
+
+    /// @brief Creates a new WatchdogImpl with mocked OS interfaces injected.
+    std::unique_ptr<WatchdogImpl> makeWatchdog()
+    {
+        return std::make_unique<WatchdogImpl>(*ioctlMock_, *fcntlMock_, *unistdMock_);
+    }
+
+    /// @brief Creates a WatchdogImpl_FireWatchdogMock with mocked OS interfaces injected.
+    std::unique_ptr<WatchdogImpl_FireWatchdogMock> makeWatchdogFireMock()
+    {
+        return std::make_unique<WatchdogImpl_FireWatchdogMock>(*ioctlMock_, *fcntlMock_, *unistdMock_);
+    }
+
+    /// @brief Programs the mocks so that opening the devices in `cfgs` succeeds (each returning `fd`).
+    void expectDeviceOpens(std::initializer_list<const WatchdogConfig*> cfgs, std::int32_t fd = 1)
+    {
+        for (const WatchdogConfig* cfg : cfgs)
+        {
+            EXPECT_CALL(*fcntlMock_, open(StrEq(cfg->device_file_path), _)).WillOnce(Return(OpenOk(fd)));
+        }
+    }
+
+    /// @brief Programs the mocks so that `times` devices go through the full enable ioctl sequence
+    /// (GETTIMEOUT -> GETTIMELEFT -> SETTIMEOUT -> SETOPTIONS) and succeed.
+    /// @note A single combined expectation per ioctl request is used (rather than one per device) since
+    /// gmock does not fall back to an older matching WillOnce() expectation once the newest one saturates.
+    void expectFullEnableIoctls(int times, std::int32_t fd = 1)
+    {
+        // Report a current timeout of 0, which never matches a configured device timeout, so that the
+        // enable sequence always goes through GETTIMELEFT + SETTIMEOUT.
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMEOUT, _)).Times(times).WillRepeatedly(SetOutParam(0));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMELEFT, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETTIMEOUT, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETOPTIONS, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
+    }
+
+    /// @brief Programs the mocks so that enabling the single device for `cfg` goes through the full enable
+    /// sequence (open -> GETTIMEOUT -> GETTIMELEFT -> SETTIMEOUT -> SETOPTIONS) and succeeds.
+    void expectFullEnable(const WatchdogConfig& cfg, std::int32_t fd = 1)
+    {
+        expectDeviceOpens({&cfg}, fd);
+        expectFullEnableIoctls(1, fd);
+    }
+
+    /// @brief Programs the mocks for a successful disableDevice() sequence on `fd`.
+    void expectDisable(const WatchdogConfig& cfg, std::int32_t fd = 1)
+    {
+        if (cfg.require_magic_close)
+        {
+            EXPECT_CALL(*unistdMock_, write(fd, _, _)).WillOnce(Return(WriteOk(2)));
+        }
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlOk()));
+        EXPECT_CALL(*unistdMock_, close(fd)).WillOnce(Return(CloseOk()));
+    }
+
+    score::os::MockGuard<score::os::FcntlMock> fcntlMock_;
+    score::os::MockGuard<score::os::IoctlMock> ioctlMock_;
+    score::os::MockGuard<score::os::UnistdMock> unistdMock_;
+};
+
+// ═══════════════════════════════════════════════════════════
+// init() tests
+// ═══════════════════════════════════════════════════════════
+
+TEST_F(WatchdogImplTest, WdgInit_FailsIfNotInIdleState)
+{
+    RecordProperty("Description", "init() fails when the watchdog is already in the activated state.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    auto cfg2 = makeCfg("/dev/watchdog_2", 2000U, true, false);
+    EXPECT_FALSE(wdg->init(cfg2, kDefaultCycleTimeNs));
+}
+
+TEST_F(WatchdogImplTest, WdgInit_FailsWatchdogTimeoutSmallerThenCycleTime)
+{
+    RecordProperty("Description",
+                   "init() fails when the configured cycle time is larger than the device's max timeout, since "
+                   "serviceWatchdog() could not be called in time to prevent a reset.");
+
+    constexpr std::uint32_t timeoutMs{2000U};
+    const std::int64_t cycleTimeNs{static_cast<std::int64_t>(timeoutMs + 1U) * 1'000'000};
+    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true, false);
+    auto wdg = makeWatchdog();
+    EXPECT_FALSE(wdg->init(cfg, cycleTimeNs));
+}
+
+TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutIsTooLarge)
+{
+    RecordProperty("Description", "init() fails when the configured timeout exceeds kTimeoutMaxMillis.");
+
+    auto cfg = makeCfg("/dev/watchdog", static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis) + 1U, true, false);
+    auto wdg = makeWatchdog();
+    EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
+}
+
+TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutIsTooSmall)
+{
+    RecordProperty("Description", "init() fails when the configured timeout is below kTimeoutMinMillis.");
+
+    auto cfg = makeCfg("/dev/watchdog", static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis) - 1U, true, false);
+    auto wdg = makeWatchdog();
+    EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
+}
+
+#ifndef __QNXNTO__
+TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutResolutionIsWrong)
+{
+    RecordProperty("Description",
+                   "init() fails on Linux when the configured timeout is not a multiple of the 1 second "
+                   "resolution.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2123U, true, false);
+    auto wdg = makeWatchdog();
+    EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
+}
+#endif
+
+TEST_F(WatchdogImplTest, WdgInit_FailsIfSameDeviceAlreadyConfigured)
+{
+    RecordProperty("Description", "init() fails when the same device file path is configured a second time.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
+}
+
+TEST_F(WatchdogImplTest, WdgInit_SucceedsWithMultipleDifferentValidDeviceConfiguration)
+{
+    RecordProperty("Description",
+                   "init() succeeds when called multiple times with distinct, valid device configurations.");
+
+    auto wdg = makeWatchdog();
+    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_0", 2000U, true, false), kDefaultCycleTimeNs));
+    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_1", 2000U, true, false), kDefaultCycleTimeNs));
+    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_2", 2000U, true, false), kDefaultCycleTimeNs));
+}
+
+class WatchdogImpl_UT_paramConfigName : public WatchdogImplTest, public ::testing::WithParamInterface<std::uint32_t>
+{
+};
+
+TEST_P(WatchdogImpl_UT_paramConfigName, WdgInit_SucceedsWithValidDeviceConfiguration)
+{
+    RecordProperty("Description", "init() succeeds for boundary timeout values (min, mid, max).");
+
+    const std::uint32_t timeoutMs{GetParam()};
+    auto cfg = makeCfg("/dev/watchdog", timeoutMs, true, false);
+    auto wdg = makeWatchdog();
+    EXPECT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs)) << "Expected init() to succeed for timeout=" << timeoutMs << "ms";
+}
+
+INSTANTIATE_TEST_SUITE_P(Boundary,
+                         WatchdogImpl_UT_paramConfigName,
+                         ::testing::Values(static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMinMillis),
+                                            static_cast<std::uint32_t>(2000U),
+                                            static_cast<std::uint32_t>(IWatchdogIf::kTimeoutMaxMillis)));
+
+// ═══════════════════════════════════════════════════════════
+// enable() tests
+// ═══════════════════════════════════════════════════════════
+
+TEST_F(WatchdogImplTest, WdgEnable_SucceedsIfNoDeviceConfigured)
+{
+    RecordProperty("Description", "enable() succeeds when no watchdog device has been configured.");
+
+    auto wdg = makeWatchdog();
+    EXPECT_TRUE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotInIdleState)
+{
+    RecordProperty("Description",
+                   "enable() fails when called a second time after the watchdog is already activated.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotAllWatchdogsCouldBeEnabled)
+{
+    RecordProperty("Description",
+                   "enable() fails when opening one of multiple configured devices fails.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    expectFullEnable(cfg1);
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutAlreadyCorrect)
+{
+    RecordProperty("Description",
+                   "enable() skips WDIOC_GETTIMELEFT and WDIOC_SETTIMEOUT when the device already reports the "
+                   "desired timeout.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+#ifndef __QNXNTO__
+    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms / 1000U)};
+#else
+    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms)};
+#endif
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(currentTimeoutRaw));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).Times(0);
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(0);
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlOk()));
+
+    EXPECT_TRUE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetTimeoutFails)
+{
+    RecordProperty("Description",
+                   "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(Return(IoctlErr()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).Times(0);
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(0);
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetRemainingTimeLeftFails)
+{
+    RecordProperty("Description",
+                   "enable() fails and skips WDIOC_SETTIMEOUT/WDIOC_SETOPTIONS when WDIOC_GETTIMELEFT fails.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlErr()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(0);
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfSetTimeoutFails)
+{
+    RecordProperty("Description", "enable() fails and skips WDIOC_SETOPTIONS when WDIOC_SETTIMEOUT fails.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlErr()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfTimeoutValueIsAltered)
+{
+    RecordProperty("Description",
+                   "enable() fails when the device alters the requested timeout to a different value.");
+
+    auto cfg = makeCfg("/dev/watchdog", 30'000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
+    // Device alters the requested timeout to a value that doesn't match what was requested.
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(AlterOutParamBy(1));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfEnablecardFails)
+{
+    RecordProperty("Description", "enable() fails when the WDIOS_ENABLECARD ioctl fails.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlOk()));
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlErr()));
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_FailsForMultipleDevices)
+{
+    RecordProperty("Description",
+                   "enable() fails and performs no ioctls when opening all configured devices fails.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(_, _)).Times(2).WillRepeatedly(Return(OpenErr()));
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
+
+    EXPECT_FALSE(wdg->enable());
+}
+
+TEST_F(WatchdogImplTest, WdgEnable_EnablesMultipleDevices)
+{
+    RecordProperty("Description",
+                   "enable() succeeds when all of multiple configured devices are enabled successfully.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", IWatchdogIf::kTimeoutMinMillis, false, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto cfg3 = makeCfg("/dev/watchdog_2", IWatchdogIf::kTimeoutMaxMillis, true, true);
+
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg3, kDefaultCycleTimeNs));
+
+    expectDeviceOpens({&cfg1, &cfg2, &cfg3});
+    expectFullEnableIoctls(3);
+
+    EXPECT_TRUE(wdg->enable());
+}
+
+// ═══════════════════════════════════════════════════════════
+// serviceWatchdog() tests
+// ═══════════════════════════════════════════════════════════
+
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_OnlyServicesActivatedWatchdogs)
+{
+    RecordProperty("Description",
+                   "serviceWatchdog() only issues WDIOC_KEEPALIVE for devices that were successfully activated.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto wdg = makeWatchdog();
+
+    expectFullEnable(cfg1);
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    ASSERT_FALSE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(1).WillOnce(Return(IoctlOk()));
+    wdg->serviceWatchdog();
+}
+
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_NotInActivatedState)
+{
+    RecordProperty("Description", "serviceWatchdog() is a no-op when the watchdog has not been enabled.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
+    wdg->serviceWatchdog();
+}
+
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_NoDevice)
+{
+    RecordProperty("Description", "serviceWatchdog() is a no-op when enabled with zero configured devices.");
+
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
+    wdg->serviceWatchdog();
+}
+
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_OneDevice)
+{
+    RecordProperty("Description", "serviceWatchdog() issues a single WDIOC_KEEPALIVE for one activated device.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(1).WillOnce(Return(IoctlOk()));
+    wdg->serviceWatchdog();
+}
+
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_NotifiesEveryWatchdogDevice)
+{
+    RecordProperty("Description", "serviceWatchdog() issues WDIOC_KEEPALIVE for every activated device.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, true);
+    auto wdg = makeWatchdog();
+
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    expectDeviceOpens({&cfg1, &cfg2});
+    expectFullEnableIoctls(2);
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(2).WillRepeatedly(Return(IoctlOk()));
+    wdg->serviceWatchdog();
+}
+
+// ═══════════════════════════════════════════════════════════
+// fireWatchdogReaction() tests
+// ═══════════════════════════════════════════════════════════
+
+TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FailsIfNotInActivatedState)
+{
+    RecordProperty("Description",
+                   "fireWatchdogReaction() is a no-op and does not call waitForever() when the watchdog has not "
+                   "been enabled.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdogFireMock();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*ioctlMock_, ioctl(_, WDIOC_SETTIMEOUT, _)).Times(0);
+    EXPECT_CALL(*wdg, waitForever).Times(0);
+    wdg->fireWatchdogReaction();
+}
+
+TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OneDevice)
+{
+    RecordProperty("Description",
+                   "fireWatchdogReaction() sets WDIOC_SETTIMEOUT to 0 and calls waitForever() for one activated "
+                   "device.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdogFireMock();
+
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(1).WillOnce(Return(IoctlOk()));
+    EXPECT_CALL(*wdg, waitForever).Times(1);
+    wdg->fireWatchdogReaction();
+}
+
+TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FiresEveryDevice)
+{
+    RecordProperty("Description",
+                   "fireWatchdogReaction() sets WDIOC_SETTIMEOUT to 0 for every activated device before calling "
+                   "waitForever().");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, true);
+    auto wdg = makeWatchdogFireMock();
+
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    expectDeviceOpens({&cfg1, &cfg2});
+    expectFullEnableIoctls(2);
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(2).WillRepeatedly(Return(IoctlOk()));
+    EXPECT_CALL(*wdg, waitForever).Times(1);
+    wdg->fireWatchdogReaction();
+}
+
+TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OnlyFiresActivatedWatchdogs)
+{
+    RecordProperty("Description",
+                   "fireWatchdogReaction() only sets WDIOC_SETTIMEOUT to 0 for devices that were successfully "
+                   "activated.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto wdg = makeWatchdogFireMock();
+
+    expectFullEnable(cfg1);
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+
+    ASSERT_FALSE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(1).WillOnce(Return(IoctlOk()));
+    EXPECT_CALL(*wdg, waitForever).Times(1);
+    wdg->fireWatchdogReaction();
+}
+
+// ═══════════════════════════════════════════════════════════
+// disable() tests
+// ═══════════════════════════════════════════════════════════
+
+TEST_F(WatchdogImplTest, WdgDisable_FailsIfNotInActivatedState)
+{
+    RecordProperty("Description", "disable() is a no-op when the watchdog has not been enabled.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
+    EXPECT_CALL(*unistdMock_, close).Times(0);
+    EXPECT_CALL(*unistdMock_, write).Times(0);
+
+    wdg->disable();
+}
+
+TEST_F(WatchdogImplTest, WdgDisable_DisablesOneDevice)
+{
+    RecordProperty("Description",
+                   "disable() issues WDIOS_DISABLECARD and closes the device file for a single activated device.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
+    auto wdg = makeWatchdog();
+
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    expectDisable(cfg);
+    wdg->disable();
+}
+
+TEST_F(WatchdogImplTest, WdgDisable_DisablesEachWatchdogDevice)
+{
+    RecordProperty("Description",
+                   "disable() disables every deactivatable device, writing the magic close character only for "
+                   "devices that require it, and skips devices that cannot be deactivated.");
+
+    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, false, false);  // cannot be deactivated
+    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);   // no magic close
+    auto cfg3 = makeCfg("/dev/watchdog_2", 2000U, true, true);    // needs magic close
+
+    auto wdg = makeWatchdog();
+    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->init(cfg3, kDefaultCycleTimeNs));
+
+    expectDeviceOpens({&cfg1, &cfg2, &cfg3});
+    expectFullEnableIoctls(3);
+    ASSERT_TRUE(wdg->enable());
+
+    // cfg1 cannot be deactivated, so only cfg2 and cfg3 go through the disable sequence.
+    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(2).WillRepeatedly(Return(IoctlOk()));
+    EXPECT_CALL(*unistdMock_, write(1, _, _)).Times(1).WillOnce(Return(WriteOk(2)));
+    EXPECT_CALL(*unistdMock_, close(1)).Times(2).WillRepeatedly(Return(CloseOk()));
+
+    wdg->disable();
+}
+
+TEST_F(WatchdogImplTest, WdgDisable_IgnoresDevicesThatCannotBeDisabled)
+{
+    RecordProperty("Description",
+                   "disable() performs no ioctl/write/close calls for a device configured as non-deactivatable.");
+
+    auto cfg = makeCfg("/dev/watchdog", 2000U, false, true);
+    auto wdg = makeWatchdog();
+
+    expectFullEnable(cfg);
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+    ASSERT_TRUE(wdg->enable());
+
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
+    EXPECT_CALL(*unistdMock_, write).Times(0);
+    EXPECT_CALL(*unistdMock_, close).Times(0);
+
+    wdg->disable();
+}
+
+}  // namespace

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -150,35 +150,17 @@ class WatchdogImplTest : public ::testing::Test
         return std::make_unique<WatchdogImpl_FireWatchdogMock>(*ioctlMock_, *fcntlMock_, *unistdMock_);
     }
 
-    /// @brief Programs the mocks so that opening the devices in `cfgs` succeeds (each returning `fd`).
-    void expectDeviceOpens(std::initializer_list<const WatchdogConfig*> cfgs, std::int32_t fd = 1)
-    {
-        for (const WatchdogConfig* cfg : cfgs)
-        {
-            EXPECT_CALL(*fcntlMock_, open(StrEq(cfg->device_file_path), _)).WillOnce(Return(OpenOk(fd)));
-        }
-    }
-
-    /// @brief Programs the mocks so that `times` devices go through the full enable ioctl sequence
-    /// (GETTIMEOUT -> GETTIMELEFT -> SETTIMEOUT -> SETOPTIONS) and succeed.
-    /// @note A single combined expectation per ioctl request is used (rather than one per device) since
-    /// gmock does not fall back to an older matching WillOnce() expectation once the newest one saturates.
-    void expectFullEnableIoctls(int times, std::int32_t fd = 1)
-    {
-        // Report a current timeout of 0, which never matches a configured device timeout, so that the
-        // enable sequence always goes through GETTIMELEFT + SETTIMEOUT.
-        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMEOUT, _)).Times(times).WillRepeatedly(SetOutParam(0));
-        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMELEFT, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
-        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETTIMEOUT, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
-        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETOPTIONS, _)).Times(times).WillRepeatedly(Return(IoctlOk()));
-    }
-
-    /// @brief Programs the mocks so that enabling the single device for `cfg` goes through the full enable
+    /// @brief Programs the mocks so that enabling the device for `cfg` goes through the full enable
     /// sequence (open -> GETTIMEOUT -> GETTIMELEFT -> SETTIMEOUT -> SETOPTIONS) and succeeds.
     void expectFullEnable(const WatchdogConfig& cfg, std::int32_t fd = 1)
     {
-        expectDeviceOpens({&cfg}, fd);
-        expectFullEnableIoctls(1, fd);
+        EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(fd)));
+        // Report a current timeout of 0, which never matches the configured device timeout, so that the
+        // enable sequence always goes through GETTIMELEFT + SETTIMEOUT.
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlOk()));
+        EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlOk()));
     }
 
     /// @brief Programs the mocks for a successful disableDevice() sequence on `fd`.
@@ -262,26 +244,17 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutResolutionIsWrong)
 }
 #endif
 
-TEST_F(WatchdogImplTest, WdgInit_FailsIfSameDeviceAlreadyConfigured)
+TEST_F(WatchdogImplTest, WdgInit_FailsIfDeviceAlreadyConfigured)
 {
-    RecordProperty("Description", "init() fails when the same device file path is configured a second time.");
+    RecordProperty("Description",
+                   "init() fails when called a second time, since only a single watchdog device is supported.");
 
     auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
-}
-
-TEST_F(WatchdogImplTest, WdgInit_SucceedsWithMultipleDifferentValidDeviceConfiguration)
-{
-    RecordProperty("Description",
-                   "init() succeeds when called multiple times with distinct, valid device configurations.");
-
-    auto wdg = makeWatchdog();
-    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_0", 2000U, true, false), kDefaultCycleTimeNs));
-    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_1", 2000U, true, false), kDefaultCycleTimeNs));
-    EXPECT_TRUE(wdg->init(makeCfg("/dev/watchdog_2", 2000U, true, false), kDefaultCycleTimeNs));
+    EXPECT_FALSE(wdg->init(makeCfg("/dev/watchdog_2", 2000U, true, false), kDefaultCycleTimeNs));
 }
 
 class WatchdogImpl_UT_paramConfigName : public WatchdogImplTest, public ::testing::WithParamInterface<std::uint32_t>
@@ -330,18 +303,16 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotInIdleState)
     EXPECT_FALSE(wdg->enable());
 }
 
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotAllWatchdogsCouldBeEnabled)
+TEST_F(WatchdogImplTest, WdgEnable_FailsIfOpenFails)
 {
-    RecordProperty("Description",
-                   "enable() fails when opening one of multiple configured devices fails.");
+    RecordProperty("Description", "enable() fails when opening the configured device file fails.");
 
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
+    auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
     auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-    expectFullEnable(cfg1);
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
+    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
+    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenErr()));
+    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
 
     EXPECT_FALSE(wdg->enable());
 }
@@ -461,67 +432,9 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfEnablecardFails)
     EXPECT_FALSE(wdg->enable());
 }
 
-TEST_F(WatchdogImplTest, WdgEnable_FailsForMultipleDevices)
-{
-    RecordProperty("Description",
-                   "enable() fails and performs no ioctls when opening all configured devices fails.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(_, _)).Times(2).WillRepeatedly(Return(OpenErr()));
-    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
-
-    EXPECT_FALSE(wdg->enable());
-}
-
-TEST_F(WatchdogImplTest, WdgEnable_EnablesMultipleDevices)
-{
-    RecordProperty("Description",
-                   "enable() succeeds when all of multiple configured devices are enabled successfully.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", IWatchdogIf::kTimeoutMinMillis, false, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
-    auto cfg3 = makeCfg("/dev/watchdog_2", IWatchdogIf::kTimeoutMaxMillis, true, true);
-
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg3, kDefaultCycleTimeNs));
-
-    expectDeviceOpens({&cfg1, &cfg2, &cfg3});
-    expectFullEnableIoctls(3);
-
-    EXPECT_TRUE(wdg->enable());
-}
-
 // ═══════════════════════════════════════════════════════════
 // serviceWatchdog() tests
 // ═══════════════════════════════════════════════════════════
-
-TEST_F(WatchdogImplTest, WdgServiceWatchdog_OnlyServicesActivatedWatchdogs)
-{
-    RecordProperty("Description",
-                   "serviceWatchdog() only issues WDIOC_KEEPALIVE for devices that were successfully activated.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
-    auto wdg = makeWatchdog();
-
-    expectFullEnable(cfg1);
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
-    ASSERT_FALSE(wdg->enable());
-
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(1).WillOnce(Return(IoctlOk()));
-    wdg->serviceWatchdog();
-}
 
 TEST_F(WatchdogImplTest, WdgServiceWatchdog_NotInActivatedState)
 {
@@ -558,25 +471,6 @@ TEST_F(WatchdogImplTest, WdgServiceWatchdog_OneDevice)
     ASSERT_TRUE(wdg->enable());
 
     EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(1).WillOnce(Return(IoctlOk()));
-    wdg->serviceWatchdog();
-}
-
-TEST_F(WatchdogImplTest, WdgServiceWatchdog_NotifiesEveryWatchdogDevice)
-{
-    RecordProperty("Description", "serviceWatchdog() issues WDIOC_KEEPALIVE for every activated device.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, true);
-    auto wdg = makeWatchdog();
-
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
-    expectDeviceOpens({&cfg1, &cfg2});
-    expectFullEnableIoctls(2);
-    ASSERT_TRUE(wdg->enable());
-
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_KEEPALIVE, nullptr)).Times(2).WillRepeatedly(Return(IoctlOk()));
     wdg->serviceWatchdog();
 }
 
@@ -617,51 +511,6 @@ TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OneDevice)
     wdg->fireWatchdogReaction();
 }
 
-TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FiresEveryDevice)
-{
-    RecordProperty("Description",
-                   "fireWatchdogReaction() sets WDIOC_SETTIMEOUT to 0 for every activated device before calling "
-                   "waitForever().");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, true);
-    auto wdg = makeWatchdogFireMock();
-
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
-    expectDeviceOpens({&cfg1, &cfg2});
-    expectFullEnableIoctls(2);
-    ASSERT_TRUE(wdg->enable());
-
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(2).WillRepeatedly(Return(IoctlOk()));
-    EXPECT_CALL(*wdg, waitForever).Times(1);
-    wdg->fireWatchdogReaction();
-}
-
-TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OnlyFiresActivatedWatchdogs)
-{
-    RecordProperty("Description",
-                   "fireWatchdogReaction() only sets WDIOC_SETTIMEOUT to 0 for devices that were successfully "
-                   "activated.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, true, false);
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);
-    auto wdg = makeWatchdogFireMock();
-
-    expectFullEnable(cfg1);
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
-    ASSERT_FALSE(wdg->enable());
-
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(1).WillOnce(Return(IoctlOk()));
-    EXPECT_CALL(*wdg, waitForever).Times(1);
-    wdg->fireWatchdogReaction();
-}
-
 // ═══════════════════════════════════════════════════════════
 // disable() tests
 // ═══════════════════════════════════════════════════════════
@@ -694,33 +543,6 @@ TEST_F(WatchdogImplTest, WdgDisable_DisablesOneDevice)
     ASSERT_TRUE(wdg->enable());
 
     expectDisable(cfg);
-    wdg->disable();
-}
-
-TEST_F(WatchdogImplTest, WdgDisable_DisablesEachWatchdogDevice)
-{
-    RecordProperty("Description",
-                   "disable() disables every deactivatable device, writing the magic close character only for "
-                   "devices that require it, and skips devices that cannot be deactivated.");
-
-    auto cfg1 = makeCfg("/dev/watchdog_0", 2000U, false, false);  // cannot be deactivated
-    auto cfg2 = makeCfg("/dev/watchdog_1", 2000U, true, false);   // no magic close
-    auto cfg3 = makeCfg("/dev/watchdog_2", 2000U, true, true);    // needs magic close
-
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-    ASSERT_TRUE(wdg->init(cfg3, kDefaultCycleTimeNs));
-
-    expectDeviceOpens({&cfg1, &cfg2, &cfg3});
-    expectFullEnableIoctls(3);
-    ASSERT_TRUE(wdg->enable());
-
-    // cfg1 cannot be deactivated, so only cfg2 and cfg3 go through the disable sequence.
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(2).WillRepeatedly(Return(IoctlOk()));
-    EXPECT_CALL(*unistdMock_, write(1, _, _)).Times(1).WillOnce(Return(WriteOk(2)));
-    EXPECT_CALL(*unistdMock_, close(1)).Times(2).WillRepeatedly(Return(CloseOk()));
-
     wdg->disable();
 }
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -489,7 +489,7 @@ TEST_F(WatchdogImplTest, WdgServiceWatchdog_NoDevice)
     wdg->serviceWatchdog();
 }
 
-TEST_F(WatchdogImplTest, WdgServiceWatchdog_OneDevice)
+TEST_F(WatchdogImplTest, WdgServiceWatchdog_WithConfiguredDevice)
 {
     RecordProperty("Description", "serviceWatchdog() issues a single WDIOC_KEEPALIVE for one activated device.");
 
@@ -524,7 +524,7 @@ TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_FailsIfNotInActivatedState)
     wdg->fireWatchdogReaction();
 }
 
-TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_OneDevice)
+TEST_F(WatchdogImplTest, WdgFireWatchdogReaction_WithConfiguredDevice)
 {
     RecordProperty(
         "Description",

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -41,31 +41,37 @@ namespace
 /// @brief Cycle time of 50ms in nanoseconds, used as the default for tests that don't care about the exact value.
 constexpr std::int64_t kDefaultCycleTimeNs{50'000'000};
 
+// Succesful return value of ioctl operation
 score::cpp::expected_blank<score::os::Error> IoctlOk()
 {
     return score::cpp::expected_blank<score::os::Error>{};
 }
 
+// Error retun value of IoctlErr
 score::cpp::expected_blank<score::os::Error> IoctlErr(std::int32_t errnoCode = EIO)
 {
     return score::cpp::unexpected(score::os::Error::createFromErrno(errnoCode));
 }
 
+// Successful return value for open()
 score::cpp::expected<std::int32_t, score::os::Error> OpenOk(std::int32_t fd)
 {
     return fd;
 }
 
+// Error return value for open()
 score::cpp::expected<std::int32_t, score::os::Error> OpenErr()
 {
     return score::cpp::unexpected(score::os::Error::createFromErrno(ENOENT));
 }
 
+// Successful return value for close()
 score::cpp::expected_blank<score::os::Error> CloseOk()
 {
     return score::cpp::expected_blank<score::os::Error>{};
 }
 
+// Successful return value for write()
 score::cpp::expected<ssize_t, score::os::Error> WriteOk(ssize_t n)
 {
     return n;
@@ -216,9 +222,11 @@ TEST_F(WatchdogImplTest, WdgInit_FailsWatchdogTimeoutSmallerThenCycleTime)
                    "serviceWatchdog() could not be called in time to prevent a reset.");
 
     constexpr std::uint32_t timeoutMs{2000U};
-    const std::int64_t cycleTimeNs{static_cast<std::int64_t>(timeoutMs + 1U) * 1'000'000};
+    constexpr std::uint32_t nanosecPerMillisec =  1'000'000;
+    const std::int64_t cycleTimeNs{static_cast<std::int64_t>(timeoutMs + 1U) * nanosecPerMillisec};
     auto cfg = makeCfg("/dev/watchdog", timeoutMs, true, false);
     auto wdg = makeWatchdog();
+
     EXPECT_FALSE(wdg->init(cfg, cycleTimeNs));
 }
 
@@ -249,6 +257,7 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfTimeoutResolutionIsWrong)
 
     auto cfg = makeCfg("/dev/watchdog", 2123U, true, false);
     auto wdg = makeWatchdog();
+
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
 }
 #endif
@@ -260,6 +269,7 @@ TEST_F(WatchdogImplTest, WdgInit_FailsIfSameDeviceAlreadyConfigured)
     auto cfg = makeCfg("/dev/watchdog", 2000U, true, false);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
+
     EXPECT_FALSE(wdg->init(cfg, kDefaultCycleTimeNs));
 }
 
@@ -316,6 +326,7 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotInIdleState)
     expectFullEnable(cfg);
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
     ASSERT_TRUE(wdg->enable());
+
     EXPECT_FALSE(wdg->enable());
 }
 
@@ -329,7 +340,6 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotAllWatchdogsCouldBeEnabled)
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg1, kDefaultCycleTimeNs));
     ASSERT_TRUE(wdg->init(cfg2, kDefaultCycleTimeNs));
-
     expectFullEnable(cfg1);
     EXPECT_CALL(*fcntlMock_, open(StrEq(cfg2.device_file_path), _)).WillOnce(Return(OpenErr()));
 
@@ -347,9 +357,10 @@ TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutA
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
 #ifndef __QNXNTO__
-    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms / 1000U)};
+    constexpr std::int32_t kMillisPerSecond = 1000U;
+    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms / kMillisPerSecond)};
 #else
-    const std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms)};
+    constexpr std::int32_t currentTimeoutRaw{static_cast<std::int32_t>(cfg.max_timeout_ms)};
 #endif
 
     EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -102,6 +102,16 @@ auto AlterOutParamBy(std::int32_t delta)
     });
 }
 
+/// @brief Steps of the enable() sequence, in the order they are issued.
+enum class EnableStep
+{
+    kOpen,
+    kGetTimeout,
+    kGetTimeLeft,
+    kSetTimeout,
+    kSetOptions,
+};
+
 /// @brief WatchdogImpl subclass that mocks waitForever() so fireWatchdogReaction() returns for testing.
 class WatchdogImpl_FireWatchdogMock : public WatchdogImpl
 {
@@ -164,6 +174,36 @@ class WatchdogImplTest : public ::testing::Test
         EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
         EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlOk()));
         EXPECT_CALL(*ioctlMock_, ioctl(fd, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlOk()));
+    }
+
+    /// @brief Programs the enable() sequence so steps before `failingStep` succeed, `failingStep`
+    /// returns an error, and every step after it is never reached.
+    void expectEnableFailingAt(const WatchdogConfig& cfg, EnableStep failingStep, std::int32_t fd = 1)
+    {
+        // An ioctl step succeeds before the failure, fails at it, and is never called after it.
+        auto ioctlStep = [&](EnableStep step, unsigned long request, auto successAction) {
+            auto& call = EXPECT_CALL(*ioctlMock_, ioctl(fd, request, _));
+            if (step < failingStep)
+            {
+                call.WillOnce(successAction);
+            }
+            else if (step == failingStep)
+            {
+                call.WillOnce(Return(IoctlErr()));
+            }
+            else
+            {
+                call.Times(0);
+            }
+        };
+
+        EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _))
+            .WillOnce(Return(failingStep == EnableStep::kOpen ? OpenErr() : OpenOk(fd)));
+
+        ioctlStep(EnableStep::kGetTimeout, WDIOC_GETTIMEOUT, SetOutParam(0));
+        ioctlStep(EnableStep::kGetTimeLeft, WDIOC_GETTIMELEFT, Return(IoctlOk()));
+        ioctlStep(EnableStep::kSetTimeout, WDIOC_SETTIMEOUT, Return(IoctlOk()));
+        ioctlStep(EnableStep::kSetOptions, WDIOC_SETOPTIONS, Return(IoctlOk()));
     }
 
     /// @brief Programs the mocks for a successful disableDevice() sequence on `fd`.
@@ -334,20 +374,6 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfNotInIdleState)
     EXPECT_FALSE(wdg->enable());
 }
 
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfOpenFails)
-{
-    RecordProperty("Description", "enable() fails when opening the configured device file fails.");
-
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenErr()));
-    EXPECT_CALL(*ioctlMock_, ioctl).Times(0);
-
-    EXPECT_FALSE(wdg->enable());
-}
-
 TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutAlreadyCorrect)
 {
     RecordProperty(
@@ -375,57 +401,53 @@ TEST_F(WatchdogImplTest, WdgEnable_DoesNotSetConfiguredTimeoutValue_WhenTimeoutA
     EXPECT_TRUE(wdg->enable());
 }
 
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetTimeoutFails)
+struct EnableFailureCase
 {
-    RecordProperty("Description", "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.");
+    std::string name;
+    std::string description;
+    EnableStep failingStep;
+};
+
+class WatchdogImpl_UT_EnableFailure : public WatchdogImplTest,
+                                      public ::testing::WithParamInterface<EnableFailureCase>
+{
+};
+
+TEST_P(WatchdogImpl_UT_EnableFailure, WdgEnable_FailsAndStopsSequence)
+{
+    const auto& param = GetParam();
+    RecordProperty("Description", param.description);
 
     auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
     auto wdg = makeWatchdog();
     ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
 
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(Return(IoctlErr()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).Times(0);
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(0);
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
+    expectEnableFailingAt(cfg, param.failingStep);
 
     EXPECT_FALSE(wdg->enable());
 }
 
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfGetRemainingTimeLeftFails)
-{
-    RecordProperty(
-        "Description", "enable() fails and skips WDIOC_SETTIMEOUT/WDIOC_SETOPTIONS when WDIOC_GETTIMELEFT fails.");
-
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlErr()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).Times(0);
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
-
-    EXPECT_FALSE(wdg->enable());
-}
-
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfSetTimeoutFails)
-{
-    RecordProperty("Description", "enable() fails and skips WDIOC_SETOPTIONS when WDIOC_SETTIMEOUT fails.");
-
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlErr()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
-
-    EXPECT_FALSE(wdg->enable());
-}
+INSTANTIATE_TEST_SUITE_P(
+    EnableFailures,
+    WatchdogImpl_UT_EnableFailure,
+    ::testing::Values(
+        EnableFailureCase{
+            "OpenFails", "enable() fails when opening the configured device file fails.", EnableStep::kOpen},
+        EnableFailureCase{
+            "GetTimeoutFails",
+            "enable() fails and skips the remaining ioctls when WDIOC_GETTIMEOUT fails.",
+            EnableStep::kGetTimeout},
+        EnableFailureCase{
+            "GetRemainingTimeLeftFails",
+            "enable() fails and skips WDIOC_SETTIMEOUT/WDIOC_SETOPTIONS when WDIOC_GETTIMELEFT fails.",
+            EnableStep::kGetTimeLeft},
+        EnableFailureCase{
+            "SetTimeoutFails",
+            "enable() fails and skips WDIOC_SETOPTIONS when WDIOC_SETTIMEOUT fails.",
+            EnableStep::kSetTimeout},
+        EnableFailureCase{
+            "EnablecardFails", "enable() fails when the WDIOS_ENABLECARD ioctl fails.", EnableStep::kSetOptions}),
+    [](const ::testing::TestParamInfo<EnableFailureCase>& info) { return info.param.name; });
 
 TEST_F(WatchdogImplTest, WdgEnable_FailsIfTimeoutValueIsAltered)
 {
@@ -441,23 +463,6 @@ TEST_F(WatchdogImplTest, WdgEnable_FailsIfTimeoutValueIsAltered)
     // Device alters the requested timeout to a value that doesn't match what was requested.
     EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(AlterOutParamBy(1));
     EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).Times(0);
-
-    EXPECT_FALSE(wdg->enable());
-}
-
-TEST_F(WatchdogImplTest, WdgEnable_FailsIfEnablecardFails)
-{
-    RecordProperty("Description", "enable() fails when the WDIOS_ENABLECARD ioctl fails.");
-
-    auto cfg = makeCfg("/dev/watchdog", 2000U, true /*canBeDeactivated*/, false /*needsMagicClose*/);
-    auto wdg = makeWatchdog();
-    ASSERT_TRUE(wdg->init(cfg, kDefaultCycleTimeNs));
-
-    EXPECT_CALL(*fcntlMock_, open(StrEq(cfg.device_file_path), _)).WillOnce(Return(OpenOk(1)));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMEOUT, _)).WillOnce(SetOutParam(0));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_GETTIMELEFT, _)).WillOnce(Return(IoctlOk()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETTIMEOUT, _)).WillOnce(Return(IoctlOk()));
-    EXPECT_CALL(*ioctlMock_, ioctl(1, WDIOC_SETOPTIONS, _)).WillOnce(Return(IoctlErr()));
 
     EXPECT_FALSE(wdg->enable());
 }


### PR DESCRIPTION
Adds missing unit tests for the watchdog code at score/launch_manager/src/daemon/src/watchdog

Note: Removes supported for multiple watchdog devices as this is actually not used, so no need to test it.

Closes: https://github.com/eclipse-score/lifecycle/issues/330