### PR TITLE
Moving secpol to osal layer instead of daemon

### DIFF
--- a/score/launch_manager/src/daemon/BUILD
+++ b/score/launch_manager/src/daemon/BUILD
@@ -16,8 +16,8 @@ cc_binary(
     name = "launch_manager",
     srcs = ["src/main.cpp"],
     linkopts = select({
-        "@platforms//os:qnx": ["-lsecpol"],
         "@platforms//os:linux": ["-lpthread"],
+        "//conditions:default": [],
     }),
     visibility = ["//score/launch_manager:__subpackages__"],
     deps = [

--- a/score/launch_manager/src/daemon/src/osal/BUILD
+++ b/score/launch_manager/src/daemon/src/osal/BUILD
@@ -62,6 +62,12 @@ cc_library(
     }),
     hdrs = ["security_policy.hpp"],
     include_prefix = "score/mw/launch_manager/osal",
+    linkopts = select({
+        "@platforms//os:qnx": [
+            "-lsecpol",
+        ],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "/score/launch_manager/src/daemon/src/osal",
     visibility = ["//score:__subpackages__"],
 )


### PR DESCRIPTION
Fixing QNX build by moving secpol link to osal layer instead of daemon