### PR TITLE
Faster `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,16 +23,11 @@ repos:
         name: //:format.fix
         entry: bazel run //:format.fix
         language: system
-        files: (BUILD|BUILD\.bazel|WORKSPACE|\.bazelrc|[^/]+\.(py|bzl|bazel|yaml|yml|rs))$
+        files: (BUILD|BUILD\.bazel|WORKSPACE|\.bazelrc|[^/]+\.(py|bzl|bazel|yaml|yml|rs|c|cpp|h|hpp))$
         pass_filenames: false
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
-      - id: clang-format
-        name: clang-format
-        entry: bazel run //:format.fix_C++_with_clang-format
-        language: system
-        files: '\.(c|cc|cpp|h|hpp)$'
       - id: clang-tidy
         name: clang-tidy
         # Run through a wrapper that sanitizes unsupported linker flags in

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@
 repos:
   - repo: local
     hooks:
-      - id: copyright-fix
-        name: //:copyright-fix
-        entry: bazel run //:copyright-fix
-        language: system
-        pass_filenames: false
       - id: format-fix
         name: //:format.fix
         entry: bazel run //:format.fix
@@ -44,3 +39,8 @@ repos:
             tests/|
             score/
           )
+  - repo: https://github.com/eclipse-score/tools
+    rev: 7694bf823421b5542cd2f45239b8bdf205dbface
+    hooks:
+      - id: copyright
+        exclude: ^.github/


### PR DESCRIPTION
- Avoid running Bazel once per file when those files had already been formatted by the previous hook
- Use a faster implementation of the copyright fixer

Should be merged after #447