### PR TITLE
Add AliveMonitorConfig header

### DIFF
--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
@@ -17,11 +17,7 @@
 
 #include <score/assert.hpp>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::internal::alive
 {
 
 namespace
@@ -62,6 +58,4 @@ AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configura
     return result;
 }
 
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::alive

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
+
+#include <utility>
+
+#include <score/assert.hpp>
+
+namespace score
+{
+namespace lcm
+{
+namespace saf
+{
+
+namespace
+{
+
+using ApplicationType = score::mw::launch_manager::configuration::ApplicationType;
+
+bool isSupervisedType(ApplicationType app_type)
+{
+    return app_type == ApplicationType::ReportingAndSupervised || app_type == ApplicationType::StateManager;
+}
+
+}  // namespace
+
+AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config)
+{
+    AliveMonitorConfig result{};
+    result.evaluation_cycle_ms = config.aliveSupervision().evaluation_cycle_ms;
+
+    for (const auto& comp : config.components())
+    {
+        if (isSupervisedType(comp.component_properties.application_profile.application_type))
+        {
+            SupervisedComponentConfig info{};
+            info.name = comp.name;
+            info.alive_supervision = comp.component_properties.application_profile.alive_supervision;
+            info.uid = comp.deployment_config.sandbox.uid;
+            result.supervised_components.push_back(std::move(info));
+        }
+    }
+
+    // The evaluation cycle is only meaningful when there is something to supervise; a zero cycle from a config
+    // without an alive-supervision section is benign as long as no supervised components exist.
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        result.supervised_components.empty() || result.evaluation_cycle_ms > 0,
+        "evaluation_cycle_ms cannot be zero when supervised components are configured");
+
+    return result;
+}
+
+}  // namespace saf
+}  // namespace lcm
+}  // namespace score

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
@@ -22,11 +22,7 @@
 
 #include "score/mw/launch_manager/configuration/config.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::internal::alive
 {
 
 /// @file AliveMonitorConfig.hpp
@@ -36,15 +32,20 @@ namespace saf
 /// @brief Supervised component configuration.
 struct SupervisedComponentConfig
 {
+    /// @brief Component short name.
     std::string name;
+    /// @brief Alive-supervision parameters.
     std::optional<score::mw::launch_manager::configuration::ComponentAliveSupervision> alive_supervision;
+    /// @brief Uid the component runs as.
     uid_t uid{};
 };
 
 /// @brief AliveMonitor configuration.
 struct AliveMonitorConfig
 {
+    /// @brief Configuration for every component that is subject to alive supervision.
     std::vector<SupervisedComponentConfig> supervised_components;
+    /// @brief Global supervision evaluation cycle, in milliseconds.
     uint32_t evaluation_cycle_ms{};
 };
 
@@ -52,8 +53,6 @@ struct AliveMonitorConfig
 /// @return AliveMonitor configuration
 AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config);
 
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::alive
 
 #endif  // ALIVE_MONITOR_CONFIG_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef ALIVE_MONITOR_CONFIG_HPP_INCLUDED
+#define ALIVE_MONITOR_CONFIG_HPP_INCLUDED
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "score/mw/launch_manager/configuration/config.hpp"
+
+namespace score
+{
+namespace lcm
+{
+namespace saf
+{
+
+/// @file AliveMonitorConfig.hpp
+/// @brief Adds temporary functionality required to copy configuration data until we can, as part of our refactoring
+/// efforts, move the configuration data to the entities intended for that purpose.
+
+/// @brief Supervised component configuration.
+struct SupervisedComponentConfig
+{
+    std::string name;
+    std::optional<score::mw::launch_manager::configuration::ComponentAliveSupervision> alive_supervision;
+    uid_t uid{};
+};
+
+/// @brief AliveMonitor configuration.
+struct AliveMonitorConfig
+{
+    std::vector<SupervisedComponentConfig> supervised_components;
+    uint32_t evaluation_cycle_ms{};
+};
+
+/// @brief Returns a copy of alive-monitor-relevant configuration.
+/// @return AliveMonitor configuration
+AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config);
+
+}  // namespace saf
+}  // namespace lcm
+}  // namespace score
+
+#endif  // ALIVE_MONITOR_CONFIG_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
@@ -18,11 +18,7 @@
 #include <utility>
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::internal::alive
 {
 namespace
 {
@@ -61,7 +57,7 @@ class AliveMonitorConfigTest : public ::testing::Test
     void SetUp() override
     {
         RecordProperty("TestType", "interface-test");
-        RecordProperty("DerivationTechnique", "explorative-testing");
+        RecordProperty("DerivationTechnique", "boundary-values");
     }
 };
 
@@ -123,6 +119,7 @@ TEST_F(AliveMonitorConfigTest, CopiesGlobalEvaluationCycle)
 
 TEST_F(AliveMonitorConfigTest, ZeroEvaluationCycleAllowedWithoutSupervisedComponents)
 {
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Description", "A zero evaluation cycle is tolerated when no components are supervised.");
     // A config lacking an alive-supervision section yields evaluation_cycle_ms == 0. That is benign as long as
     // there is nothing to supervise, so it must not trip the production assertion.
@@ -133,6 +130,4 @@ TEST_F(AliveMonitorConfigTest, ZeroEvaluationCycleAllowedWithoutSupervisedCompon
 }
 
 }  // namespace
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::alive

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+namespace score
+{
+namespace lcm
+{
+namespace saf
+{
+namespace
+{
+
+namespace cfg = score::mw::launch_manager::configuration;
+
+cfg::ComponentConfig makeComponent(
+    const std::string& name,
+    cfg::ApplicationType type,
+    uid_t uid,
+    std::optional<cfg::ComponentAliveSupervision> alive_supervision)
+{
+    cfg::ComponentConfig comp;
+    comp.name = name;
+    comp.component_properties.application_profile.application_type = type;
+    comp.component_properties.application_profile.alive_supervision = alive_supervision;
+    comp.deployment_config.sandbox.uid = uid;
+    return comp;
+}
+
+cfg::Config makeConfig(std::vector<cfg::ComponentConfig> components, uint32_t evaluation_cycle_ms)
+{
+    cfg::AliveSupervisionConfig alive;
+    alive.evaluation_cycle_ms = evaluation_cycle_ms;
+
+    return cfg::ConfigBuilder{}
+        .setComponents(std::move(components))
+        .setInitialRunTarget("Startup")
+        .setAliveSupervision(alive)
+        .build();
+}
+
+class AliveMonitorConfigTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        RecordProperty("TestType", "interface-test");
+        RecordProperty("DerivationTechnique", "explorative-testing");
+    }
+};
+
+TEST_F(AliveMonitorConfigTest, CapturesOnlySupervisedComponents)
+{
+    RecordProperty("Description", "Only supervised component types are captured from the configuration.");
+    std::vector<cfg::ComponentConfig> components;
+    components.push_back(makeComponent(
+        "supervised_reporting",
+        cfg::ApplicationType::ReportingAndSupervised,
+        1001,
+        cfg::ComponentAliveSupervision{500, 2, 1, 3}));
+    components.push_back(makeComponent("native_app", cfg::ApplicationType::Native, 1002, std::nullopt));
+    components.push_back(makeComponent("reporting_app", cfg::ApplicationType::Reporting, 1003, std::nullopt));
+    components.push_back(makeComponent(
+        "state_manager",
+        cfg::ApplicationType::StateManager,
+        1004,
+        cfg::ComponentAliveSupervision{100, 0, std::nullopt, std::nullopt}));
+
+    const AliveMonitorConfig result = aliveMonitorConfig(makeConfig(std::move(components), 250));
+
+    ASSERT_EQ(result.supervised_components.size(), 2U);
+    EXPECT_EQ(result.supervised_components[0].name, "supervised_reporting");
+    EXPECT_EQ(result.supervised_components[1].name, "state_manager");
+}
+
+TEST_F(AliveMonitorConfigTest, CopiesPerComponentFields)
+{
+    RecordProperty("Description", "Per-component fields are copied from the configuration.");
+    std::vector<cfg::ComponentConfig> components;
+    components.push_back(makeComponent(
+        "supervised",
+        cfg::ApplicationType::ReportingAndSupervised,
+        4242,
+        cfg::ComponentAliveSupervision{500, 2, 1, 3}));
+
+    const AliveMonitorConfig result = aliveMonitorConfig(makeConfig(std::move(components), 250));
+
+    ASSERT_EQ(result.supervised_components.size(), 1U);
+    const auto& info = result.supervised_components[0];
+    EXPECT_EQ(info.name, "supervised");
+    EXPECT_EQ(info.uid, 4242U);
+    ASSERT_TRUE(info.alive_supervision.has_value());
+    EXPECT_EQ(info.alive_supervision->reporting_cycle_ms, 500U);
+    EXPECT_EQ(info.alive_supervision->failed_cycles_tolerance, 2U);
+    EXPECT_EQ(info.alive_supervision->min_indications, 1U);
+    EXPECT_EQ(info.alive_supervision->max_indications, 3U);
+}
+
+TEST_F(AliveMonitorConfigTest, CopiesGlobalEvaluationCycle)
+{
+    RecordProperty("Description", "The global evaluation cycle is copied from the configuration.");
+    const AliveMonitorConfig result = aliveMonitorConfig(makeConfig({}, 777));
+
+    EXPECT_TRUE(result.supervised_components.empty());
+    EXPECT_EQ(result.evaluation_cycle_ms, 777U);
+}
+
+TEST_F(AliveMonitorConfigTest, ZeroEvaluationCycleAllowedWithoutSupervisedComponents)
+{
+    RecordProperty("Description", "A zero evaluation cycle is tolerated when no components are supervised.");
+    // A config lacking an alive-supervision section yields evaluation_cycle_ms == 0. That is benign as long as
+    // there is nothing to supervise, so it must not trip the production assertion.
+    const AliveMonitorConfig result = aliveMonitorConfig(makeConfig({}, 0));
+
+    EXPECT_TRUE(result.supervised_components.empty());
+    EXPECT_EQ(result.evaluation_cycle_ms, 0U);
+}
+
+}  // namespace
+}  // namespace saf
+}  // namespace lcm
+}  // namespace score

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tests/utils/bazel:unit_test.bzl", "lm_cc_test")
 
 cc_library(
     name = "types",
@@ -18,6 +19,27 @@ cc_library(
     include_prefix = "score/mw/launch_manager/alive_monitor/details/common",
     strip_include_prefix = "/score/launch_manager/src/daemon/src/alive_monitor/details/common",
     visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
+)
+
+cc_library(
+    name = "alive_monitor_config",
+    srcs = ["AliveMonitorConfig.cpp"],
+    hdrs = ["AliveMonitorConfig.hpp"],
+    include_prefix = "score/mw/launch_manager/alive_monitor/details/common",
+    strip_include_prefix = "/score/launch_manager/src/daemon/src/alive_monitor/details/common",
+    visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
+    deps = [
+        "//score/launch_manager/src/daemon/src/configuration:config",
+    ],
+)
+
+lm_cc_test(
+    name = "alive_monitor_config_UT",
+    srcs = ["AliveMonitorConfig_UT.cpp"],
+    deps = [
+        ":alive_monitor_config",
+        "@googletest//:gtest_main",
+    ],
 )
 
 cc_library(

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -33,7 +33,7 @@ AliveMonitorImpl::AliveMonitorImpl(
     const Config& config)
     : m_recovery_client(recovery_client),
       m_process_state_receiver(std::move(process_state_receiver)),
-      m_config(aliveMonitorConfig(config))
+      m_config(score::mw::lifecycle::internal::alive::aliveMonitorConfig(config))
 {
 }
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -12,7 +12,6 @@
  ********************************************************************************/
 #include <sys/types.h>
 
-#include <cstdint>
 #include <iostream>
 
 #include <score/assert.hpp>
@@ -32,7 +31,9 @@ AliveMonitorImpl::AliveMonitorImpl(
     SptrIRecoveryClient recovery_client,
     UptrIProcessStateReceiver process_state_receiver,
     const Config& config)
-    : m_recovery_client(recovery_client), m_process_state_receiver{std::move(process_state_receiver)}, m_config(config)
+    : m_recovery_client(recovery_client),
+      m_process_state_receiver(std::move(process_state_receiver)),
+      m_config(aliveMonitorConfig(config))
 {
 }
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <memory>
 
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/daemon/IAliveMonitor.hpp"
 #include "score/mw/launch_manager/configuration/config.hpp"
 
@@ -55,7 +56,7 @@ class AliveMonitorImpl : public IAliveMonitor
     UptrPhmDaemon m_daemon{nullptr};
     OsClock m_osClock{};
     UptrIProcessStateReceiver m_process_state_receiver;
-    const Config& m_config;
+    AliveMonitorConfig m_config;
 };
 
 }  // namespace daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -38,6 +38,7 @@ using UptrIProcessStateReceiver = std::unique_ptr<score::lcm::IProcessStateRecei
 using UptrPhmDaemon = std::unique_ptr<score::lcm::saf::daemon::PhmDaemon>;
 using OsClock = score::lcm::saf::timers::OsClockInterface;
 using Config = score::mw::launch_manager::configuration::Config;
+using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
 class AliveMonitorImpl : public IAliveMonitor
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/BUILD
@@ -28,6 +28,7 @@ cc_library(
     strip_include_prefix = "/score/launch_manager/src/daemon/src/alive_monitor/details/daemon",
     visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
     deps = [
+        "//score/launch_manager/src/daemon/src/alive_monitor/details/common:alive_monitor_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/factory:flat_cfg_factory",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/factory:static_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/ifappl:checkpoint",
@@ -38,7 +39,6 @@ cc_library(
         "//score/launch_manager/src/daemon/src/alive_monitor/details/supervision:alive",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:timers_os_clock",
         "//score/launch_manager/src/daemon/src/common:log",
-        "//score/launch_manager/src/daemon/src/configuration:config",
     ],
 )
 
@@ -52,6 +52,7 @@ cc_library(
     deps = [
         ":phm_daemon_config",
         ":sw_cluster_handler",
+        "//score/launch_manager/src/daemon/src/alive_monitor/details/common:alive_monitor_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/factory:flat_cfg_factory",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/factory:static_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/ifappl:monitor_if_daemon",
@@ -61,7 +62,6 @@ cc_library(
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:cycle_timer",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/timers:timers_os_clock",
         "//score/launch_manager/src/daemon/src/common:log",
-        "//score/launch_manager/src/daemon/src/configuration:config",
     ],
 )
 
@@ -83,6 +83,8 @@ cc_library(
     visibility = ["//score/launch_manager/src/daemon:__subpackages__"],
     deps = [
         ":i_health_monitor",
+        "//score/launch_manager/src/daemon/src/alive_monitor/details/common:alive_monitor_config",
+        "//score/launch_manager/src/daemon/src/configuration:config",
         "@score_baselibs//score/language/futurecpp",
     ],
 )

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
@@ -64,7 +64,8 @@ void PhmDaemon::performCyclicTriggers(void)
     }
 }
 
-bool PhmDaemon::construct(const Config& config, const SupervisionBufferConfig& f_bufferConfig_r) noexcept(false)
+bool PhmDaemon::construct(const AliveMonitorConfig& config, const SupervisionBufferConfig& f_bufferConfig_r) noexcept(
+    false)
 {
     bool isSuccess{true};
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -60,7 +60,7 @@ class PhmDaemon
     using CycleTimeValidator = score::lcm::saf::timers::CycleTimeValidator;
     using NanoSecondType = score::lcm::saf::timers::NanoSecondType;
     using ProcessStateReader = score::lcm::saf::ifexm::ProcessStateReader;
-    using AliveMonitorConfig = score::lcm::saf::AliveMonitorConfig;
+    using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
     /* RULECHECKER_comment(0, 4, check_expensive_to_copy_in_parameter, "f_supervisionErrorInfo name is passed by value\
      as same as generated function", true_no_defect) */

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/daemon/PhmDaemonConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/daemon/SwClusterHandler.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/factory/StaticConfig.hpp"
@@ -26,7 +27,6 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimer.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
-#include "score/mw/launch_manager/configuration/config.hpp"
 namespace score
 {
 namespace lcm
@@ -60,7 +60,7 @@ class PhmDaemon
     using CycleTimeValidator = score::lcm::saf::timers::CycleTimeValidator;
     using NanoSecondType = score::lcm::saf::timers::NanoSecondType;
     using ProcessStateReader = score::lcm::saf::ifexm::ProcessStateReader;
-    using Config = score::mw::launch_manager::configuration::Config;
+    using AliveMonitorConfig = score::lcm::saf::AliveMonitorConfig;
 
     /* RULECHECKER_comment(0, 4, check_expensive_to_copy_in_parameter, "f_supervisionErrorInfo name is passed by value\
      as same as generated function", true_no_defect) */
@@ -90,7 +90,7 @@ class PhmDaemon
     /// (Constructing the workers, adjusting the cycle time, initialization of fixed step timer)
     /// @param[in] recovery_client Shared pointer to recovery client
     /// @return See EInitCode definition
-    EInitCode init(std::shared_ptr<RecoveryClient> recovery_client, const Config& config) noexcept(false)
+    EInitCode init(std::shared_ptr<RecoveryClient> recovery_client, const AliveMonitorConfig& config) noexcept(false)
     {
         recoveryClient = recovery_client;
 
@@ -99,8 +99,8 @@ class PhmDaemon
             return EInitCode::kConstructFlatCfgFactoryFailed;
         }
 
-        int64_t cycleTimeModified{static_cast<std::int64_t>(
-            timers::TimeConversion::convertMilliSecToNanoSec(config.aliveSupervision().evaluation_cycle_ms))};
+        int64_t cycleTimeModified{
+            static_cast<std::int64_t>(timers::TimeConversion::convertMilliSecToNanoSec(config.evaluation_cycle_ms))};
 
         cycleTimeModified = CycleTimeValidator::adjustCycleTimeOnClockAccuracy(cycleTimeModified, osClock);
 
@@ -198,7 +198,7 @@ class PhmDaemon
     /// @details Create the SwclusterHandler objects and the workers for the SwclusterHandler
     /// @param[in] f_bufferConfig_r The buffer configuration used for worker construction
     /// @return bool true if workers creation succeeded, false otherwise
-    bool construct(const Config& config, const SupervisionBufferConfig& f_bufferConfig_r) noexcept(false);
+    bool construct(const AliveMonitorConfig& config, const SupervisionBufferConfig& f_bufferConfig_r) noexcept(false);
 
     /// @brief Perform cyclic execution of Phm daemon
     /// @details Perform cyclic execution of Phm daemon functionalities, for e.g., evaluation of supervisions.

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
@@ -46,7 +46,7 @@ SwClusterHandler::~SwClusterHandler() = default;
 /* RULECHECKER_comment(0, 3, check_max_cyclomatic_complexity, "Max cyclomatic complexity violation\
    is tolerated for this function. ", true_no_defect) */
 bool SwClusterHandler::constructWorkers(
-    const score::mw::launch_manager::configuration::Config& config,
+    const AliveMonitorConfig& config,
     std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
     ifexm::ProcessStateReader& f_processStateReader_r,
     const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false)
@@ -54,7 +54,7 @@ bool SwClusterHandler::constructWorkers(
     bool isSuccess{false};
     factory::FlatCfgFactory flatCfgFactory{f_bufferConfig_r};
 
-    isSuccess = flatCfgFactory.init(config);
+    isSuccess = flatCfgFactory.init(config.supervised_components);
     if (isSuccess)
     {
         LM_LOG_DEBUG() << "Software Cluster Handler starts constructing workers:" << f_swClusterName;

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -20,7 +20,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessStateReader.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-#include "score/mw/launch_manager/configuration/config.hpp"
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
 #include <string>
 #include <vector>
 
@@ -93,7 +93,7 @@ class SwClusterHandler
     /// @param [in] f_bufferConfig_r           Configuration settings for constructing workers
     /// @return                              Construction is successful (true), otherwise failure (false)
     bool constructWorkers(
-        const score::mw::launch_manager::configuration::Config& config,
+        const AliveMonitorConfig& config,
         std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
         ifexm::ProcessStateReader& f_processStateReader_r,
         const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false);

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -51,6 +51,8 @@ class Alive;
 namespace daemon
 {
 
+using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
+
 /// @brief Software Cluster Handler wraps the full PHM Supervision and Recovery Notification functionality for one
 ///        Software Cluster.
 /// @details This class requests construction of all required objects to do the Supervisions and Recovery Notifications

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/BUILD
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/BUILD
@@ -44,6 +44,7 @@ cc_library(
     visibility = ["//score/launch_manager/src/daemon/src/alive_monitor:__subpackages__"],
     deps = [
         ":i_phm_factory",
+        "//score/launch_manager/src/daemon/src/alive_monitor/details/common:alive_monitor_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/common:types",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/factory:static_config",
         "//score/launch_manager/src/daemon/src/alive_monitor/details/ifappl:checkpoint",
@@ -57,7 +58,6 @@ cc_library(
         "//score/launch_manager/src/daemon/src/common:alive_interface_path",
         "//score/launch_manager/src/daemon/src/common:identifier_hash",
         "//score/launch_manager/src/daemon/src/common:log",
-        "//score/launch_manager/src/daemon/src/configuration:config",
         "@score_baselibs//score/language/futurecpp",
     ] + select({
         "@platforms//os:qnx": [],

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -42,41 +42,17 @@ namespace factory
 {
 
 using BufferConfig = SupervisionBufferConfig;
-using Config = score::mw::launch_manager::configuration::Config;
-using ComponentConfig = score::mw::launch_manager::configuration::ComponentConfig;
-using ApplicationType = score::mw::launch_manager::configuration::ApplicationType;
 using RecoveryClient = score::lcm::IRecoveryClient;
 using NanoSecondType = saf::timers::NanoSecondType;
 using IdentifierHash = score::lcm::IdentifierHash;
 
-namespace
-{
-
-bool isSupervisedType(ApplicationType app_type)
-{
-    return app_type == ApplicationType::ReportingAndSupervised || app_type == ApplicationType::StateManager;
-}
-
-}  // namespace
-
-FlatCfgFactory::FlatCfgFactory(const BufferConfig& f_bufferConfig_r)
-    : IPhmFactory(), bufferConfig_r(f_bufferConfig_r), config_(nullptr)
+FlatCfgFactory::FlatCfgFactory(const BufferConfig& f_bufferConfig_r) : IPhmFactory(), bufferConfig_r(f_bufferConfig_r)
 {
 }
 
-bool FlatCfgFactory::init(const Config& config)
+bool FlatCfgFactory::init(const std::vector<SupervisedComponentConfig>& supervised)
 {
-    config_ = &config;
-
-    supervised_components_.clear();
-    for (const auto& comp : config_->components())
-    {
-        if (isSupervisedType(comp.component_properties.application_profile.application_type))
-        {
-            supervised_components_.push_back(&comp);
-        }
-    }
-
+    supervised_components_ = supervised;
     return true;
 }
 
@@ -89,10 +65,10 @@ bool FlatCfgFactory::createProcessStates(
     try
     {
         f_processStates_r.reserve(supervised_components_.size());
-        for (const auto* comp : supervised_components_)
+        for (const auto& comp : supervised_components_)
         {
             ifexm::ProcessCfg processCfg{};
-            processCfg.processShortName = std::string_view(comp->name);
+            processCfg.processShortName = std::string_view(comp.name);
 
             const auto processId = getProcessId(comp);
             processCfg.processId = processId.data();
@@ -104,7 +80,7 @@ bool FlatCfgFactory::createProcessStates(
                 break;
             }
 
-            LM_LOG_DEBUG() << "Successfully created Process States:" << comp->name;
+            LM_LOG_DEBUG() << "Successfully created Process States:" << comp.name;
         }
     }
     catch (const std::exception& f_exception_r)
@@ -158,11 +134,11 @@ bool FlatCfgFactory::createAliveIfIpcs(std::vector<ifappl::CheckpointIpcServer>&
     {
         f_interfaceIpcs_r.reserve(supervised_components_.size());
 
-        for (const auto* comp : supervised_components_)
+        for (const auto& comp : supervised_components_)
         {
-            const std::string pathInterface = score::lcm::internal::aliveInterfacePath(comp->name);
+            const std::string pathInterface = score::lcm::internal::aliveInterfacePath(comp.name);
             f_interfaceIpcs_r.emplace_back();
-            const std::int32_t configuredUid = static_cast<std::int32_t>(comp->deployment_config.sandbox.uid);
+            const std::int32_t configuredUid = static_cast<std::int32_t>(comp.uid);
             isSuccess = initIpcServerWithUidBasedAccess(f_interfaceIpcs_r.back(), pathInterface, configuredUid);
 
             if (isSuccess)
@@ -241,8 +217,8 @@ bool FlatCfgFactory::createSupervisionCheckpoints(
 
         for (size_t idx = 0; idx < supervised_components_.size(); ++idx)
         {
-            const auto* comp = supervised_components_[idx];
-            const std::string checkpointCfgName = comp->name + "_checkpoint";
+            const auto& comp = supervised_components_[idx];
+            const std::string checkpointCfgName = comp.name + "_checkpoint";
             const uint32_t checkpointId = StaticConfig::k_DefaultCheckpointId;
 
             const ifexm::ProcessState* process_p{&f_processStates_r.at(idx)};
@@ -289,12 +265,12 @@ bool FlatCfgFactory::createAliveSupervisions(
 
         for (size_t idx = 0; idx < supervised_components_.size(); ++idx)
         {
-            const auto* comp = supervised_components_[idx];
-            const auto& alive_sup = comp->component_properties.application_profile.alive_supervision;
+            const auto& comp = supervised_components_[idx];
+            const auto& alive_sup = comp.alive_supervision;
             SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
                 alive_sup.has_value(), "Supervised component must have alive_supervision configured");
 
-            alive_cfg_names_.emplace_back(comp->name + "_alive_supervision");
+            alive_cfg_names_.emplace_back(comp.name + "_alive_supervision");
             NanoSecondType aliveReferenceCycleCfg{
                 timers::TimeConversion::convertMilliSecToNanoSec(static_cast<double>(alive_sup->reporting_cycle_ms))};
             uint32_t minAliveIndicationsCfg = alive_sup->min_indications.value_or(0U);
@@ -346,9 +322,9 @@ bool FlatCfgFactory::createAliveSupervisions(
     return isSuccess;
 }
 
-IdentifierHash FlatCfgFactory::getProcessId(const ComponentConfig* comp) noexcept(true)
+IdentifierHash FlatCfgFactory::getProcessId(const SupervisedComponentConfig& comp) noexcept(true)
 {
-    return IdentifierHash{comp->name};
+    return IdentifierHash{comp.name};
 }
 
 }  // namespace factory

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
@@ -41,6 +41,8 @@ namespace saf
 namespace factory
 {
 
+using SupervisedComponentConfig = score::mw::lifecycle::internal::alive::SupervisedComponentConfig;
+
 /// @brief PHM Factory for FlatCfg AR21-11 format
 /// @details Provides methods to create worker objects depending on a AR21-11 based PHM FlatCfg file
 ///          and establishes required links between the worker objects automatically.

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
@@ -16,11 +16,10 @@
 
 #include <memory>
 
-#include "score/mw/launch_manager/alive_monitor/details/common/Types.hpp"
+#include "score/mw/launch_manager/alive_monitor/details/common/AliveMonitorConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/factory/IPhmFactory.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/factory/StaticConfig.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessStateReader.hpp"
-#include "score/mw/launch_manager/configuration/config.hpp"
 #include <string>
 #include <vector>
 
@@ -67,10 +66,9 @@ class FlatCfgFactory : public IPhmFactory
     FlatCfgFactory& operator=(FlatCfgFactory&&) = delete;
 
     /// @brief Initialize SW cluster
-    /// @param [inout] f_flatCfgPhm_r   FlatCfg configuration for PHM
-    /// @param [in] f_nameSwCluster_r   Software Cluster name which for which workers shall be constructed
-    /// @return                         Initialization is successful (true), otherwise failure (false)
-    bool init(const score::mw::launch_manager::configuration::Config& config);
+    /// @param [in] supervised  Vector of supervised component configurations
+    /// @return                 Initialization is successful (true), otherwise failure (false)
+    bool init(const std::vector<SupervisedComponentConfig>& supervised);
 
     /// @brief Refer to the description of the base class (IPhmFactory)
     bool createProcessStates(
@@ -101,10 +99,9 @@ class FlatCfgFactory : public IPhmFactory
 
   private:
     /// @brief Get process id based on ASR path of process
-    /// @param[in] comp  Pointer to component configuration
+    /// @param[in] comp  Reference to component configuration
     /// @return          process id
-    static score::lcm::IdentifierHash getProcessId(
-        const score::mw::launch_manager::configuration::ComponentConfig* comp) noexcept(true);
+    static score::lcm::IdentifierHash getProcessId(const SupervisedComponentConfig& comp) noexcept(true);
 
     /// @brief Create IPC Channel with uid-based access permission
     /// @details Only the given uid will ge granted r/w access, no group will be granted access
@@ -120,8 +117,7 @@ class FlatCfgFactory : public IPhmFactory
     /// @brief The buffer configuration for constructing supervision objects
     const factory::SupervisionBufferConfig& bufferConfig_r;
 
-    const score::mw::launch_manager::configuration::Config* config_;
-    std::vector<const score::mw::launch_manager::configuration::ComponentConfig*> supervised_components_;
+    std::vector<SupervisedComponentConfig> supervised_components_;
     std::vector<std::string> alive_cfg_names_;
 };
 


### PR DESCRIPTION
Adds temporary functionality required to copy configuration data until we can, as part of our refactoring efforts, move the configuration data to the entities intended for that purpose.