### PR TITLE
Remove using namespace from headers

### DIFF
--- a/score/launch_manager/src/alive/src/details/AliveImpl.cpp
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.cpp
@@ -34,7 +34,7 @@ AliveImpl::AliveImpl(
 
 void AliveImpl::ReportCheckpoint(std::uint32_t f_checkpointId) const noexcept(true)
 {
-    (void)ipcClient->sendEmplace(score::lcm::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
+    (void)ipcClient->sendEmplace(score::mw::lifecycle::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
 }
 
 void AliveImpl::connectToPhmDaemon(void) noexcept(false)

--- a/score/launch_manager/src/alive/src/details/AliveImpl.h
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.h
@@ -32,10 +32,10 @@ class AliveImpl
 {
   public:
     /// @brief The element that is sent via IPC
-    using CheckpointBufferElement = score::lcm::saf::ifappl::CheckpointBufferElement;
+    using CheckpointBufferElement = score::mw::lifecycle::saf::ifappl::CheckpointBufferElement;
     /// @brief The IPC Connection type
-    using CheckpointIpcClient = score::lcm::saf::ipc::
-        IpcClient<CheckpointBufferElement, score::lcm::saf::ifappl::k_maxCheckpointBufferElements>;
+    using CheckpointIpcClient = score::mw::lifecycle::saf::ipc::
+        IpcClient<CheckpointBufferElement, score::mw::lifecycle::saf::ifappl::k_maxCheckpointBufferElements>;
 
     /// @brief Non-parametric constructor is not supported
     AliveImpl() = delete;

--- a/score/launch_manager/src/control_client/src/control_client.cpp
+++ b/score/launch_manager/src/control_client/src/control_client.cpp
@@ -36,8 +36,8 @@ score::concurrency::InterruptibleFuture<void> GetErrorFuture(ExecErrc errType) n
 
 ControlClient::ControlClient() noexcept
 {
-    static std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback =
-        []([[maybe_unused]] const score::lcm::ExecutionErrorEvent& event) {
+    static std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback =
+        []([[maybe_unused]] const score::mw::lifecycle::ExecutionErrorEvent& event) {
         };
 
     try
@@ -70,8 +70,8 @@ score::concurrency::InterruptibleFuture<void> ControlClient::ActivateRunTarget(
 
     if (control_client_impl_ != nullptr)
     {
-        static score::lcm::IdentifierHash pg_name{"MainPG"};
-        score::lcm::IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
+        static score::mw::lifecycle::IdentifierHash pg_name{"MainPG"};
+        score::mw::lifecycle::IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
         retVal_ = control_client_impl_->SetState(pg_name, pg_state);
     }
     else

--- a/score/launch_manager/src/control_client/src/details/control_client_impl.cpp
+++ b/score/launch_manager/src/control_client/src/details/control_client_impl.cpp
@@ -30,15 +30,15 @@
 // This approach is used to avoid using switch-case statements
 // RULECHECKER_comment(1, 2, check_static_object_dynamic_initialization, "Map doesn't rely on any other static so this
 // is fine", false)
-static std::map<score::lcm::internal::ControlClientCode, score::mw::lifecycle::ExecErrc> scErrorMap = {
-    {score::lcm::internal::ControlClientCode::kSetStateInvalidArguments,
+static std::map<score::mw::lifecycle::internal::ControlClientCode, score::mw::lifecycle::ExecErrc> scErrorMap = {
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateInvalidArguments,
      score::mw::lifecycle::ExecErrc::kInvalidArguments},
-    {score::lcm::internal::ControlClientCode::kSetStateCancelled, score::mw::lifecycle::ExecErrc::kCancelled},
-    {score::lcm::internal::ControlClientCode::kSetStateFailed, score::mw::lifecycle::ExecErrc::kFailed},
-    {score::lcm::internal::ControlClientCode::kSetStateAlreadyInState, score::mw::lifecycle::ExecErrc::kAlreadyInState},
-    {score::lcm::internal::ControlClientCode::kSetStateTransitionToSameState,
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateCancelled, score::mw::lifecycle::ExecErrc::kCancelled},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateFailed, score::mw::lifecycle::ExecErrc::kFailed},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateAlreadyInState, score::mw::lifecycle::ExecErrc::kAlreadyInState},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateTransitionToSameState,
      score::mw::lifecycle::ExecErrc::kInTransitionToSameState},
-    {score::lcm::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter,
+    {score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter,
      score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnEnter}};
 
 namespace score::mw::lifecycle
@@ -59,7 +59,7 @@ bool ControlClientImpl::instance_created_{false};
 std::mutex ControlClientImpl::instance_creation_mutex_{};
 
 ControlClientImpl::ControlClientImpl(
-    std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback) noexcept
+    std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback) noexcept
     : undefined_state_callback_{undefinedStateCallback},
       control_client_requests_{},
       ipc_request_semaphore_{},
@@ -80,10 +80,10 @@ ControlClientImpl::ControlClientImpl(
     }
 
     struct stat stats;
-    const auto fstat_ret = fstat(score::lcm::internal::osal::IpcCommsSync::sync_fd, &stats);
+    const auto fstat_ret = fstat(score::mw::lifecycle::internal::osal::IpcCommsSync::sync_fd, &stats);
     // Check size we have access of to avoid a crash if fd is not pointing to correct data
     const auto needed_size =
-        sizeof(score::lcm::internal::osal::IpcCommsSync) + sizeof(score::lcm::internal::ControlClientChannel);
+        sizeof(score::mw::lifecycle::internal::osal::IpcCommsSync) + sizeof(score::mw::lifecycle::internal::ControlClientChannel);
     if (fstat_ret == -1 || stats.st_size != static_cast<off_t>(needed_size))
     {
         LM_LOG_ERROR() << "Control client channel at sync_fd is not valid!";
@@ -101,11 +101,11 @@ ControlClientImpl::ControlClientImpl(
         control_client_requests_[i].initial_machine_state_transition_request_ = false;
     }
 
-    ipc_channel_ = score::lcm::internal::ControlClientChannel::initializeControlClientChannel();
+    ipc_channel_ = score::mw::lifecycle::internal::ControlClientChannel::initializeControlClientChannel();
 
     const auto init_result = ipc_request_semaphore_.init(1U, false);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-        score::lcm::internal::osal::OsalReturnType::kSuccess == init_result,
+        score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess == init_result,
         "ControlClient semaphore initialization failed");
     ipc_response_thread_ = std::make_unique<std::thread>(&ControlClientImpl::run, this);
 }
@@ -128,7 +128,7 @@ void ControlClientImpl::run()
 {
     // creating a instance called msg for ControlClientMessage that will handle all the communication between LCM and
     // ControlClientImpl
-    score::lcm::internal::ControlClientMessage msg;
+    score::mw::lifecycle::internal::ControlClientMessage msg;
 
     // This lambda function will be used to set the error of the promise.
     // This lamdba funcitons are used to avoid code duplication.
@@ -146,7 +146,7 @@ void ControlClientImpl::run()
 
     // This lambda function will be used to set the error of the promise at unexpected termination.
     auto funcUtermination = [&]() {
-        score::lcm::ExecutionErrorEvent tmp{
+        score::mw::lifecycle::ExecutionErrorEvent tmp{
             msg.execution_error_code_,           // executionError
             msg.process_group_state_.pg_name_};  // processGroup
 
@@ -186,7 +186,7 @@ void ControlClientImpl::run()
 
     // This lambda function will be used to set the error of the promise at default error for ControlClientCode kNotSet.
     std::function<void()> funcDefaultError = [&]() {
-        if (msg.request_or_response_ != score::lcm::internal::ControlClientCode::kNotSet)
+        if (msg.request_or_response_ != score::mw::lifecycle::internal::ControlClientCode::kNotSet)
         {
             LM_LOG_WARN() << "ControlClient error. Undefined message from Launch Manager:"
                           << static_cast<int>(msg.request_or_response_);
@@ -203,52 +203,52 @@ void ControlClientImpl::run()
             {
                 switch (msg.request_or_response_)
                 {
-                    case score::lcm::internal::ControlClientCode::kSetStateInvalidArguments:
-                    case score::lcm::internal::ControlClientCode::kSetStateCancelled:
-                    case score::lcm::internal::ControlClientCode::kSetStateFailed:
-                    case score::lcm::internal::ControlClientCode::kSetStateAlreadyInState:
-                    case score::lcm::internal::ControlClientCode::kSetStateTransitionToSameState:
-                    case score::lcm::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateInvalidArguments:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateCancelled:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateFailed:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateAlreadyInState:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateTransitionToSameState:
+                    case score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter:
                         funcSetError();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kSetStateSuccess:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateSuccess:
                         funcSetValue();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kFailedUnexpectedTermination:
+                    case score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTermination:
                         funcUtermination();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateNotSet:
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateFailed:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateNotSet:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateFailed:
                         funcMcStateWrong();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateSuccess:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateSuccess:
                         funcMcStateSuccess();
                         break;
 
                     default:
-                        // score::lcm::internal::ControlClientCode::kNotSet is just an initialization value
+                        // score::mw::lifecycle::internal::ControlClientCode::kNotSet is just an initialization value
                         // not an error
                         funcDefaultError();
                         break;
                 }
             }
 
-            std::this_thread::sleep_for(score::lcm::internal::kControlClientBgThreadSleepTime);
+            std::this_thread::sleep_for(score::mw::lifecycle::internal::kControlClientBgThreadSleepTime);
         }
     }
 }
 
 score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
-    score::lcm::internal::ControlClientMessage& msg) noexcept
+    score::mw::lifecycle::internal::ControlClientMessage& msg) noexcept
 {
     score::concurrency::InterruptibleFuture<void> retVal_{};
 
-    if (score::lcm::internal::osal::OsalReturnType::kSuccess ==
-        ipc_request_semaphore_.timedWait(score::lcm::internal::kControlClientMaxIpcDelay))
+    if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess ==
+        ipc_request_semaphore_.timedWait(score::mw::lifecycle::internal::kControlClientMaxIpcDelay))
     {
         // first we need to check if we have empty space in control_client_requests_ array
         uint16_t i = 0U;
@@ -268,7 +268,7 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
             // 1) claim the slot and create a fresh promise for this request
             control_client_requests_[i].promise_ = score::concurrency::InterruptiblePromise<void>{};
 
-            if (score::lcm::internal::ControlClientCode::kGetInitialMachineStateRequest == msg.request_or_response_)
+            if (score::mw::lifecycle::internal::ControlClientCode::kGetInitialMachineStateRequest == msg.request_or_response_)
             {
                 // the GetInitialMachineStateTransitionResult request is a bit special
                 // and will need special treatment in bg thread servicing response_ link
@@ -300,7 +300,7 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
 
         // we definitely shouldn't forget to release semaphore
         const auto post_result = ipc_request_semaphore_.post();
-        if (score::lcm::internal::osal::OsalReturnType::kSuccess != post_result)
+        if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess != post_result)
         {
             // Invalid semaphore usage is a logic error and should be asserted.
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
@@ -326,16 +326,16 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
 }
 
 score::concurrency::InterruptibleFuture<void> ControlClientImpl::SetState(
-    const score::lcm::IdentifierHash& pg_name,
-    const score::lcm::IdentifierHash& pg_state) noexcept
+    const score::mw::lifecycle::IdentifierHash& pg_name,
+    const score::mw::lifecycle::IdentifierHash& pg_state) noexcept
 {
     score::concurrency::InterruptibleFuture<void> retVal_{};
 
     if (nullptr != ipc_channel_)
     {
-        score::lcm::internal::ControlClientMessage msg;
+        score::mw::lifecycle::internal::ControlClientMessage msg;
 
-        msg.request_or_response_ = score::lcm::internal::ControlClientCode::kSetStateRequest;
+        msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kSetStateRequest;
         msg.process_group_state_.pg_name_ = pg_name;
         msg.process_group_state_.pg_state_name_ = pg_state;
 
@@ -355,9 +355,9 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::GetInitialMachi
 
     if (nullptr != ipc_channel_)
     {
-        score::lcm::internal::ControlClientMessage msg;
+        score::mw::lifecycle::internal::ControlClientMessage msg;
 
-        msg.request_or_response_ = score::lcm::internal::ControlClientCode::kGetInitialMachineStateRequest;
+        msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kGetInitialMachineStateRequest;
         // pg_name_ is not used by this request
         // pg_state_name_ is not used by this request
 
@@ -371,23 +371,23 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::GetInitialMachi
     return retVal_;
 }
 
-score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionError(
-    const score::lcm::IdentifierHash& processGroup) noexcept
+score::Result<score::mw::lifecycle::ExecutionErrorEvent> ControlClientImpl::GetExecutionError(
+    const score::mw::lifecycle::IdentifierHash& processGroup) noexcept
 {
     // default error (just in case)
-    score::Result<score::lcm::ExecutionErrorEvent> retVal_{
+    score::Result<score::mw::lifecycle::ExecutionErrorEvent> retVal_{
         score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
 
     if (nullptr != ipc_channel_)
     {
-        if (score::lcm::internal::osal::OsalReturnType::kSuccess ==
-            ipc_request_semaphore_.timedWait(score::lcm::internal::kControlClientMaxIpcDelay))
+        if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess ==
+            ipc_request_semaphore_.timedWait(score::mw::lifecycle::internal::kControlClientMaxIpcDelay))
         {
             // 1) prepare message for LCM
-            score::lcm::internal::ControlClientMessage msg;
+            score::mw::lifecycle::internal::ControlClientMessage msg;
 
             // future_id_ is not used by this request
-            msg.request_or_response_ = score::lcm::internal::ControlClientCode::kGetExecutionErrorRequest;
+            msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kGetExecutionErrorRequest;
             msg.process_group_state_.pg_name_ = processGroup;
             // pg_state_name_ is not used by this request
 
@@ -398,14 +398,14 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
             switch (msg.request_or_response_)
             {
                 // GetExecutionError
-                case score::lcm::internal::ControlClientCode::kExecutionErrorInvalidArguments:
-                case score::lcm::internal::ControlClientCode::kExecutionErrorRequestFailed:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorInvalidArguments:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorRequestFailed:
                     retVal_ = score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kFailed);
                     break;
 
-                case score::lcm::internal::ControlClientCode::kExecutionErrorRequestSuccess:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorRequestSuccess:
                 {
-                    score::lcm::ExecutionErrorEvent tmp{
+                    score::mw::lifecycle::ExecutionErrorEvent tmp{
                         msg.execution_error_code_,           // executionError
                         msg.process_group_state_.pg_name_};  // processGroup
                     retVal_.emplace(std::move(tmp));
@@ -421,7 +421,7 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
 
             // we definitely shouldn't forget to release semaphore
             const auto post_result = ipc_request_semaphore_.post();
-            if (score::lcm::internal::osal::OsalReturnType::kSuccess != post_result)
+            if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess != post_result)
             {
                 // Invalid semaphore usage is a logic error and should be asserted.
                 SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(

--- a/score/launch_manager/src/control_client/src/details/control_client_impl.hpp
+++ b/score/launch_manager/src/control_client/src/details/control_client_impl.hpp
@@ -77,7 +77,7 @@ class ControlClientImpl final
   public:
     ControlClientImpl() = delete;
 
-    ControlClientImpl(std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback) noexcept;
+    ControlClientImpl(std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback) noexcept;
 
     // this class is not movable or copyable by definition
     ControlClientImpl(const ControlClientImpl&) = delete;
@@ -117,8 +117,8 @@ class ControlClientImpl final
     /// (e.g. Off state for MainPG)
     /// @error score::mw::lifecycle::ExecErrc::kGeneralError if any other error occurs.
     score::concurrency::InterruptibleFuture<void> SetState(
-        const score::lcm::IdentifierHash& pg_name,
-        const score::lcm::IdentifierHash& pg_state) noexcept;
+        const score::mw::lifecycle::IdentifierHash& pg_name,
+        const score::mw::lifecycle::IdentifierHash& pg_state) noexcept;
 
     /// @brief Method to retrieve result of Machine State initial transition to Startup state.
     ///
@@ -146,8 +146,8 @@ class ControlClientImpl final
     /// State.
     /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch
     /// Manager (e.g. IPC link is down)
-    score::Result<score::lcm::ExecutionErrorEvent> GetExecutionError(
-        const score::lcm::IdentifierHash& processGroup) noexcept;
+    score::Result<score::mw::lifecycle::ExecutionErrorEvent> GetExecutionError(
+        const score::mw::lifecycle::IdentifierHash& processGroup) noexcept;
 
     ~ControlClientImpl() noexcept;
 
@@ -161,7 +161,7 @@ class ControlClientImpl final
     static std::mutex instance_creation_mutex_;
 
     /// @brief callback that ControlClient instance ask us to invoke when there is a problem with PG
-    std::function<void(const score::lcm::ExecutionErrorEvent&)> undefined_state_callback_;
+    std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefined_state_callback_;
 
     /// @brief Array of active requests, that wait for completion from LCM side.
     /// When a request has been send to LCM and the answer is not immediately available,
@@ -170,7 +170,7 @@ class ControlClientImpl final
     /// answer arrives from LCM.
     std::array<
         ControlClientRequestInfo,
-        static_cast<uint16_t>(score::lcm::internal::ControlClientLimits::kControlClientMaxRequests)>
+        static_cast<uint16_t>(score::mw::lifecycle::internal::ControlClientLimits::kControlClientMaxRequests)>
         control_client_requests_;
 
     /// @brief Semaphore used to protect access to the request_ link of ControlClientChannel,
@@ -180,7 +180,7 @@ class ControlClientImpl final
     /// Please note that synchronization for control_client_requests_ is only needed, when we are booking a slot
     /// inside this array. When we are releasing a slot inside this array, this can be done without
     /// ipc_request_semaphore_ protection.
-    score::lcm::internal::osal::Semaphore ipc_request_semaphore_;
+    score::mw::lifecycle::internal::osal::Semaphore ipc_request_semaphore_;
 
     /// @brief Thread used for monitoring response_ link of ControlClientChannel.
     /// Asynchronous nature of ControlClient API means responses to ControlClient requests, will arrive at
@@ -202,7 +202,7 @@ class ControlClientImpl final
 
     /// @brief Handle to the real IPC communication channel with LCM
     /// This handle is used to perform low level communication with LCM.
-    score::lcm::internal::ControlClientChannelP ipc_channel_;
+    score::mw::lifecycle::internal::ControlClientChannelP ipc_channel_;
 
     /// @brief Helper method to send a message to LCM, through IPC link (aka request_ link).
     ///
@@ -225,7 +225,7 @@ class ControlClientImpl final
     ///
     /// @threadsafety{thread-safe}
     score::concurrency::InterruptibleFuture<void> SendIpcMessage(
-        score::lcm::internal::ControlClientMessage& msg) noexcept;
+        score::mw::lifecycle::internal::ControlClientMessage& msg) noexcept;
 };
 
 }  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal::alive
 namespace
 {
 
-using ApplicationType = score::mw::launch_manager::configuration::ApplicationType;
+using ApplicationType = score::mw::lifecycle::configuration::ApplicationType;
 
 bool isSupervisedType(ApplicationType app_type)
 {
@@ -32,7 +32,7 @@ bool isSupervisedType(ApplicationType app_type)
 
 }  // namespace
 
-AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config)
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config)
 {
     AliveMonitorConfig result{};
     result.evaluation_cycle_ms = config.aliveSupervision().evaluation_cycle_ms;

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
@@ -35,7 +35,7 @@ struct SupervisedComponentConfig
     /// @brief Component short name.
     std::string name;
     /// @brief Alive-supervision parameters.
-    std::optional<score::mw::launch_manager::configuration::ComponentAliveSupervision> alive_supervision;
+    std::optional<score::mw::lifecycle::configuration::ComponentAliveSupervision> alive_supervision;
     /// @brief Uid the component runs as.
     uid_t uid{};
 };
@@ -51,7 +51,7 @@ struct AliveMonitorConfig
 
 /// @brief Returns a copy of alive-monitor-relevant configuration.
 /// @return AliveMonitor configuration
-AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config);
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config);
 
 }  // namespace score::mw::lifecycle::internal::alive
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal::alive
 namespace
 {
 
-namespace cfg = score::mw::launch_manager::configuration;
+namespace cfg = score::mw::lifecycle::configuration;
 
 cfg::ComponentConfig makeComponent(
     const std::string& name,

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
@@ -16,11 +16,7 @@
 
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace common
 {
@@ -238,8 +234,6 @@ class FixedSizeVector
     std::vector<Type> fixedSizedVector{};
 };
 }  // namespace common
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
@@ -16,11 +16,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/common/FixedSizeVector.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace common
 {
@@ -124,8 +120,6 @@ class LockedVector final : private FixedSizeVector<Type>
 };
 
 }  // namespace common
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
@@ -19,11 +19,7 @@
 
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace common
 {
@@ -131,8 +127,6 @@ class Observable
 };
 
 }  // namespace common
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
@@ -19,11 +19,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/common/FixedSizeVector.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace common
 {
@@ -73,7 +69,7 @@ class TimeSortingBuffer
     /// @return                     Success of push (true) sufficient space in buffer was available
     /* RULECHECKER_comment(0, 3, check_cheap_to_copy_in_parameter, "For template argument f_element_r, it is not \
     possible to classify cheap_to_copy or expensive_to_copy without referring original object.", true_no_defect) */
-    bool push(const TimeSortedElementType& f_element_r, const score::lcm::saf::timers::NanoSecondType f_timestamp)
+    bool push(const TimeSortedElementType& f_element_r, const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp)
     {
         bool isSuccess{false};
         SortChainElement newElement{nullptr, nullptr, f_element_r, f_timestamp};
@@ -138,7 +134,7 @@ class TimeSortingBuffer
             nullptr};                       // Pointer to previous element, null pointer means first element (oldest)
         SortChainElement* next_p{nullptr};  // Pointer to next element, null pointer means last element (latest)
         TimeSortedElementType element{};    // Element to be sorted
-        score::lcm::saf::timers::NanoSecondType timestamp{0U};  // Timestamp used for sorting the elements
+        score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  // Timestamp used for sorting the elements
     };
 
     /// Sort elements
@@ -228,8 +224,6 @@ class TimeSortingBuffer
 };
 
 }  // namespace common
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/Types.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/Types.hpp
@@ -15,11 +15,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace common
 {
@@ -27,8 +23,6 @@ namespace common
 using ProcessId = std::size_t;
 
 }  // namespace common
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -18,13 +18,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 AliveMonitorImpl::AliveMonitorImpl(
@@ -78,7 +72,4 @@ bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept
     return m_daemon->startCyclicExec(cancel_thread);
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -20,9 +20,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/daemon/IAliveMonitor.hpp"
 #include "score/mw/launch_manager/configuration/config.hpp"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 class IRecoveryClient;
@@ -33,11 +31,11 @@ namespace saf
 namespace daemon
 {
 
-using SptrIRecoveryClient = std::shared_ptr<score::lcm::IRecoveryClient>;
-using UptrIProcessStateReceiver = std::unique_ptr<score::lcm::IProcessStateReceiver>;
-using UptrPhmDaemon = std::unique_ptr<score::lcm::saf::daemon::PhmDaemon>;
-using OsClock = score::lcm::saf::timers::OsClockInterface;
-using Config = score::mw::launch_manager::configuration::Config;
+using SptrIRecoveryClient = std::shared_ptr<score::mw::lifecycle::IRecoveryClient>;
+using UptrIProcessStateReceiver = std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver>;
+using UptrPhmDaemon = std::unique_ptr<score::mw::lifecycle::saf::daemon::PhmDaemon>;
+using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
+using Config = score::mw::lifecycle::configuration::Config;
 using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
 class AliveMonitorImpl : public IAliveMonitor
@@ -60,9 +58,6 @@ class AliveMonitorImpl : public IAliveMonitor
     AliveMonitorConfig m_config;
 };
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -58,6 +58,8 @@ class AliveMonitorImpl : public IAliveMonitor
     AliveMonitorConfig m_config;
 };
 
-}  // namespace score::mw::lifecycle::saf::daemon
+}  // namespace daemon
+}  // namespace saf
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
@@ -17,13 +17,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/PhmDaemon.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 /// @brief Interface for HealthMonitor functionality
@@ -41,8 +35,5 @@ class IAliveMonitor
     virtual bool run(std::atomic_bool& cancel_thread) noexcept = 0;
 };
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
@@ -18,13 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 /* RULECHECKER_comment(0, 6, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const ref",
@@ -102,7 +96,4 @@ bool PhmDaemon::construct(const AliveMonitorConfig& config, const SupervisionBuf
     return isSuccess;
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -27,13 +27,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimer.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 /// @brief Return codes for PhmDaemon Initialization
@@ -52,14 +46,14 @@ enum class EInitCode : std::int8_t
 class PhmDaemon
 {
   public:
-    using OsClock = score::lcm::saf::timers::OsClockInterface;
-    using ProcessStateReceiver = score::lcm::IProcessStateReceiver;
-    using RecoveryClient = score::lcm::IRecoveryClient;
+    using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
+    using ProcessStateReceiver = score::mw::lifecycle::IProcessStateReceiver;
+    using RecoveryClient = score::mw::lifecycle::IRecoveryClient;
     using SupervisionBufferConfig = factory::SupervisionBufferConfig;
-    using CycleTimer = score::lcm::saf::timers::CycleTimer;
-    using CycleTimeValidator = score::lcm::saf::timers::CycleTimeValidator;
-    using NanoSecondType = score::lcm::saf::timers::NanoSecondType;
-    using ProcessStateReader = score::lcm::saf::ifexm::ProcessStateReader;
+    using CycleTimer = score::mw::lifecycle::saf::timers::CycleTimer;
+    using CycleTimeValidator = score::mw::lifecycle::saf::timers::CycleTimeValidator;
+    using NanoSecondType = score::mw::lifecycle::saf::timers::NanoSecondType;
+    using ProcessStateReader = score::mw::lifecycle::saf::ifexm::ProcessStateReader;
     using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
     /* RULECHECKER_comment(0, 4, check_expensive_to_copy_in_parameter, "f_supervisionErrorInfo name is passed by value\
@@ -220,9 +214,6 @@ class PhmDaemon
     ProcessStateReader processStateReader;
 };
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
@@ -16,13 +16,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 /// @brief Configuration parameters of the PHM daemon
@@ -37,9 +31,6 @@ class PhmDaemonConfig
     }
 };
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
@@ -18,13 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/MonitorIfDaemon.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 SwClusterHandler::SwClusterHandler(const std::string& f_swClusterName_r)
@@ -47,7 +41,7 @@ SwClusterHandler::~SwClusterHandler() = default;
    is tolerated for this function. ", true_no_defect) */
 bool SwClusterHandler::constructWorkers(
     const AliveMonitorConfig& config,
-    std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r,
     ifexm::ProcessStateReader& f_processStateReader_r,
     const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false)
 {
@@ -118,7 +112,4 @@ void SwClusterHandler::performCyclicTriggers(const timers::NanoSecondType f_sync
     evaluateSupervisions(f_syncTimestamp);
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -137,6 +137,8 @@ class SwClusterHandler
     std::vector<supervision::Alive> aliveSupervisions;
 };
 
-}  // namespace score::mw::lifecycle::saf::daemon
+}  // namespace daemon
+}  // namespace saf
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -24,9 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 class IRecoveryClient;
@@ -96,7 +94,7 @@ class SwClusterHandler
     /// @return                              Construction is successful (true), otherwise failure (false)
     bool constructWorkers(
         const AliveMonitorConfig& config,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r,
         ifexm::ProcessStateReader& f_processStateReader_r,
         const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false);
 
@@ -139,9 +137,6 @@ class SwClusterHandler
     std::vector<supervision::Alive> aliveSupervisions;
 };
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::daemon
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -32,19 +32,13 @@
 #include "score/mw/launch_manager/common/alive_interface_path.hpp"
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace factory
+namespace score::mw::lifecycle::saf::factory
 {
 
 using BufferConfig = SupervisionBufferConfig;
-using RecoveryClient = score::lcm::IRecoveryClient;
+using RecoveryClient = score::mw::lifecycle::IRecoveryClient;
 using NanoSecondType = saf::timers::NanoSecondType;
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 FlatCfgFactory::FlatCfgFactory(const BufferConfig& f_bufferConfig_r) : IPhmFactory(), bufferConfig_r(f_bufferConfig_r)
 {
@@ -136,7 +130,7 @@ bool FlatCfgFactory::createAliveIfIpcs(std::vector<ifappl::CheckpointIpcServer>&
 
         for (const auto& comp : supervised_components_)
         {
-            const std::string pathInterface = score::lcm::internal::aliveInterfacePath(comp.name);
+            const std::string pathInterface = score::mw::lifecycle::internal::aliveInterfacePath(comp.name);
             f_interfaceIpcs_r.emplace_back();
             const std::int32_t configuredUid = static_cast<std::int32_t>(comp.uid);
             isSuccess = initIpcServerWithUidBasedAccess(f_interfaceIpcs_r.back(), pathInterface, configuredUid);
@@ -327,7 +321,4 @@ IdentifierHash FlatCfgFactory::getProcessId(const SupervisedComponentConfig& com
     return IdentifierHash{comp.name};
 }
 
-}  // namespace factory
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::factory

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
@@ -23,19 +23,13 @@
 #include <string>
 #include <vector>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 class ControlClient;
 }
 }  // namespace score
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 
 namespace factory
@@ -97,13 +91,13 @@ class FlatCfgFactory : public IPhmFactory
         std::vector<supervision::Alive>& f_alive_r,
         std::vector<ifappl::Checkpoint>& f_checkpoints_r,
         std::vector<ifexm::ProcessState>& f_processStates_r,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r) override;
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r) override;
 
   private:
     /// @brief Get process id based on ASR path of process
     /// @param[in] comp  Reference to component configuration
     /// @return          process id
-    static score::lcm::IdentifierHash getProcessId(const SupervisedComponentConfig& comp) noexcept(true);
+    static score::mw::lifecycle::IdentifierHash getProcessId(const SupervisedComponentConfig& comp) noexcept(true);
 
     /// @brief Create IPC Channel with uid-based access permission
     /// @details Only the given uid will ge granted r/w access, no group will be granted access
@@ -123,9 +117,6 @@ class FlatCfgFactory : public IPhmFactory
     std::vector<std::string> alive_cfg_names_;
 };
 
-}  // namespace factory
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::factory
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
@@ -17,19 +17,13 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/DataStructures.hpp"
 #include <vector>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 class IRecoveryClient;
 }
 }  // namespace score
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 
 // Forward declarations
@@ -119,12 +113,9 @@ class IPhmFactory
         std::vector<supervision::Alive>& f_alive_r,
         std::vector<ifappl::Checkpoint>& f_checkpoints_r,
         std::vector<ifexm::ProcessState>& f_processStates_r,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r) = 0;
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r) = 0;
 };
 
-}  // namespace factory
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::factory
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
@@ -19,13 +19,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/DataStructures.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace factory
+namespace score::mw::lifecycle::saf::factory
 {
 
 struct SupervisionBufferConfig
@@ -59,9 +53,6 @@ class StaticConfig
         StaticConfig::k_DefaultMonitorBufferElements};
 };
 
-}  // namespace factory
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::factory
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
@@ -13,13 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/Checkpoint.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 Checkpoint::Checkpoint(
@@ -79,7 +73,4 @@ const ifexm::ProcessState* Checkpoint::getProcess(void) const noexcept(true)
     return processState;
 }
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
@@ -23,13 +23,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessState.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 /// @brief Checkpoint Observer
@@ -78,12 +72,12 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
 
     /// @brief Get timestamp
     /// @return NanoSecondType  Timestamp value of the reported checkpoint in [nano seconds]
-    score::lcm::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
+    score::mw::lifecycle::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
 
     /// @brief Push data to checkpoint observer
     /// @details Push the checkpoint timestamp to the checkpoint observer to notify it was reported
     /// @param [in] f_timestamp     Timestamp value captured when the checkpoint was reported in [nano seconds]
-    void pushData(const score::lcm::saf::timers::NanoSecondType f_timestamp) noexcept(true);
+    void pushData(const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp) noexcept(true);
 
     /// @brief Set data loss event
     /// @details Set data loss event in the checkpoint observer
@@ -116,12 +110,9 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
     bool isDataLossEvent;
 
     /// @brief Timestamp value in [nano seconds]
-    score::lcm::saf::timers::NanoSecondType timestamp;
+    score::mw::lifecycle::saf::timers::NanoSecondType timestamp;
 };
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifappl
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
@@ -19,13 +19,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ipc/IpcServer.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 /// Maximum number of Checkpoints to be stored in IPC channel
@@ -42,7 +36,7 @@ constexpr uint16_t k_maxCheckpointBufferElements{512U};
 required for Vector and IPC APIs", true_no_defect) */
 struct CheckpointBufferElement final
 {
-    score::lcm::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
+    score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
     uint32_t checkpointId{0U};                              ///< Checkpoint ID
 
     /// @brief Default constructor needed for storage in vector
@@ -51,7 +45,7 @@ struct CheckpointBufferElement final
     /// @brief Constructor for usage with emplace
     /// @param [in] f_timestamp The checkpoint timestamp
     /// @param [in] f_checkpointId  The checkpoint id
-    CheckpointBufferElement(score::lcm::saf::timers::NanoSecondType f_timestamp, uint32_t f_checkpointId) noexcept(true)
+    CheckpointBufferElement(score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp, uint32_t f_checkpointId) noexcept(true)
         : timestamp(f_timestamp), checkpointId(f_checkpointId)
     {
     }
@@ -60,9 +54,6 @@ struct CheckpointBufferElement final
 /// @brief IPC server type instantiation with maximum checkpoint buffer size
 using CheckpointIpcServer = ipc::IpcServer<CheckpointBufferElement, k_maxCheckpointBufferElements>;
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifappl
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
@@ -18,13 +18,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessState.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 MonitorIfDaemon::MonitorIfDaemon(CheckpointIpcServer& f_ipcServer_r, const char* f_interfaceName_p)
@@ -207,7 +201,4 @@ void MonitorIfDaemon::pushOverflowInfoToCheckpointObservers(void) const
     }
 }
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
@@ -20,13 +20,7 @@
 #include <string>
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 class ProcessState;
 }
@@ -95,7 +89,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ProcessState>
     /// @brief Check for new data
     /// @details Check Alive interface for new data from application side
     /// @param [in]  f_syncTimestamp    Timestamp till data shall be read, newer data will not be considered
-    void checkForNewData(const score::lcm::saf::timers::NanoSecondType f_syncTimestamp) noexcept(true);
+    void checkForNewData(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp) noexcept(true);
 
   private:
     /// @brief Check if checkpoint ring buffer overflow has occurred
@@ -118,7 +112,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ProcessState>
     /// @details The checkpoint ring buffer data is pushed to checkpoint specific objects.
     /// @param [in]  f_syncTimestamp        Timestamp till data shall be read, newer data will not be considered
     /// @returns True if reading data from IPC channel and pushing data to observers was successful, else false
-    bool pushNewDataToCheckpointObservers(const score::lcm::saf::timers::NanoSecondType f_syncTimestamp);
+    bool pushNewDataToCheckpointObservers(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp);
 
     /// @brief Push a single checkpoint to observers
     /// @param[in] f_elem_r The checkpoint to push to observers
@@ -154,9 +148,6 @@ class MonitorIfDaemon : public common::Observer<ifexm::ProcessState>
     CheckpointIpcServer& ipcserver_r;
 };
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifappl
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
@@ -25,7 +25,7 @@
 
 using namespace testing;
 
-namespace score::lcm::saf
+namespace score::mw::lifecycle::saf
 {
 
 namespace
@@ -462,4 +462,4 @@ TEST_F(MonitorIfDaemonTest, InactiveOverflow_ProcessRestartFlag_ClearedAfterNoti
     fix.monitor.checkForNewData(mockClock());  // no new restart -> no additional notification
 }
 
-}  // namespace score::lcm::saf
+}  // namespace score::mw::lifecycle::saf

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessCfg.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessCfg.hpp
@@ -20,13 +20,7 @@
 #include <string_view>
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 /* RULECHECKER_comment(0, 18, check_non_private_non_pod_field, "Process configuration is intended to be\
@@ -49,9 +43,6 @@ class ProcessCfg final
     }
 };
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifexm
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessState.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessState.cpp
@@ -13,13 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessState.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 ProcessState::ProcessState(const ProcessCfg& f_processCfg_r) noexcept(false)
@@ -65,7 +59,4 @@ void ProcessState::pushData(void) noexcept
     pushResultToObservers();
 }
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifexm

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessState.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessState.hpp
@@ -22,13 +22,7 @@
 
 #include "score/mw/launch_manager/process_state_client/posix_process.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 /// @brief Process State
@@ -75,12 +69,12 @@ class ProcessState : public saf::common::Observable<ProcessState>
     /// @brief Enumeration of process states
     enum class EProcState : uint8_t
     {
-        idle = static_cast<uint8_t>(score::lcm::ProcessState::kIdle),
-        starting = static_cast<uint8_t>(score::lcm::ProcessState::kStarting),
-        running = static_cast<uint8_t>(score::lcm::ProcessState::kRunning),
-        sigterm = static_cast<uint8_t>(score::lcm::ProcessState::kTerminating),
-        off = static_cast<uint8_t>(score::lcm::ProcessState::kTerminated),
-        failed = static_cast<uint8_t>(score::lcm::ProcessState::kFailed)
+        idle = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kIdle),
+        starting = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kStarting),
+        running = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kRunning),
+        sigterm = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kTerminating),
+        off = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kTerminated),
+        failed = static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kFailed)
     };
 
     /// @brief Get Process State
@@ -117,9 +111,6 @@ class ProcessState : public saf::common::Observable<ProcessState>
     timers::NanoSecondType timestamp{UINT64_MAX};
 };
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifexm
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessStateReader.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessStateReader.cpp
@@ -15,13 +15,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 ProcessStateReader::ProcessStateReader(std::unique_ptr<LcmProcessStateReceiver> f_process_state_receiver)
@@ -136,32 +130,29 @@ constexpr ProcessState::EProcState ProcessStateReader::translateProcessState(
 {
     // Following static assertion ensures consistency of process states in EXM and PHM
     static_assert(
-        static_cast<uint8_t>(ProcessState::EProcState::idle) == static_cast<uint8_t>(score::lcm::ProcessState::kIdle),
+        static_cast<uint8_t>(ProcessState::EProcState::idle) == static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kIdle),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     static_assert(
         static_cast<uint8_t>(ProcessState::EProcState::starting) ==
-            static_cast<uint8_t>(score::lcm::ProcessState::kStarting),
+            static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kStarting),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     static_assert(
         static_cast<uint8_t>(ProcessState::EProcState::running) ==
-            static_cast<uint8_t>(score::lcm::ProcessState::kRunning),
+            static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kRunning),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     static_assert(
         static_cast<uint8_t>(ProcessState::EProcState::sigterm) ==
-            static_cast<uint8_t>(score::lcm::ProcessState::kTerminating),
+            static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kTerminating),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     static_assert(
         static_cast<uint8_t>(ProcessState::EProcState::off) ==
-            static_cast<uint8_t>(score::lcm::ProcessState::kTerminated),
+            static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kTerminated),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     static_assert(
         static_cast<uint8_t>(ProcessState::EProcState::failed) ==
-            static_cast<uint8_t>(score::lcm::ProcessState::kFailed),
+            static_cast<uint8_t>(score::mw::lifecycle::ProcessState::kFailed),
         "Lcm State Enum and ProcessState::EProcState Enum do not match.");
     return static_cast<ProcessState::EProcState>(f_processStateLcm);
 }
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifexm

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessStateReader.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ProcessStateReader.hpp
@@ -22,13 +22,7 @@
 #include "score/mw/launch_manager/process_state_client/iprocess_state_receiver.hpp"
 #include "score/mw/launch_manager/process_state_client/posix_process.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 /// @brief Process State reader
@@ -37,9 +31,9 @@ namespace ifexm
 class ProcessStateReader
 {
   public:
-    using LcmProcessState = score::lcm::ProcessState;
-    using LcmPosixProcess = score::lcm::PosixProcess;
-    using LcmProcessStateReceiver = score::lcm::IProcessStateReceiver;
+    using LcmProcessState = score::mw::lifecycle::ProcessState;
+    using LcmPosixProcess = score::mw::lifecycle::PosixProcess;
+    using LcmProcessStateReceiver = score::mw::lifecycle::IProcessStateReceiver;
 
     /// @brief Constructor
     /// @param [in] f_process_state_receiver   Process state receiver implementation
@@ -100,9 +94,6 @@ class ProcessStateReader
     ProcessState* lastChangedProcess_p{nullptr};
 };
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::ifexm
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
@@ -19,11 +19,7 @@
 #include "ipc_dropin/socket.hpp"
 #include <string_view>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace ipc
 {
@@ -175,8 +171,6 @@ class IpcBase
 };
 
 }  // namespace ipc
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
@@ -20,11 +20,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ipc/IpcBase.hpp"
 #include <string>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace ipc
 {
@@ -101,8 +97,6 @@ class IpcClient final : public IpcBase<Payload, MaxNumberElements, Socket>
 };
 
 }  // namespace ipc
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
@@ -26,11 +26,7 @@
 #include <unistd.h>
 #include <string>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
+namespace score::mw::lifecycle::saf
 {
 namespace ipc
 {
@@ -212,8 +208,6 @@ class IpcServer final : public IpcBase<Payload, MaxNumberElements, Socket>
 };
 
 }  // namespace ipc
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
@@ -21,13 +21,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ProcessState.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
@@ -54,7 +48,7 @@ Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
 }
 
 // coverity[exn_spec_violation:FALSE] std::length_error is not thrown from push() which uses fixed-size-vector
-void Alive::updateData(const score::lcm::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
+void Alive::updateData(const score::mw::lifecycle::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
 {
     timers::NanoSecondType timestamp{f_observable_r.getTimestamp()};
 
@@ -610,7 +604,4 @@ timers::NanoSecondType Alive::getTimestampOfUpdateEvent(const TimeSortedUpdateEv
     return timestamp;
 }
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
@@ -25,13 +25,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/supervision/SupervisionCfg.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 /// @brief Alive Supervision
@@ -127,7 +121,7 @@ class Alive : public ISupervision,
   private:
     /// @brief The pointer is only stored for the identification of a checkpoint observer. It can be further used for
     /// accessing const members only.
-    using CheckpointIdentifier = const score::lcm::saf::ifappl::Checkpoint*;
+    using CheckpointIdentifier = const score::mw::lifecycle::saf::ifappl::Checkpoint*;
 
     /// @brief Time sorted checkpoint snapshot
     struct CheckpointSnapshot final
@@ -287,7 +281,7 @@ class Alive : public ISupervision,
     bool setReferenceCycleTimestamps(timers::NanoSecondType f_baseValue) noexcept(true);
 
     /// @brief Alive reference cycle in [nano seconds]
-    const score::lcm::saf::timers::NanoSecondType k_aliveReferenceCycle;
+    const score::mw::lifecycle::saf::timers::NanoSecondType k_aliveReferenceCycle;
 
     /// @brief Minimum allowed alive indications
     const uint32_t k_minAliveIndications;
@@ -305,10 +299,10 @@ class Alive : public ISupervision,
     const uint32_t k_failedSupervisionCyclesTolerance;
 
     /// @brief Recovery client invoked when supervision expires (null means recovery is disabled)
-    std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient_p;
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient_p;
 
     /// @brief Identifier of the supervised process, sent via recovery client when supervision expires
-    const score::lcm::IdentifierHash processIdentifier_;
+    const score::mw::lifecycle::IdentifierHash processIdentifier_;
 
     /// @brief Set to true when sendRecoveryRequest fails (ring buffer full)
     bool recoveryEnqueueFailed_{false};
@@ -341,12 +335,9 @@ class Alive : public ISupervision,
 
     /// @brief Time sorting buffer for update events in alive supervision
     /// @details This buffer sorts all process events and checkpoint events in the same buffer.
-    score::lcm::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
+    score::mw::lifecycle::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
 };
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::supervision
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
@@ -27,24 +27,24 @@
 
 using namespace testing;
 
-using EStatus = score::lcm::saf::supervision::Alive::EStatus;
-using EProcState = score::lcm::saf::ifexm::ProcessState::EProcState;
+using EStatus = score::mw::lifecycle::saf::supervision::Alive::EStatus;
+using EProcState = score::mw::lifecycle::saf::ifexm::ProcessState::EProcState;
 
 namespace
 {
 
-class MockRecoveryClient : public score::lcm::IRecoveryClient
+class MockRecoveryClient : public score::mw::lifecycle::IRecoveryClient
 {
   public:
     MOCK_METHOD(
         void,
         setRecoveryRequestCallback,
-        (score::lcm::IRecoveryClient::RecoveryRequestCallback callback),
+        (score::mw::lifecycle::IRecoveryClient::RecoveryRequestCallback callback),
         (noexcept, override));
     MOCK_METHOD(
         bool,
         sendRecoveryRequest,
-        (const score::lcm::IdentifierHash& process_group_identifier),
+        (const score::mw::lifecycle::IdentifierHash& process_group_identifier),
         (noexcept, override));
 };
 
@@ -54,14 +54,14 @@ struct AliveFixture
 {
     static constexpr char kProcessName[] = "test_proc";
     static constexpr char kCheckpointName[] = "test_cp";
-    static constexpr score::lcm::saf::common::ProcessId kProcessId = 42U;
+    static constexpr score::mw::lifecycle::saf::common::ProcessId kProcessId = 42U;
 
     struct Builder
     {
         uint32_t failedCyclesTolerance = 0U;
         uint32_t minIndications = 1U;
         uint32_t maxIndications = 3U;
-        score::lcm::saf::timers::NanoSecondType referenceCycleNs = 1000U;
+        score::mw::lifecycle::saf::timers::NanoSecondType referenceCycleNs = 1000U;
 
         Builder& withFailedCyclesTolerance(uint32_t val)
         {
@@ -78,7 +78,7 @@ struct AliveFixture
             maxIndications = val;
             return *this;
         }
-        Builder& withReferenceCycleNs(score::lcm::saf::timers::NanoSecondType val)
+        Builder& withReferenceCycleNs(score::mw::lifecycle::saf::timers::NanoSecondType val)
         {
             referenceCycleNs = val;
             return *this;
@@ -90,19 +90,19 @@ struct AliveFixture
         }
     };
 
-    const score::lcm::IdentifierHash kProcessIdentifier{"test_proc"};
+    const score::mw::lifecycle::IdentifierHash kProcessIdentifier{"test_proc"};
 
     std::shared_ptr<MockRecoveryClient> mockClient = std::make_shared<MockRecoveryClient>();
 
-    score::lcm::saf::ifexm::ProcessState processState;
-    score::lcm::saf::ifappl::Checkpoint checkpoint;
+    score::mw::lifecycle::saf::ifexm::ProcessState processState;
+    score::mw::lifecycle::saf::ifappl::Checkpoint checkpoint;
 
-    std::unique_ptr<score::lcm::saf::supervision::Alive> alive;
+    std::unique_ptr<score::mw::lifecycle::saf::supervision::Alive> alive;
 
     explicit AliveFixture(const Builder& bld)
         : processState(makeProcessCfg()), checkpoint(kCheckpointName, 1U, &processState)
     {
-        score::lcm::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
+        score::mw::lifecycle::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
         cfg.cfgName_p = "test_alive";
         cfg.aliveReferenceCycle = bld.referenceCycleNs;
         cfg.minAliveIndications = bld.minIndications;
@@ -114,12 +114,12 @@ struct AliveFixture
         cfg.recoveryClient = mockClient;
         cfg.processIdentifier = kProcessIdentifier;
 
-        alive = std::make_unique<score::lcm::saf::supervision::Alive>(cfg);
+        alive = std::make_unique<score::mw::lifecycle::saf::supervision::Alive>(cfg);
         processState.attachObserver(*alive);
     }
 
     /// Simulate the process reporting kRunning at the given timestamp.
-    void activateProcess(score::lcm::saf::timers::NanoSecondType timestamp)
+    void activateProcess(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
     {
         processState.setTimestamp(timestamp);
         processState.setState(EProcState::running);
@@ -127,7 +127,7 @@ struct AliveFixture
     }
 
     /// Simulate the process reporting sigterm at the given timestamp.
-    void sigtermProcess(score::lcm::saf::timers::NanoSecondType timestamp)
+    void sigtermProcess(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
     {
         processState.setTimestamp(timestamp);
         processState.setState(EProcState::sigterm);
@@ -135,7 +135,7 @@ struct AliveFixture
     }
 
     /// Simulate the process crashing (off without sigterm) at the given timestamp.
-    void crashProcess(score::lcm::saf::timers::NanoSecondType timestamp)
+    void crashProcess(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
     {
         processState.setTimestamp(timestamp);
         processState.setState(EProcState::off);
@@ -143,15 +143,15 @@ struct AliveFixture
     }
 
     /// Report one alive heartbeat checkpoint at the given timestamp.
-    void reportHeartbeat(score::lcm::saf::timers::NanoSecondType timestamp)
+    void reportHeartbeat(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
     {
         checkpoint.pushData(timestamp);
     }
 
   private:
-    static score::lcm::saf::ifexm::ProcessCfg makeProcessCfg()
+    static score::mw::lifecycle::saf::ifexm::ProcessCfg makeProcessCfg()
     {
-        score::lcm::saf::ifexm::ProcessCfg cfg{};
+        score::mw::lifecycle::saf::ifexm::ProcessCfg cfg{};
         cfg.processShortName = kProcessName;
         cfg.processId = kProcessId;
         return cfg;

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
@@ -13,13 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/supervision/ISupervision.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 ISupervision::ISupervision(const char* const f_supervisionConfigName_p) : k_cfgName(f_supervisionConfigName_p)
@@ -33,7 +27,4 @@ std::string_view ISupervision::getConfigName(void) const noexcept
     return k_cfgName;
 }
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
@@ -21,13 +21,7 @@
 #include <string_view>
 #include <vector>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 /// @brief ISupervision
@@ -81,9 +75,6 @@ class ISupervision
     const std::string k_cfgName;
 };
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::supervision
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
@@ -21,13 +21,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 #include "score/mw/launch_manager/recovery_client/irecovery_client.h"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 class Checkpoint;
 }
@@ -66,9 +60,9 @@ class AliveSupervisionCfg final
     saf::ifappl::Checkpoint& checkpoint_r;
 
     /// Recovery client to invoke when supervision expires
-    std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient{};
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient{};
     /// Identifier of the supervised process, sent via recovery client when supervision expires
-    score::lcm::IdentifierHash processIdentifier{};
+    score::mw::lifecycle::IdentifierHash processIdentifier{};
 
     /// Default destructor
     ~AliveSupervisionCfg() = default;
@@ -96,9 +90,6 @@ class AliveSupervisionCfg final
     AliveSupervisionCfg& operator=(AliveSupervisionCfg&&) = delete;
 };
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::supervision
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
@@ -12,17 +12,11 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 int64_t CycleTimeValidator::getMonotonicClockAccuracy(
-    const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     struct timespec clockResolution{};
     int64_t accuracyNs{-1};
@@ -38,11 +32,11 @@ int64_t CycleTimeValidator::getMonotonicClockAccuracy(
 
 int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     const int64_t f_requested_interval_ns,
-    const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     int64_t intervalNs{-1};  // start with an invalid value
 
-    const int64_t accuracyNs{score::lcm::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
+    const int64_t accuracyNs{score::mw::lifecycle::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
 
     if (0 < accuracyNs)
     {
@@ -59,7 +53,4 @@ int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     return intervalNs;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
@@ -18,13 +18,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/OsClockInterface.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 /// @brief Perform validations on the cycle time configured.
@@ -34,7 +28,7 @@ class CycleTimeValidator
     /// @brief Get the monotonic clock accuracy in nanoseconds
     /// @param[in] f_clock_sys Interface to access the system clock functionality
     /// @return nanoseconds or -1 if receiving the clock resolution fails
-    static int64_t getMonotonicClockAccuracy(const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(
+    static int64_t getMonotonicClockAccuracy(const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(
         true);
 
     /// @brief Adjust a given time interval based on the clock accuracy of
@@ -47,12 +41,9 @@ class CycleTimeValidator
     /// - -1 if retrieving the system's clock resolution failed
     static int64_t adjustCycleTimeOnClockAccuracy(
         const int64_t f_requested_interval_ns,
-        const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
+        const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
 };
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
@@ -13,19 +13,13 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimer.hpp"
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 /* RULECHECKER_comment(0, 3, check_static_object_zero_initialization, "As per rule definition, \
 using constexpr enforces constant initialization by the compiler", false) */
 constexpr int CycleTimer::kDeadlineAlreadyOver;
 
-CycleTimer::CycleTimer(const score::lcm::saf::timers::OsClockInterface* f_osInterface) noexcept
+CycleTimer::CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept
     : osInterface{f_osInterface}, sleepIntervalNs{0}, deadline{}
 {
     static_cast<void>(0U);
@@ -98,7 +92,4 @@ void CycleTimer::handleNanoSecOverflow() noexcept(true)
     }
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
@@ -21,13 +21,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/OsClockInterface.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 // coverity[autosar_cpp14_m3_4_1_violation] value is referenced in multiple files, but depending on build package.
@@ -47,7 +41,7 @@ class CycleTimer
     /// @brief Sets the interface for performing the OS clock system calls.
     /// @param[in] f_osInterface OS clock interface to access clock_nanosleep() and clock_gettime() via
     /// OsClockInterface. The pointer allows the interface exchange to enhance testability.
-    explicit CycleTimer(const score::lcm::saf::timers::OsClockInterface* f_osInterface) noexcept;
+    explicit CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept;
 
     /// @brief Initialize the time interval object and check for internal errors, which prevent from incorrect
     /// execution.
@@ -130,7 +124,7 @@ class CycleTimer
     void handleNanoSecOverflow() noexcept;
 
     /// @brief Interface to perform system calls such as clock_nanosleep()
-    const score::lcm::saf::timers::OsClockInterface* osInterface;
+    const score::mw::lifecycle::saf::timers::OsClockInterface* osInterface;
 
     /// @brief Cycle time interval value in nanoseconds
     ///
@@ -143,9 +137,6 @@ class CycleTimer
     struct timespec deadline;
 };
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
@@ -16,13 +16,7 @@
 
 #include <chrono>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 /* RULECHECKER_comment(0, 60, check_member_function_missing_static, "Intentionally not static and\
    retained as member function", true_no_defect) */
@@ -104,9 +98,6 @@ class OsClockInterface
     struct timespec initFinishedTime{0, 0};
 };
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
@@ -15,13 +15,7 @@
 
 #include <limits>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 NanoSecondType TimeConversion::convertToNanoSec(const timespec f_timespec) noexcept(true)
@@ -72,7 +66,4 @@ double TimeConversion::convertNanoSecToMilliSec(const NanoSecondType f_timeValue
     return milliSeconds;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
@@ -21,13 +21,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 /// Convert one unit of time value to another
@@ -69,9 +63,6 @@ class TimeConversion
     static constexpr double k_nanoSecInMilliSec{1000.0 * 1000.0};
 };
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
@@ -20,8 +20,8 @@
 
 using namespace testing;
 
-using score::lcm::saf::timers::NanoSecondType;
-using score::lcm::saf::timers::TimeConversion;
+using score::mw::lifecycle::saf::timers::NanoSecondType;
+using score::mw::lifecycle::saf::timers::TimeConversion;
 
 namespace
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
@@ -21,13 +21,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
@@ -56,7 +50,4 @@ NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
     return result;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
@@ -16,13 +16,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 /// Special type for storing nanoseconds.
@@ -53,9 +47,6 @@ class OsClock
     static NanoSecondType getMonotonicSystemClock(void) noexcept(true);
 };
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::saf::timers
 
 #endif

--- a/score/launch_manager/src/daemon/src/common/alive_interface_path.hpp
+++ b/score/launch_manager/src/daemon/src/common/alive_interface_path.hpp
@@ -16,11 +16,7 @@
 
 #include <string>
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// Returns the IPC socket path for the alive monitoring interface of a component.
@@ -29,8 +25,6 @@ inline std::string aliveInterfacePath(const std::string& component_name)
     return "/lifecycle_health_" + component_name;
 }
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // ALIVE_INTERFACE_PATH_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
@@ -20,7 +20,7 @@ namespace
 // that links this library gets diagnostic output on assertion failure without any
 // explicit setup call.
 const bool kAssertionHandlerRegistered = []() noexcept {
-    score::lcm::common::registerAssertionHandler();
+    score::mw::lifecycle::common::registerAssertionHandler();
     return true;
 }();
 

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace score::lcm::common
+namespace score::mw::lifecycle::common
 {
 
 inline void registerAssertionHandler() noexcept
@@ -38,6 +38,6 @@ inline void registerAssertionHandler() noexcept
     });
 }
 
-}  // namespace score::lcm::common
+}  // namespace score::mw::lifecycle::common
 
 #endif  // ASSERTION_HANDLER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <ostream>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 enum class ConcurrencyErrc : std::uint8_t
@@ -52,12 +52,12 @@ inline std::ostream& operator<<(std::ostream& os, ConcurrencyErrc errc) noexcept
     }
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #ifdef LC_LOG_SCORE_MW_LOG
 #include "score/mw/log/logger.h"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& os, ConcurrencyErrc errc) noexcept
@@ -77,7 +77,7 @@ inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& os, Conc
     }
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // LC_LOG_SCORE_MW_LOG
 

--- a/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <vector>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Fixed-size FIFO queue
@@ -126,6 +126,6 @@ class FixedSizeQueue
     std::vector<std::optional<T>> slots_;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // FIXED_SIZED_QUEUE_HPP_INCLUDE

--- a/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue_test.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class FixedSizeQueueTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
@@ -30,7 +30,7 @@
 #include "score/mw/launch_manager/osal/semaphore.hpp"
 #include <score/expected.hpp>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 // this is based on https://github.com/rigtorp/MPMCQueue
 
@@ -305,6 +305,6 @@ class MPMCConcurrentQueue
     osal::Semaphore m_spaces{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // MPMC_CONCURRENT_QUEUE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_benchmark.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_benchmark.cpp
@@ -20,7 +20,7 @@
 #include <thread>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 constexpr std::uint64_t g_items_per_prod = 10'000;
 

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
@@ -24,7 +24,7 @@
 #include <tuple>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class MPMCConcurrentQueueTest_Basic : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
@@ -29,7 +29,7 @@
 #include <score/assert.hpp>
 #include <score/expected.hpp>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Fixed-capacity queue for the multi-producer / single-consumer case,
@@ -176,6 +176,6 @@ class MpscBoundedQueue
     std::thread::id consumer_thread_id_{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // MPSC_BOUNDED_QUEUE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue_test.cpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class MpscBoundedQueueTest_Basic : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 
@@ -117,6 +117,6 @@ class WorkerThread final
     std::vector<std::unique_ptr<std::thread>> worker_threads_{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // WORKER_THREAD_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
@@ -25,7 +25,7 @@
 namespace score::lcm::internal
 {
 
-using namespace score::mw::lifecycle::internal;
+
 
 /// @brief Templated worker thread pool for executing jobs from a queue.
 /// This class manages a pool of worker threads that continuously retrieve and execute jobs
@@ -42,7 +42,7 @@ class WorkerThread final
     /// @param queue The MpmcQueue from which threads will take work items.
     /// @param num_threads Number of threads in the pool.
     /// @param component_controller_ The controller to delegate work to.
-    WorkerThread(std::shared_ptr<Queue> queue, uint32_t num_threads, IComponentController& component_controller)
+    WorkerThread(std::shared_ptr<Queue> queue, uint32_t num_threads, score::mw::lifecycle::internal::IComponentController& component_controller)
         : the_job_queue_(queue), component_controller_(component_controller)
     {
         worker_threads_.reserve(num_threads);
@@ -111,7 +111,7 @@ class WorkerThread final
     /// @brief The queue from which each thread takes work.
     std::shared_ptr<Queue> the_job_queue_{};
 
-    IComponentController& component_controller_;
+    score::mw::lifecycle::internal::IComponentController& component_controller_;
 
     /// @brief Vector of worker threads.
     std::vector<std::unique_ptr<std::thread>> worker_threads_{};

--- a/score/launch_manager/src/daemon/src/common/constants.hpp
+++ b/score/launch_manager/src/daemon/src/common/constants.hpp
@@ -18,13 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 // coverity[autosar_cpp14_a0_1_1_violation:INTENTIONAL] These are constants that are used globally.
@@ -75,10 +69,6 @@ enum class ProcessLimits : std::uint32_t
     maxLocalBuffSize = 32U    ///< Maximum size for local buffer
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // CONSTANTS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
@@ -16,10 +16,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 // Please note that a lot of the following info, would normally belong to identifier_hash.hpp file.
@@ -133,6 +130,4 @@ std::mutex& IdentifierHash::get_registry_mutex()
     return registry_mutex;
 }
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/common/identifier_hash.hpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash.hpp
@@ -22,7 +22,7 @@
 #include <string_view>
 #include <unordered_map>
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 /// @file identifier_hash.hpp
@@ -168,12 +168,12 @@ inline std::ostream& operator<<(std::ostream& stream, const IdentifierHash& id_h
     return stream;
 }
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #ifdef LC_LOG_SCORE_MW_LOG
 #include "score/mw/log/logger.h"
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& stream, const IdentifierHash& id_hash) noexcept(
@@ -193,7 +193,7 @@ inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& stream, 
     return stream;
 }
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #endif  // LC_LOG_SCORE_MW_LOG
 

--- a/score/launch_manager/src/daemon/src/common/identifier_hash_UT.cpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash_UT.cpp
@@ -20,7 +20,7 @@
 using namespace testing;
 using std::stringstream;
 
-using score::lcm::IdentifierHash;
+using score::mw::lifecycle::IdentifierHash;
 
 class IdentifierHashTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/log.hpp
+++ b/score/launch_manager/src/daemon/src/common/log.hpp
@@ -60,7 +60,7 @@ inline score::mw::log::Logger& _getLmLogger() noexcept
 #include <iostream>
 #include <string>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 enum class LogLevel
@@ -270,11 +270,11 @@ inline Logger& _getLmLogger() noexcept
     return log;
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // LC_LOG_SCORE_MW_LOG
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Returns a string_view of the errno error message.
@@ -284,13 +284,13 @@ inline std::string_view errno_message(const int err) noexcept(true)
     return std::string_view{std::strerror(err)};
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 // wrapper macros for Launch Manager
-#define LM_LOG_FATAL() (score::lcm::internal::_getLmLogger().LogFatal())
-#define LM_LOG_ERROR() (score::lcm::internal::_getLmLogger().LogError())
-#define LM_LOG_WARN()  (score::lcm::internal::_getLmLogger().LogWarn())
-#define LM_LOG_INFO()  (score::lcm::internal::_getLmLogger().LogInfo())
-#define LM_LOG_DEBUG() (score::lcm::internal::_getLmLogger().LogDebug())
+#define LM_LOG_FATAL() (score::mw::lifecycle::internal::_getLmLogger().LogFatal())
+#define LM_LOG_ERROR() (score::mw::lifecycle::internal::_getLmLogger().LogError())
+#define LM_LOG_WARN()  (score::mw::lifecycle::internal::_getLmLogger().LogWarn())
+#define LM_LOG_INFO()  (score::mw::lifecycle::internal::_getLmLogger().LogInfo())
+#define LM_LOG_DEBUG() (score::mw::lifecycle::internal::_getLmLogger().LogDebug())
 
 #endif  // LCM_LOG_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/log.hpp
+++ b/score/launch_manager/src/daemon/src/common/log.hpp
@@ -24,13 +24,7 @@
 
 #include "score/mw/log/logger.h"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Function to access global logging context, for Launch Manager.
@@ -46,11 +40,7 @@ inline score::mw::log::Logger& _getLmLogger() noexcept
     return log;
 }
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #else  // LC_LOG_SCORE_MW_LOG
 

--- a/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
+++ b/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
@@ -31,8 +31,8 @@ namespace internal
 // have user-declared constructor. The rule doesn’t apply.", false)
 struct ProcessGroupStateID final
 {
-    score::lcm::IdentifierHash pg_name_;        ///< Name of the process group.
-    score::lcm::IdentifierHash pg_state_name_;  ///< Name of the process group state.
+    score::mw::lifecycle::IdentifierHash pg_name_;        ///< Name of the process group.
+    score::mw::lifecycle::IdentifierHash pg_state_name_;  ///< Name of the process group state.
 };
 
 }  // namespace internal

--- a/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
+++ b/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
@@ -16,13 +16,7 @@
 
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Represents process group state in a particular process group. process group state is unique within a process
@@ -35,10 +29,6 @@ struct ProcessGroupStateID final
     score::mw::lifecycle::IdentifierHash pg_state_name_;  ///< Name of the process group state.
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // FUNCTION_STATE_ID_HPP_

--- a/score/launch_manager/src/daemon/src/common/signal_safe_log.hpp
+++ b/score/launch_manager/src/daemon/src/common/signal_safe_log.hpp
@@ -92,7 +92,7 @@ class signal_safe_buffer
 
 }  // namespace
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 template <typename... T>
@@ -125,6 +125,6 @@ template <typename... T>
 #endif
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif

--- a/score/launch_manager/src/daemon/src/common/signal_safe_log_UT.cpp
+++ b/score/launch_manager/src/daemon/src/common/signal_safe_log_UT.cpp
@@ -16,8 +16,8 @@
 #include "score/mw/launch_manager/common/signal_safe_log.hpp"
 
 using namespace testing;
-using score::lcm::internal::signal_safe_log;
-using score::lcm::internal::signal_safe_log_errno;
+using score::mw::lifecycle::internal::signal_safe_log;
+using score::mw::lifecycle::internal::signal_safe_log_errno;
 
 class signal_safe_log_test : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/configuration/config.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config.hpp
@@ -20,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 enum class ApplicationType : uint8_t
@@ -290,6 +290,6 @@ class ConfigBuilder
     std::optional<WatchdogConfig> watchdog_;
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // CONFIG_HPP

--- a/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
@@ -20,7 +20,7 @@
 #include <score/expected.hpp>
 #include <cstdint>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 /// @brief Abstract interface for loading Launch Manager configuration from a file.
@@ -53,6 +53,6 @@ class IConfigLoader
     [[nodiscard]] virtual score::cpp::expected<Config, Error> load(const score::filesystem::Path& path) = 0;
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <set>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 namespace
@@ -32,22 +32,22 @@ constexpr uint32_t kDefaultProcessExecutionError = 1U;
 
 uint64_t defaultProcessorAffinityMask()
 {
-    return (1ULL << score::lcm::internal::osal::getNumCores()) - 1ULL;
+    return (1ULL << score::mw::lifecycle::internal::osal::getNumCores()) - 1ULL;
 }
 }  // namespace
 
-score::lcm::internal::osal::CommsType ConfigurationAdapter::mapApplicationType(ApplicationType app_type) const
+score::mw::lifecycle::internal::osal::CommsType ConfigurationAdapter::mapApplicationType(ApplicationType app_type) const
 {
     switch (app_type)
     {
         case ApplicationType::Reporting:
         case ApplicationType::ReportingAndSupervised:
-            return score::lcm::internal::osal::CommsType::kReporting;
+            return score::mw::lifecycle::internal::osal::CommsType::kReporting;
         case ApplicationType::StateManager:
-            return score::lcm::internal::osal::CommsType::kControlClient;
+            return score::mw::lifecycle::internal::osal::CommsType::kControlClient;
         case ApplicationType::Native:
         default:
-            return score::lcm::internal::osal::CommsType::kNoComms;
+            return score::mw::lifecycle::internal::osal::CommsType::kNoComms;
     }
 }
 
@@ -62,7 +62,7 @@ void ConfigurationAdapter::deinitialize()
     {
         for (auto& process : process_group.processes_)
         {
-            for (size_t i = 0U; i < score::lcm::internal::kArgvArraySize && process.startup_config_.argv_[i] != nullptr;
+            for (size_t i = 0U; i < score::mw::lifecycle::internal::kArgvArraySize && process.startup_config_.argv_[i] != nullptr;
                  ++i)
             {
                 free(const_cast<char*>(process.startup_config_.argv_[i]));
@@ -81,7 +81,7 @@ void ConfigurationAdapter::deinitialize()
 
 void ConfigurationAdapter::fillStartupConfigFromDeployment(
     const ComponentConfig& comp,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     const auto& deploy = comp.deployment_config;
     const auto& props = comp.component_properties;
@@ -112,7 +112,7 @@ void ConfigurationAdapter::fillStartupConfigFromDeployment(
 
 void ConfigurationAdapter::fillStartupArguments(
     const ComponentProperties& props,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     // strdup() returns nullptr on OOM. On this embedded target, OOM during daemon
     // startup is unrecoverable — the OS will terminate the process.
@@ -120,8 +120,8 @@ void ConfigurationAdapter::fillStartupArguments(
     startup.argv_[arg_index++] = strdup(startup.executable_path_.c_str());
 
     assert(
-        props.process_arguments.size() <= score::lcm::internal::kMaxArg && "Too many process arguments for argv array");
-    size_t max_args = std::min(props.process_arguments.size(), static_cast<size_t>(score::lcm::internal::kMaxArg));
+        props.process_arguments.size() <= score::mw::lifecycle::internal::kMaxArg && "Too many process arguments for argv array");
+    size_t max_args = std::min(props.process_arguments.size(), static_cast<size_t>(score::mw::lifecycle::internal::kMaxArg));
     for (size_t i = 0U; i < max_args; ++i)
     {
         startup.argv_[arg_index++] = strdup(props.process_arguments[i].c_str());
@@ -130,15 +130,15 @@ void ConfigurationAdapter::fillStartupArguments(
 
 size_t ConfigurationAdapter::fillStartupEnvironment(
     const DeploymentConfig& deploy,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     size_t env_index = 0U;
 
     assert(
-        deploy.environmental_variables.size() + 1U <= score::lcm::internal::kMaxEnv &&
+        deploy.environmental_variables.size() + 1U <= score::mw::lifecycle::internal::kMaxEnv &&
         "Too many environmental variables for envp array");
     size_t max_env =
-        std::min(deploy.environmental_variables.size(), static_cast<size_t>(score::lcm::internal::kMaxEnv));
+        std::min(deploy.environmental_variables.size(), static_cast<size_t>(score::mw::lifecycle::internal::kMaxEnv));
     size_t env_count = 0;
     for (const auto& ev : deploy.environmental_variables)
     {
@@ -158,18 +158,18 @@ size_t ConfigurationAdapter::fillStartupEnvironment(
 void ConfigurationAdapter::appendAliveInterfaceEnvironment(
     const ComponentConfig& comp,
     size_t& env_index,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     bool is_supervised =
         comp.component_properties.application_profile.application_type == ApplicationType::ReportingAndSupervised ||
         comp.component_properties.application_profile.application_type == ApplicationType::StateManager;
-    if (!is_supervised || env_index >= static_cast<size_t>(score::lcm::internal::kMaxEnv))
+    if (!is_supervised || env_index >= static_cast<size_t>(score::mw::lifecycle::internal::kMaxEnv))
     {
         return;
     }
 
     std::string iface_path =
-        std::string(kAliveInterfaceEnvName) + "=" + score::lcm::internal::aliveInterfacePath(comp.name);
+        std::string(kAliveInterfaceEnvName) + "=" + score::mw::lifecycle::internal::aliveInterfacePath(comp.name);
     startup.envp_[env_index++] = strdup(iface_path.c_str());
 }
 
@@ -200,7 +200,7 @@ DependencyList ConfigurationAdapter::buildDependencyList(const ComponentProperti
     for (const auto& dep_name : props.depends_on)
     {
         Dependency dep{};
-        dep.process_state_ = score::lcm::ProcessState::kRunning;
+        dep.process_state_ = score::mw::lifecycle::ProcessState::kRunning;
 
         auto dep_it = component_by_name_.find(dep_name);
         if (dep_it != component_by_name_.end())
@@ -209,8 +209,8 @@ DependencyList ConfigurationAdapter::buildDependencyList(const ComponentProperti
             if (dep_props.ready_condition.has_value())
             {
                 dep.process_state_ = dep_props.ready_condition->process_state == ProcessState::Running
-                                         ? score::lcm::ProcessState::kRunning
-                                         : score::lcm::ProcessState::kTerminated;
+                                         ? score::mw::lifecycle::ProcessState::kRunning
+                                         : score::mw::lifecycle::ProcessState::kTerminated;
             }
         }
 
@@ -388,7 +388,7 @@ bool ConfigurationAdapter::buildFromConfig(const Config& config)
     process_groups_.push_back(std::move(pg));
     process_group_names_.push_back(pg_name);
 
-    main_pg_startup_state_ = score::lcm::internal::ProcessGroupStateID{
+    main_pg_startup_state_ = score::mw::lifecycle::internal::ProcessGroupStateID{
         pg_name, IdentifierHash{std::string("MainPG/") + initial_run_target_name}};
 
     LM_LOG_DEBUG() << "ConfigurationAdapter: Built configuration with " << process_groups_[0].processes_.size()
@@ -446,7 +446,7 @@ IdentifierHash ConfigurationAdapter::getNameOfRecoveryState(const IdentifierHash
     return IdentifierHash{"Recovery"};
 }
 
-std::optional<const score::lcm::internal::ProcessGroupStateID*> ConfigurationAdapter::getMainPGStartupState() const
+std::optional<const score::mw::lifecycle::internal::ProcessGroupStateID*> ConfigurationAdapter::getMainPGStartupState() const
 {
     if (!process_groups_.empty())
     {
@@ -458,7 +458,7 @@ std::optional<const score::lcm::internal::ProcessGroupStateID*> ConfigurationAda
 }
 
 std::optional<const std::vector<uint32_t>*> ConfigurationAdapter::getProcessIndexesList(
-    const score::lcm::internal::ProcessGroupStateID& pg_state_id) const
+    const score::mw::lifecycle::internal::ProcessGroupStateID& pg_state_id) const
 {
     auto state = getProcessGroupStateByID(pg_state_id);
     if (state)
@@ -520,7 +520,7 @@ ProcessGroup* ConfigurationAdapter::getProcessGroupByID(const IdentifierHash& pg
 }
 
 ProcessGroupState* ConfigurationAdapter::getProcessGroupStateByID(
-    const score::lcm::internal::ProcessGroupStateID& pg_id) const
+    const score::mw::lifecycle::internal::ProcessGroupStateID& pg_id) const
 {
     ProcessGroup* pg = getProcessGroupByID(pg_id.pg_name_);
     if (pg)
@@ -556,4 +556,4 @@ std::optional<const ProcessGroup*> ConfigurationAdapter::getProcessGroupByNameAn
     return std::nullopt;
 }
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
@@ -27,10 +27,10 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 struct PgManagerConfig final
 {
@@ -43,7 +43,7 @@ struct PgManagerConfig final
 
 struct Dependency final
 {
-    score::lcm::ProcessState process_state_{};
+    score::mw::lifecycle::ProcessState process_state_{};
     IdentifierHash target_process_id_{};
     uint32_t os_process_index_{};
 };
@@ -54,7 +54,7 @@ struct OsProcess final
 {
     IdentifierHash process_id_{};
     uint32_t process_number_{};
-    score::lcm::internal::osal::OsalConfig startup_config_{};
+    score::mw::lifecycle::internal::osal::OsalConfig startup_config_{};
     PgManagerConfig pgm_config_{};
     DependencyList dependencies_{};
 };
@@ -92,9 +92,9 @@ class ConfigurationAdapter final
     std::optional<uint32_t> getNumberOfOsProcesses(const IdentifierHash& pg_name) const;
     IdentifierHash getNameOfOffState(const IdentifierHash& pg_name) const;
     IdentifierHash getNameOfRecoveryState(const IdentifierHash& pg_name) const;
-    std::optional<const score::lcm::internal::ProcessGroupStateID*> getMainPGStartupState() const;
+    std::optional<const score::mw::lifecycle::internal::ProcessGroupStateID*> getMainPGStartupState() const;
     std::optional<const std::vector<uint32_t>*> getProcessIndexesList(
-        const score::lcm::internal::ProcessGroupStateID& process_group_state_id) const;
+        const score::mw::lifecycle::internal::ProcessGroupStateID& process_group_state_id) const;
     std::optional<const std::vector<ProcessGroupState>*> getListOfProcessGroupStates(
         const IdentifierHash& pg_name) const;
     std::optional<const OsProcess*> getOsProcessConfiguration(const IdentifierHash& pg_name_, const uint32_t index)
@@ -109,15 +109,15 @@ class ConfigurationAdapter final
     bool buildFromConfig(const Config& config);
 
     OsProcess buildOsProcess(const ComponentConfig& comp, uint32_t process_index) const;
-    void fillStartupConfigFromDeployment(const ComponentConfig& comp, score::lcm::internal::osal::OsalConfig& startup)
+    void fillStartupConfigFromDeployment(const ComponentConfig& comp, score::mw::lifecycle::internal::osal::OsalConfig& startup)
         const;
-    void fillStartupArguments(const ComponentProperties& props, score::lcm::internal::osal::OsalConfig& startup) const;
-    size_t fillStartupEnvironment(const DeploymentConfig& deploy, score::lcm::internal::osal::OsalConfig& startup)
+    void fillStartupArguments(const ComponentProperties& props, score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
+    size_t fillStartupEnvironment(const DeploymentConfig& deploy, score::mw::lifecycle::internal::osal::OsalConfig& startup)
         const;
     void appendAliveInterfaceEnvironment(
         const ComponentConfig& comp,
         size_t& env_index,
-        score::lcm::internal::osal::OsalConfig& startup) const;
+        score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
     PgManagerConfig buildPgManagerConfig(const ComponentConfig& comp) const;
     DependencyList buildDependencyList(const ComponentProperties& props) const;
 
@@ -134,10 +134,10 @@ class ConfigurationAdapter final
 
     static void resolveDependencyIndexes(std::vector<OsProcess>& processes);
 
-    score::lcm::internal::osal::CommsType mapApplicationType(ApplicationType app_type) const;
+    score::mw::lifecycle::internal::osal::CommsType mapApplicationType(ApplicationType app_type) const;
 
     ProcessGroup* getProcessGroupByID(const IdentifierHash& pg_name) const;
-    ProcessGroupState* getProcessGroupStateByID(const score::lcm::internal::ProcessGroupStateID& pg_id) const;
+    ProcessGroupState* getProcessGroupStateByID(const score::mw::lifecycle::internal::ProcessGroupStateID& pg_id) const;
     std::optional<const ProcessGroup*> getProcessGroupByNameAndIndex(
         const IdentifierHash& pg_name,
         const uint32_t index) const;
@@ -146,23 +146,23 @@ class ConfigurationAdapter final
     std::map<std::string, uint32_t> component_to_process_index_{};
     std::vector<ProcessGroup> process_groups_{};
     std::vector<IdentifierHash> process_group_names_{};
-    score::lcm::internal::ProcessGroupStateID main_pg_startup_state_{
+    score::mw::lifecycle::internal::ProcessGroupStateID main_pg_startup_state_{
         static_cast<IdentifierHash>("MainPG"),
         static_cast<IdentifierHash>("MainPG/Startup")};
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
-// Aliases for backward compatibility with score::lcm::internal consumers
-namespace score::lcm::internal
+// Aliases for backward compatibility with score::mw::lifecycle::internal consumers
+namespace score::mw::lifecycle::internal
 {
-using ConfigurationAdapter = score::mw::launch_manager::configuration::ConfigurationAdapter;
-using OsProcess = score::mw::launch_manager::configuration::OsProcess;
-using DependencyList = score::mw::launch_manager::configuration::DependencyList;
-using ProcessGroup = score::mw::launch_manager::configuration::ProcessGroup;
-using ProcessGroupState = score::mw::launch_manager::configuration::ProcessGroupState;
-using PgManagerConfig = score::mw::launch_manager::configuration::PgManagerConfig;
-using Dependency = score::mw::launch_manager::configuration::Dependency;
-}  // namespace score::lcm::internal
+using ConfigurationAdapter = score::mw::lifecycle::configuration::ConfigurationAdapter;
+using OsProcess = score::mw::lifecycle::configuration::OsProcess;
+using DependencyList = score::mw::lifecycle::configuration::DependencyList;
+using ProcessGroup = score::mw::lifecycle::configuration::ProcessGroup;
+using ProcessGroupState = score::mw::lifecycle::configuration::ProcessGroupState;
+using PgManagerConfig = score::mw::lifecycle::configuration::PgManagerConfig;
+using Dependency = score::mw::lifecycle::configuration::Dependency;
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // CONFIGURATIONADAPTER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <string>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
@@ -29,7 +29,7 @@ using ::testing::IsNull;
 using ::testing::Ne;
 using ::testing::NotNull;
 
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 Config makeMinimalConfig()
 {
@@ -173,7 +173,7 @@ TEST_F(ConfigurationAdapterTest, GetProcessIndexesListResolvesRunTargetDependenc
 {
     RecordProperty("Description", "getProcessIndexesList resolves RunTarget depends_on to component indexes.");
 
-    score::lcm::internal::ProcessGroupStateID startup_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Startup"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID startup_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Startup"}};
 
     auto result = adapter_.getProcessIndexesList(startup_id);
 
@@ -189,7 +189,7 @@ TEST_F(ConfigurationAdapterTest, GetProcessIndexesListResolvesTransitiveDependen
         "Description",
         "Full run target depends on comp_b and Startup; transitive resolution yields both component indexes.");
 
-    score::lcm::internal::ProcessGroupStateID full_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Full"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID full_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Full"}};
 
     auto result = adapter_.getProcessIndexesList(full_id);
 
@@ -276,7 +276,7 @@ TEST_F(ConfigurationAdapterTest, GetOsProcessDependenciesMapsComponentDependsOn)
     ASSERT_THAT(deps->size(), Eq(1U));
     EXPECT_THAT((*deps)[0].target_process_id_, Eq(IdentifierHash{"comp_a"}));
     EXPECT_THAT((*deps)[0].os_process_index_, Eq(0U));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kRunning));
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ConfigurationAdapterTest, GetOsProcessDependenciesEmptyForComponentWithNoDeps)
@@ -334,7 +334,7 @@ TEST_F(ConfigurationAdapterTest, OffStateReturnsProcessIndexesListEmpty)
 {
     RecordProperty("Description", "The Off state has no process indexes.");
 
-    score::lcm::internal::ProcessGroupStateID off_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Off"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID off_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Off"}};
 
     auto result = adapter_.getProcessIndexesList(off_id);
 
@@ -412,7 +412,7 @@ TEST(ConfigurationAdapterReadyConditionTest, DependencyUsesTargetComponentReadyC
     const auto* deps = *result;
     ASSERT_THAT(deps->size(), Eq(1U));
     EXPECT_THAT((*deps)[0].target_process_id_, Eq(IdentifierHash{"comp_a"}));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kTerminated))
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kTerminated))
         << "Dependency should use comp_a's ready_condition (Terminated), not comp_b's (Running)";
 
     adapter.deinitialize();
@@ -485,7 +485,7 @@ TEST(ConfigurationAdapterReadyConditionTest, DependencyDefaultsToRunningWhenTarg
     ASSERT_TRUE(result.has_value());
     const auto* deps = *result;
     ASSERT_THAT(deps->size(), Eq(1U));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kRunning))
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kRunning))
         << "comp_a has no ready_condition, so dependency should default to Running";
 
     adapter.deinitialize();
@@ -552,7 +552,7 @@ TEST(ConfigurationAdapterFallbackTest, FallbackRunTargetResolvesDependenciesRecu
     ConfigurationAdapter adapter;
     adapter.initialize(config);
 
-    score::lcm::internal::ProcessGroupStateID fallback_id{
+    score::mw::lifecycle::internal::ProcessGroupStateID fallback_id{
         IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/fallback_run_target"}};
 
     auto result = adapter.getProcessIndexesList(fallback_id);
@@ -570,4 +570,4 @@ TEST(ConfigurationAdapterFallbackTest, FallbackRunTargetResolvesDependenciesRecu
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config.cpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 // --- EnvironmentVariable ---
@@ -230,4 +230,4 @@ std::optional<WatchdogConfig> Config::takeWatchdog()
     return std::move(watchdog_);
 }
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <string_view>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
@@ -257,4 +257,4 @@ TEST_F(EnvironmentTest, RangeBasedForLoopWorks)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
@@ -24,10 +24,10 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 namespace details
 {
@@ -148,4 +148,4 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
 }
 
 }  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
@@ -23,12 +23,12 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -695,4 +695,4 @@ TEST_F(FlatbufferConfigLoaderTest, MissingSchemaVersionReturnsInvalidFormat)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 namespace
 {
@@ -653,4 +653,4 @@ score::cpp::expected<std::vector<RunTargetConfig>, IConfigLoader::Error> convert
 }
 
 }  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 namespace details
@@ -143,6 +143,6 @@ score::cpp::expected<TargetT, IConfigLoader::Error> validateRange(int64_t value,
     const fb::Watchdog* fb_wd);
 
 }  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // FLATBUFFER_TYPE_CONVERTERS_HPP

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
@@ -22,12 +22,12 @@
 #include <limits>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -1228,4 +1228,4 @@ TEST_F(ConverterTest, ConvertEnvironmentalVariablesNullReturnsEmpty)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
+++ b/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
@@ -10,7 +10,7 @@
 //   Note: Without "= null", flatbuffer will return a default value and there is no way to know if it has been configured or not
 // - optional values are defined with "= null" and they are populated as std::optional in the code
 
-namespace score.mw.launch_manager.configuration.fb;
+namespace score.mw.lifecycle.configuration.fb;
 
 // Specifies the level of integration between the component and the Launch Manager.
 enum ApplicationType : byte {

--- a/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 /// @brief Internal helpers for FlatBuffer config parsing.
@@ -69,6 +69,6 @@ class FlatbufferConfigLoaderImpl : public IConfigLoader
 /// @brief Alias using the default buffer loader.
 using FlatbufferConfigLoader = FlatbufferConfigLoaderImpl<>;
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // FLATBUFFER_CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -21,13 +21,7 @@
 #include "score/mw/launch_manager/common/constants.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 void ControlClientChannel::initialize()
@@ -280,8 +274,4 @@ bool ControlClientChannel::is_initialized_ = false;
 std::condition_variable ControlClientChannel::init_cv_{};
 std::mutex ControlClientChannel::init_mutex_{};
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
@@ -22,13 +22,7 @@
 #include "score/mw/launch_manager/common/process_group_state_id.hpp"
 #include "score/mw/launch_manager/osal/ipc_comms.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief This is initially some ID provided by the Control Client library. When received
@@ -308,10 +302,6 @@ constexpr ControlClientCodeMapping stateArray[] = {
     {ControlClientCode::kValidateProcessGroupStateFailed, "kValidateProcessGroupStateFailed"},
     {ControlClientCode::kValidateProcessGroupStateSuccess, "kValidateProcessGroupStateSuccess"}};
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // CONTROL_CLIENT_CHANNEL_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -26,7 +26,7 @@
 #include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
 
 using namespace std;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 /// @brief Runs the LCM daemon.
 /// This function runs the LCM daemon by calling the run() method of the provided
@@ -148,7 +148,7 @@ int main(int argc, const char* argv[])
         //     return EXIT_FAILURE;
         // }
 
-        score::mw::launch_manager::configuration::FlatbufferConfigLoader config_loader;
+        score::mw::lifecycle::configuration::FlatbufferConfigLoader config_loader;
         auto config_result = config_loader.load(config_path);
         if (!config_result.has_value())
         {
@@ -156,15 +156,15 @@ int main(int argc, const char* argv[])
             return EXIT_FAILURE;
         }
         LM_LOG_DEBUG() << "Launch Manager Started !!!!";
-        std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient{std::make_shared<score::lcm::RecoveryClient>()};
-        auto process_state_notifier = std::make_unique<score::lcm::internal::ProcessStateNotifier>();
-        std::unique_ptr<score::lcm::saf::daemon::IAliveMonitor> healthMonitor{
-            std::make_unique<score::lcm::saf::daemon::AliveMonitorImpl>(
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient{std::make_shared<score::mw::lifecycle::RecoveryClient>()};
+        auto process_state_notifier = std::make_unique<score::mw::lifecycle::internal::ProcessStateNotifier>();
+        std::unique_ptr<score::mw::lifecycle::saf::daemon::IAliveMonitor> healthMonitor{
+            std::make_unique<score::mw::lifecycle::saf::daemon::AliveMonitorImpl>(
                 recoveryClient, process_state_notifier->constructReceiver(), *config_result)};
-        std::unique_ptr<score::lcm::internal::IAliveMonitorThread> aliveMonitorThread{
-            std::make_unique<score::lcm::internal::AliveMonitorThread>(std::move(healthMonitor))};
+        std::unique_ptr<score::mw::lifecycle::internal::IAliveMonitorThread> aliveMonitorThread{
+            std::make_unique<score::mw::lifecycle::internal::AliveMonitorThread>(std::move(healthMonitor))};
 
-        auto watchdog = score::lcm::watchdog::createWatchdog();
+        auto watchdog = score::mw::lifecycle::watchdog::createWatchdog();
         auto process_group_manager = std::make_unique<ProcessGroupManager>(
             std::move(aliveMonitorThread), recoveryClient, std::move(process_state_notifier), std::move(watchdog));
 

--- a/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
@@ -15,13 +15,7 @@
 
 #include "score/mw/launch_manager/osal/num_cores.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
-{
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 uint32_t getNumCores()
 {
@@ -35,7 +29,4 @@ uint32_t getNumCores()
         return static_cast<uint32_t>(res);
     }
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
@@ -12,16 +12,7 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/osal/security_policy.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setSecurityPolicy(const char*)
@@ -29,10 +20,4 @@ int setSecurityPolicy(const char*)
     return 0;
 }
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
@@ -44,7 +44,4 @@ std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)
     }
     return 0 == sched_setaffinity(0, sizeof(mask), &mask) ? 0 : -1;
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
@@ -16,16 +16,7 @@
 #include "score/mw/launch_manager/osal/set_affinity.hpp"
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
@@ -32,7 +32,4 @@ int setgroups(size_t __n, const gid_t* __groups) noexcept(true)
 {
     return ::setgroups(__n, __n ? __groups : nullptr);
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
@@ -16,16 +16,7 @@
 
 #include "score/mw/launch_manager/osal/set_groups.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setgroups(size_t __n, const gid_t* __groups) noexcept(true)

--- a/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
@@ -17,16 +17,7 @@
 
 #include "score/mw/launch_manager/osal/semaphore.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 OsalReturnType Semaphore::init(uint32_t value, bool shared)
@@ -114,10 +105,4 @@ OsalReturnType Semaphore::wait()
     return result;
 }
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
@@ -13,16 +13,7 @@
 
 #include <cstdlib>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 #if defined(__CTC__)
 /* RULECHECKER_comment(1:0,2:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */

--- a/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
@@ -44,7 +44,4 @@ void sysexit(int status)
 /* RULECHECKER_comment(1:0,1:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
 #pragma CTC ENDSKIP
 #endif
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/num_cores.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/num_cores.cpp
@@ -15,13 +15,7 @@
 
 #include "score/mw/launch_manager/osal/num_cores.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
-{
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 uint32_t getNumCores()
@@ -33,7 +27,4 @@ uint32_t getNumCores()
     }
     return num_cores;
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/security_policy.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/security_policy.cpp
@@ -14,16 +14,7 @@
 
 #include "score/mw/launch_manager/osal/security_policy.hpp"
 #include <cerrno>
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setSecurityPolicy(const char* policy)
@@ -42,10 +33,4 @@ int setSecurityPolicy(const char* policy)
     }
 }
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
@@ -49,7 +49,4 @@ int32_t setaffinity(uint64_t cpumask) noexcept(true)
 
     return 0 == ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, &tm) ? 0 : -1;
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
@@ -13,16 +13,7 @@
 #include <sys/neutrino.h>
 
 #include "score/mw/launch_manager/osal/set_affinity.hpp"
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int32_t setaffinity(uint64_t cpumask) noexcept(true)

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
@@ -31,7 +31,4 @@ int setgroups(size_t __n, const gid_t* __groups) noexcept(true)
     return ::setgroups(static_cast<int>(__n & 0X7FFFFFFFUL), __n ? __groups : NULL);
 }
 
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
@@ -14,16 +14,7 @@
 
 #include "score/mw/launch_manager/osal/set_groups.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setgroups(size_t __n, const gid_t* __groups) noexcept(true)

--- a/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
+++ b/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
@@ -20,16 +20,7 @@
 #include "score/mw/launch_manager/common/log.hpp"
 #include "semaphore.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 struct IpcCommsSync;
@@ -137,12 +128,6 @@ struct IpcCommsSync final
     };
 };
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // OSAL_IPC_COMMS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/osal/num_cores.hpp
+++ b/score/launch_manager/src/daemon/src/osal/num_cores.hpp
@@ -16,13 +16,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
-{
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 // coverity[autosar_cpp14_m3_4_1_violation:INTENTIONAL] The value is used in a global context.
 constexpr uint32_t kDefaultNumCores = 64U;  // Default value if unable to determine number of cores
@@ -31,9 +25,6 @@ constexpr uint32_t kDefaultNumCores = 64U;  // Default value if unable to determ
 /// @return Returns the number of CPU cores available.
 uint32_t getNumCores();
 
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif

--- a/score/launch_manager/src/daemon/src/osal/return_types.hpp
+++ b/score/launch_manager/src/daemon/src/osal/return_types.hpp
@@ -17,16 +17,7 @@
 #include <sys/types.h>
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 // We cant rule out of the possibility of porting OSAL code for the non-posix complain OS in the future.
@@ -67,12 +58,6 @@ enum class [[nodiscard]] OsalReturnType
     kTimeout = 2
 };
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // OSAL_ERROR_TYPES_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/osal/security_policy.hpp
+++ b/score/launch_manager/src/daemon/src/osal/security_policy.hpp
@@ -11,24 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 [[nodiscard]] int setSecurityPolicy(const char* policy);
 
-}
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/semaphore.hpp
+++ b/score/launch_manager/src/daemon/src/osal/semaphore.hpp
@@ -19,16 +19,7 @@
 
 #include "return_types.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief Semaphore class is a wrapper class for POSIX semaphores.
@@ -123,12 +114,6 @@ class Semaphore final
     sem_t sem_;
 };
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  /// SEMAPHORE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
@@ -16,16 +16,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief Set the processor affinity for the current thread

--- a/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
@@ -39,8 +39,5 @@ namespace osal
 ///        thread according to any restrictions that may be imposed
 ///        elsewhere.
 [[nodiscard]] int32_t setaffinity(uint64_t cpumask) noexcept(true);
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 #endif

--- a/score/launch_manager/src/daemon/src/osal/set_groups.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_groups.hpp
@@ -18,16 +18,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief Call the setgroups() function, which has a different signature in Linux and QNX.

--- a/score/launch_manager/src/daemon/src/osal/set_groups.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_groups.hpp
@@ -36,8 +36,5 @@ namespace osal
 /// @param __groups pointer to the list of groups, may be NULL
 /// @returns 0 on success, -1 on failure.
 [[nodiscard]] std::int32_t setgroups(size_t __n, const gid_t* __groups) noexcept(true);
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 #endif

--- a/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
+++ b/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
@@ -14,16 +14,7 @@
 #ifndef SYSEXIT_HPP_INCLUDED
 #define SYSEXIT_HPP_INCLUDED
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief Call the system exit function, which is marked [noreturn].

--- a/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
+++ b/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
@@ -30,8 +30,5 @@ namespace osal
 /// The purpose of wrapping this function is so that it may be mocked during tests.
 /// @param status The exit status to be reported to the operating system
 void sysexit(int status);
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
@@ -12,11 +12,7 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/process_group_manager/alive_monitor_thread.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonitor> health_monitor)
@@ -26,7 +22,7 @@ AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonito
 
 bool AliveMonitorThread::start()
 {
-    score::lcm::saf::daemon::EInitCode init_status{score::lcm::saf::daemon::EInitCode::kNotInitialized};
+    score::mw::lifecycle::saf::daemon::EInitCode init_status{score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized};
     alive_monitor_thread_ = std::thread([this, &init_status]() {
         const auto initResult = m_health_monitor->init();
 
@@ -53,8 +49,8 @@ void AliveMonitorThread::stop()
 }
 
 void AliveMonitorThread::notifyInitializationComplete(
-    score::lcm::saf::daemon::EInitCode& f_init_status_r,
-    const score::lcm::saf::daemon::EInitCode f_init_result)
+    score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
+    const score::mw::lifecycle::saf::daemon::EInitCode f_init_result)
 {
     {
         std::lock_guard lk(m_initialization_mutex);
@@ -63,14 +59,12 @@ void AliveMonitorThread::notifyInitializationComplete(
     m_initialization_cv.notify_all();
 }
 
-void AliveMonitorThread::waitForInitializationCompleted(score::lcm::saf::daemon::EInitCode& f_init_status_r)
+void AliveMonitorThread::waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r)
 {
     std::unique_lock lk(m_initialization_mutex);
     m_initialization_cv.wait(lk, [&f_init_status_r]() {
-        return f_init_status_r != score::lcm::saf::daemon::EInitCode::kNotInitialized;
+        return f_init_status_r != score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized;
     });
 }
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
@@ -20,11 +20,7 @@
 
 #include "score/mw/launch_manager/process_group_manager/ialive_monitor_thread.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief AliveMonitor manages the lifecycle of the alive monitoring daemon in a separate thread.
@@ -42,9 +38,9 @@ class AliveMonitorThread final : public IAliveMonitorThread
 
   private:
     void notifyInitializationComplete(
-        score::lcm::saf::daemon::EInitCode& f_init_status_r,
-        const score::lcm::saf::daemon::EInitCode f_init_result);
-    void waitForInitializationCompleted(score::lcm::saf::daemon::EInitCode& f_init_status_r);
+        score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
+        const score::mw::lifecycle::saf::daemon::EInitCode f_init_result);
+    void waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r);
 
     std::unique_ptr<saf::daemon::IAliveMonitor> m_health_monitor{nullptr};
     std::thread alive_monitor_thread_{};
@@ -53,7 +49,5 @@ class AliveMonitorThread final : public IAliveMonitorThread
     std::condition_variable m_initialization_cv{};
 };
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
@@ -59,7 +59,7 @@ struct [[nodiscard]] JobSkipped
 /// @brief Alive supervision has failed for the given process identifier.
 struct [[nodiscard]] SupervisionFailure
 {
-    score::lcm::IdentifierHash process_identifier;
+    score::mw::lifecycle::IdentifierHash process_identifier;
 };
 
 /// @brief A graph-relevant state change. There is only ever a single graph, so no process-group

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
@@ -23,7 +23,7 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm;
+
 
 /// @brief A node finished activating successfully.
 struct [[nodiscard]] ActivationSuccessful
@@ -59,7 +59,7 @@ struct [[nodiscard]] JobSkipped
 /// @brief Alive supervision has failed for the given process identifier.
 struct [[nodiscard]] SupervisionFailure
 {
-    IdentifierHash process_identifier;
+    score::lcm::IdentifierHash process_identifier;
 };
 
 /// @brief A graph-relevant state change. There is only ever a single graph, so no process-group

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue.hpp
@@ -51,7 +51,7 @@ class ComponentEventQueue final : public IComponentEventPublisherConsumer
     [[nodiscard]] bool push(ComponentEvent&& event) override
     {
         auto result = queue_.push(std::move(event));
-        if (!result.has_value() && result.error() == lcm::internal::ConcurrencyErrc::kOverflow)
+        if (!result.has_value() && result.error() == score::mw::lifecycle::internal::ConcurrencyErrc::kOverflow)
         {
             overflow_.store(true, std::memory_order_release);
             return false;
@@ -95,7 +95,7 @@ class ComponentEventQueue final : public IComponentEventPublisherConsumer
     }
 
   private:
-    lcm::internal::MpscBoundedQueue<ComponentEvent> queue_;
+    score::mw::lifecycle::internal::MpscBoundedQueue<ComponentEvent> queue_;
     std::size_t capacity_;
     std::atomic<bool> overflow_{false};
 };

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
@@ -19,7 +19,7 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
 class ComponentEventQueueTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
@@ -22,11 +22,11 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm::internal;
+
 
 /// @brief Returns the IComponent reference from a variant type
 /// @details All types in the variant must implement the IComponent interface.
-inline IComponent& componentOf(std::variant<ProcessInfoNode, RunTarget>& node)
+inline IComponent& componentOf(std::variant<score::lcm::internal::ProcessInfoNode, RunTarget>& node)
 {
     return std::visit(
         [](auto& component) -> IComponent& {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
@@ -26,7 +26,7 @@ namespace score::mw::lifecycle::internal
 
 /// @brief Returns the IComponent reference from a variant type
 /// @details All types in the variant must implement the IComponent interface.
-inline IComponent& componentOf(std::variant<score::lcm::internal::ProcessInfoNode, RunTarget>& node)
+inline IComponent& componentOf(std::variant<score::mw::lifecycle::internal::ProcessInfoNode, RunTarget>& node)
 {
     return std::visit(
         [](auto& component) -> IComponent& {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
@@ -23,7 +23,7 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::lcm::internal;
+
 
 /// @brief Index type used to identify nodes in the graph.
 using GraphIndex = std::size_t;
@@ -186,7 +186,7 @@ class DependencyGraph
     std::vector<GraphNode> nodes;
 
     /// @brief Presized queue reused by single-threaded traversals.
-    FixedSizeQueue<GraphIndex> traversal_queue;
+    score::lcm::internal::FixedSizeQueue<GraphIndex> traversal_queue;
     /// @brief Presized visited set reused by single-threaded traversals.
     std::vector<bool> visited;
 };

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
@@ -186,7 +186,7 @@ class DependencyGraph
     std::vector<GraphNode> nodes;
 
     /// @brief Presized queue reused by single-threaded traversals.
-    score::lcm::internal::FixedSizeQueue<GraphIndex> traversal_queue;
+    score::mw::lifecycle::internal::FixedSizeQueue<GraphIndex> traversal_queue;
     /// @brief Presized visited set reused by single-threaded traversals.
     std::vector<bool> visited;
 };

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
@@ -22,7 +22,7 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
 TEST(DependencyGraphTest, EmplaceAndAccessByIndex)
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
@@ -33,6 +33,9 @@ namespace lcm
 namespace internal
 {
 
+using namespace score::mw::lifecycle;
+using namespace score::mw::lifecycle::internal;
+
 Graph::Graph(
     uint32_t max_num_nodes,
     ConfigurationInterface* configuration,

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
@@ -103,7 +103,7 @@ void Graph::createProcessInfoNodes(uint32_t num_processes)
                                    : ProcessInfoNode::ReadyCondition::kRunning;
 
         auto report_state_lambda = [this](IdentifierHash id, ProcessState state, timespec timestamp) {
-            score::lcm::PosixProcess process_info;
+            score::mw::lifecycle::PosixProcess process_info;
             process_info.id = id;
             process_info.processStateId = state;
             process_info.processGroupStateId = getProcessGroupState();

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
@@ -24,13 +24,7 @@
 
 #include "score/assert.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace score::mw::lifecycle;
@@ -721,8 +715,4 @@ std::chrono::time_point<std::chrono::steady_clock> Graph::getRequestStartTime()
     return request_start_time_;
 }
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -39,13 +39,7 @@
 #include "score/mw/launch_manager/process_state_client/iprocess_state_notifier.hpp"
 #include <score/stop_token.hpp>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 
@@ -427,10 +421,6 @@ class Graph final
     score::cpp::stop_source stop_source_;
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  /// GRAPH_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -190,7 +190,7 @@ class Graph final
     ///     pushes this event once a process has already reached its ready condition, so it is
     ///     always a post-ready crash.
     /// @param event The event to process.
-    void handleComponentEvent(const ComponentEvent& event);
+    void handleComponentEvent(const score::mw::lifecycle::internal::ComponentEvent& event);
 
     /// @brief Cancel the current transition because a new state has been requested.
     /// Sets the graph state to kCancelled and posts a kSetStateCancelled pending event.
@@ -329,7 +329,7 @@ class Graph final
     /// @brief Pushes the given task onto the worker queue while the graph is in transition.
     /// Retries on timeout.
     /// @param task The task to enqueue.
-    void tryQueueNode(ComponentTask task);
+    void tryQueueNode(score::mw::lifecycle::internal::ComponentTask task);
 
     /// @brief Every node that is ready to execute is either executed in place (RunTarget) or queued for execution
     /// (ProcessInfoNode).

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -51,7 +51,7 @@ namespace internal
 
 
 using ConfigurationInterface = ConfigurationAdapter;
-using Config = score::mw::launch_manager::configuration::Config;
+using Config = score::mw::lifecycle::configuration::Config;
 
 using WorkerQueue =
     MPMCConcurrentQueue<std::optional<score::mw::lifecycle::internal::ComponentTask>, static_cast<std::size_t>(ProcessLimits::kMaxProcesses)>;

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -48,13 +48,13 @@ namespace lcm
 namespace internal
 {
 
-using namespace score::mw::lifecycle;
+
 
 using ConfigurationInterface = ConfigurationAdapter;
 using Config = score::mw::launch_manager::configuration::Config;
 
 using WorkerQueue =
-    MPMCConcurrentQueue<std::optional<ComponentTask>, static_cast<std::size_t>(ProcessLimits::kMaxProcesses)>;
+    MPMCConcurrentQueue<std::optional<score::mw::lifecycle::internal::ComponentTask>, static_cast<std::size_t>(ProcessLimits::kMaxProcesses)>;
 
 /// @brief GraphState - the graph/process group state.
 /// @details Enumeration representing the state of the graph.
@@ -297,12 +297,12 @@ class Graph final
 
     /// @brief Reports that a node has finished executing, enqueuing successors or updating the graph state if a
     /// transition has finished.
-    void nodeExecuted(uint32_t node, score::cpp::expected_blank<IComponent::ComponentError> error);
+    void nodeExecuted(uint32_t node, score::cpp::expected_blank<score::mw::lifecycle::internal::IComponent::ComponentError> error);
 
     /// @brief Abort the current transition due to a process error.
     /// @deprecated @param code The execution error for the process that caused the abort.
     /// @param reason The process error that triggered the abort.
-    void abort(uint32_t code, IComponent::ComponentError reason);
+    void abort(uint32_t code, score::mw::lifecycle::internal::IComponent::ComponentError reason);
 
     /// @brief Sets the current state of the graph.
     /// @param new_state The new state to set for the graph.
@@ -338,7 +338,7 @@ class Graph final
     /// @brief Executes a RunTarget's activation/deactivation in place
     /// @details Since a RunTarget is a virtual node with no work to do
     /// and reports its completion to the current transition immediately.
-    void updateRunTargetInPlace(RunTarget& run_target, ComponentTaskType task_type);
+    void updateRunTargetInPlace(score::mw::lifecycle::internal::RunTarget& run_target, score::mw::lifecycle::internal::ComponentTaskType task_type);
 
     /// @brief Common tail of a transition that finished without error: moves the graph to
     /// kSuccess, posts kSetStateSuccess, and reports initial-state-transition success if this
@@ -358,16 +358,16 @@ class Graph final
 
     /// @brief Nodes for all unique processes in this process group, plus a virtual RunTarget node
     /// per configured ProcessGroupState.
-    DependencyGraph<std::variant<ProcessInfoNode, RunTarget>> nodes_;
+    score::mw::lifecycle::DependencyGraph<std::variant<ProcessInfoNode, score::mw::lifecycle::internal::RunTarget>> nodes_;
 
     /// @brief Maps a ProcessGroupState name to the index of its RunTarget node in @c nodes_.
     std::vector<std::pair<IdentifierHash, uint32_t>> run_targets_;
 
     /// @brief Builder for creating the transition object for the current state transition.
-    TransitionBuilder<std::variant<ProcessInfoNode, RunTarget>> transition_builder_;
+    score::mw::lifecycle::TransitionBuilder<std::variant<ProcessInfoNode, score::mw::lifecycle::internal::RunTarget>> transition_builder_;
 
     /// @brief The currently active transition or nullptr before the first one starts.
-    Transition<std::variant<ProcessInfoNode, RunTarget>>* current_transition_{nullptr};
+    score::mw::lifecycle::Transition<std::variant<ProcessInfoNode, score::mw::lifecycle::internal::RunTarget>>* current_transition_{nullptr};
 
     /// @brief Current state of the graph.
     GraphState state_{GraphState::kSuccess};

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
@@ -18,12 +18,12 @@
 #include "score/mw/launch_manager/process_group_manager/details/graph.hpp"
 #include "score/mw/launch_manager/process_group_manager/mock_iprocess.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace testing;
 using namespace score::mw::lifecycle;
-using namespace score::mw::launch_manager::configuration;
+using namespace score::mw::lifecycle::configuration;
 using namespace std::chrono_literals;
 
 class MockProcessMap : public SafeProcessMapInserter
@@ -35,8 +35,8 @@ class MockProcessMap : public SafeProcessMapInserter
 class MockProcessStateNotifier : public IProcessStateNotifier
 {
   public:
-    MOCK_METHOD(std::unique_ptr<score::lcm::IProcessStateReceiver>, constructReceiver, (), (override));
-    MOCK_METHOD(bool, queuePosixProcess, (const score::lcm::PosixProcess& f_posixProcess), (override, noexcept));
+    MOCK_METHOD(std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver>, constructReceiver, (), (override));
+    MOCK_METHOD(bool, queuePosixProcess, (const score::mw::lifecycle::PosixProcess& f_posixProcess), (override, noexcept));
 };
 
 class MockTransitionResultPublisher : public ITransitionResultPublisher
@@ -613,4 +613,4 @@ TEST_F(GraphUtilitiesTest, gettersSetters)
     EXPECT_LE(graph_time, after_time);
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/itransition_result_publisher.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/itransition_result_publisher.hpp
@@ -16,7 +16,7 @@
 
 #include "score/mw/launch_manager/control/control_client_channel.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 class ITransitionResultPublisher
@@ -27,6 +27,6 @@ class ITransitionResultPublisher
     virtual ~ITransitionResultPublisher() = default;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // SCORE_LCM_ITRANSITION_RESULT_PUBLISHER

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
@@ -31,7 +31,7 @@ void OsHandler::run(void)
 
         if (result.has_value() && result.value() > 0)
         {
-            if (score::lcm::internal::SafeProcessMapReturnType::kInsertionError ==
+            if (score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError ==
                 safe_process_map_.findTerminated(result.value(), wait_status))
             {
                 LM_LOG_ERROR() << "No more resources available to track process with PID " << result.value()

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
@@ -13,13 +13,7 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/os_handler.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 void OsHandler::run(void)
@@ -48,8 +42,4 @@ void OsHandler::run(void)
     }
 }
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
@@ -92,7 +92,7 @@ class OsHandler final
     score::os::SysWait& sys_wait_;
 
     /// @brief Thread object to manage execution of the run method.
-    std::thread os_handler_{&score::lcm::internal::OsHandler::run, this};
+    std::thread os_handler_{&score::mw::lifecycle::internal::OsHandler::run, this};
 };
 
 }  // namespace internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
@@ -20,13 +20,7 @@
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 #include "score/os/sys_wait.h"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Delay duration between successive iterations of the OsHandler's main loop when no processes are terminating.
@@ -95,10 +89,6 @@ class OsHandler final
     std::thread os_handler_{&score::mw::lifecycle::internal::OsHandler::run, this};
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  /// OS_HANDLER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/oshandler_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/oshandler_UT.cpp
@@ -27,7 +27,8 @@
 #include "score/os/mocklib/sys_wait_mock.h"
 
 using namespace testing;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
+using namespace score::mw::lifecycle::internal;
 
 namespace
 {
@@ -152,7 +153,7 @@ TEST_F(OsHandlerTest, WaitReturnsProcessIdBeforeRegistration_LaterRegistrationRe
     // callback immediately with the saved exit status instead of creating a new live entry.
     EXPECT_CALL(ccontroller_, terminated(_, 99)).Times(1);
     EXPECT_EQ(
-        process_map_.insertIfNotTerminated(4000, &component_), score::lcm::internal::SafeProcessMapReturnType::kYield);
+        process_map_.insertIfNotTerminated(4000, &component_), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 
     sut_.reset();
 }
@@ -170,7 +171,7 @@ TEST_F(OsHandlerTest, WaitReturnsUnknownPidWhenMapIsFull_OutOfResourcesPathDoesN
     {
         ASSERT_EQ(
             process_map_.insertIfNotTerminated(static_cast<int32_t>(i + 1U), &callbacks[i]),
-            score::lcm::internal::SafeProcessMapReturnType::kOk);
+            score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 
     EXPECT_CALL(*sys_wait_mock_, wait(_))

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
@@ -41,7 +41,7 @@ ProcessInfoNode::ProcessInfoNode(
       process_index_(index),
       pid_(0),
       status_(0),
-      process_state_(score::lcm::ProcessState::kIdle),
+      process_state_(score::mw::lifecycle::ProcessState::kIdle),
       ready_condition_(ready_condition),
       config_(config),
       report_state_(std::move(report_function)),
@@ -50,7 +50,7 @@ ProcessInfoNode::ProcessInfoNode(
 {
 }
 
-IComponent::RequestResult ProcessInfoNode::tryReportCompletion(score::lcm::ProcessState new_state)
+IComponent::RequestResult ProcessInfoNode::tryReportCompletion(score::mw::lifecycle::ProcessState new_state)
 {
     ProcessState desired_state{};
     switch (ready_condition_)
@@ -94,18 +94,18 @@ IComponent::RequestResult ProcessInfoNode::tryReportError(ComponentError error)
     return {IComponent::RequestState::kWaiting};
 }
 
-bool ProcessInfoNode::setState(score::lcm::ProcessState new_state)
+bool ProcessInfoNode::setState(score::mw::lifecycle::ProcessState new_state)
 {
     bool success = true;
-    score::lcm::ProcessState old_state = getState();
+    score::mw::lifecycle::ProcessState old_state = getState();
 
     if (new_state > old_state || (new_state == old_state && new_state == ProcessState::kIdle))
     {
         success = process_state_.compare_exchange_strong(old_state, new_state);
     }
     else if (
-        new_state == score::lcm::ProcessState::kIdle &&
-        (old_state == score::lcm::ProcessState::kTerminated || old_state == ProcessState::kFailed))
+        new_state == score::mw::lifecycle::ProcessState::kIdle &&
+        (old_state == score::mw::lifecycle::ProcessState::kTerminated || old_state == ProcessState::kFailed))
     {
         process_state_.store(new_state);
     }
@@ -115,7 +115,7 @@ bool ProcessInfoNode::setState(score::lcm::ProcessState new_state)
     }
 
     if (success && config_->startup_config_.comms_type_ != osal::CommsType::kNoComms &&
-        score::lcm::ProcessState::kIdle != new_state)
+        score::mw::lifecycle::ProcessState::kIdle != new_state)
     {
         // for a reporting process, report a process state change to PHM
         // Note the following system call will not fail by design.
@@ -205,7 +205,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         SCORE_LANGUAGE_FUTURECPP_ASSERT_DBG_MESSAGE(
             getState() != ProcessState::kRunning, "Restart attempted even though process is running");
         // - Terminating: A termination is in progress (allowed)
-        if (!setState(score::lcm::ProcessState::kIdle))
+        if (!setState(score::mw::lifecycle::ProcessState::kIdle))
         {
             LM_LOG_WARN() << "Starting process" << this << "failed: termination in progress";
             error = ComponentError::kErrorBeforeReady;
@@ -215,7 +215,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         pid_ = 0;
         status_ = 0;
         error = std::nullopt;
-        static_cast<void>(setState(score::lcm::ProcessState::kStarting));  // Cannot fail by design
+        static_cast<void>(setState(score::mw::lifecycle::ProcessState::kStarting));  // Cannot fail by design
 
         if (osal::OsalReturnType::kSuccess ==
             process_interface_->startProcess(&pid_, &sync_, &config_->startup_config_))
@@ -231,7 +231,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
             if (!res.has_value())
             {
                 // Fatal error, do not retry
-                setState(score::lcm::ProcessState::kFailed);
+                setState(score::mw::lifecycle::ProcessState::kFailed);
                 error = res.error();
                 break;
             }
@@ -247,7 +247,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         }
         else
         {
-            setState(score::lcm::ProcessState::kFailed);
+            setState(score::mw::lifecycle::ProcessState::kFailed);
             error = ComponentError::kErrorBeforeReady;
             break;
         }
@@ -321,10 +321,10 @@ ProcessInfoNode::handleProcessStarted(const score::cpp::stop_token& stop_token)
 {
     switch (process_map_->insertIfNotTerminated(pid_, this))
     {
-        case score::lcm::internal::SafeProcessMapReturnType::kOk:  // Normal case, entry was put in
+        case score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk:  // Normal case, entry was put in
                                                                    // the map, process still running
             return handleProcessStillStarting(stop_token);
-        case score::lcm::internal::SafeProcessMapReturnType::kYield:  // Process has already exited
+        case score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield:  // Process has already exited
             return handleProcessAlreadyTerminated();
         default:  // Error case when pn == -1
             // really bad fatal error, should not happen, treat as a failure to set the state & kill the process
@@ -352,7 +352,7 @@ void ProcessInfoNode::terminateProcess(const score::cpp::stop_token& stop_token)
 {
     LM_LOG_DEBUG() << "terminating process" << process_index_ << "(" << config_->startup_config_.short_name_ << ")";
 
-    if (setState(score::lcm::ProcessState::kTerminating))
+    if (setState(score::mw::lifecycle::ProcessState::kTerminating))
     {
         handleTerminationProcess(stop_token);
     }
@@ -392,7 +392,7 @@ void ProcessInfoNode::handleForcedTermination(const score::cpp::stop_token& stop
                   << ") did not respond to SIGTERM, sending SIGKILL";
 
     while ((osal::OsalReturnType::kSuccess == process_interface_->forceTermination(pid_)) &&
-           (terminator_.timedWait(score::lcm::internal::kMaxSigKillDelay) != osal::OsalReturnType::kSuccess))
+           (terminator_.timedWait(score::mw::lifecycle::internal::kMaxSigKillDelay) != osal::OsalReturnType::kSuccess))
     {
         LM_LOG_FATAL() << "Process" << process_index_ << "(" << config_->startup_config_.short_name_
                        << ") did not respond to SIGKILL!!";
@@ -430,7 +430,7 @@ osal::ProcessID ProcessInfoNode::getPid() const
     return pid_;
 }
 
-score::lcm::ProcessState ProcessInfoNode::getState() const
+score::mw::lifecycle::ProcessState ProcessInfoNode::getState() const
 {
     return process_state_.load();
 }

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
@@ -18,13 +18,7 @@
 #include <score/assert.hpp>
 #include <unistd.h>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace score::mw::lifecycle::internal;
@@ -445,8 +439,4 @@ ControlClientChannelP ProcessInfoNode::getControlClientChannel() const
     return std::atomic_load(&control_client_channel_);
 }
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
@@ -27,6 +27,8 @@ namespace lcm
 namespace internal
 {
 
+using namespace score::mw::lifecycle::internal;
+
 ProcessInfoNode::ProcessInfoNode(
     const OsProcess* config,
     uint32_t index,

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -21,13 +21,7 @@
 #include <score/stop_token.hpp>
 #include <atomic>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 
@@ -216,10 +210,6 @@ class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
     std::shared_ptr<SafeProcessMapInserter> process_map_;
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -105,7 +105,7 @@ class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
     osal::ProcessID getPid() const;
 
     /// @return The current state of this process.
-    score::lcm::ProcessState getState() const;
+    score::mw::lifecycle::ProcessState getState() const;
 
     /// @return The ControlClientChannel for this process, or nullptr if none exists.
     ControlClientChannelP getControlClientChannel() const;
@@ -115,7 +115,7 @@ class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
     /// processes, also notifies the platform health manager of the state change.
     /// @param new_state The desired process state.
     /// @return True if the state was changed, false if the transition was not valid.
-    bool setState(score::lcm::ProcessState new_state);
+    bool setState(score::mw::lifecycle::ProcessState new_state);
 
     /// @brief Helper method to post on the semaphore waiting for kRunning if it exists
     void unblockSync();
@@ -124,7 +124,7 @@ class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
     /// terminated, the function will only return kSuccess if the new state is kTerminated.
     /// @return Success if the ready condition is satisfied and completion is not already reported, an error if the
     /// state is unrecoverable, waiting otherwise.
-    RequestResult tryReportCompletion(score::lcm::ProcessState new_state);
+    RequestResult tryReportCompletion(score::mw::lifecycle::ProcessState new_state);
 
     /// @return The provided error if the result has not been reported yet. A waiting result otherwise.
     RequestResult tryReportError(ComponentError error);
@@ -185,7 +185,7 @@ class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
     std::atomic<int32_t> status_{0};
 
     /// @brief The current state of the OS process
-    std::atomic<score::lcm::ProcessState> process_state_{score::lcm::ProcessState::kIdle};
+    std::atomic<score::mw::lifecycle::ProcessState> process_state_{score::mw::lifecycle::ProcessState::kIdle};
 
     /// @brief Flag indicating whether the Ready Condition has been satisfied.
     /// The flag is reset when deactivate() is called.

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -30,7 +30,7 @@ namespace lcm
 namespace internal
 {
 
-using namespace score::mw::lifecycle::internal;
+
 
 using ReportStateFn = std::function<bool(IdentifierHash, ProcessState, timespec)>;
 
@@ -43,7 +43,7 @@ using ReportStateFn = std::function<bool(IdentifierHash, ProcessState, timespec)
 /// @note A Component and a Process have distinct state machines. The component may be in kActive state while the
 /// process is in kTerminated state, for example, if the process self-terminates after reaching its ready condition.
 ///       In the future, this class shall be split up to properly separate Component and Process lifecycle.
-class ProcessInfoNode final : public IComponent
+class ProcessInfoNode final : public score::mw::lifecycle::internal::IComponent
 {
   public:
     /// @brief The criteria for when a process is considered "ready"

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node_UT.cpp
@@ -20,8 +20,8 @@
 #include <vector>
 
 using namespace testing;
-using namespace score::lcm::internal;
-using namespace score::lcm;
+using namespace score::mw::lifecycle::internal;
+using namespace score::mw::lifecycle;
 
 // Default ProcessIndex for testing
 constexpr uint32_t kProcessIndex = 111;
@@ -89,7 +89,7 @@ class ProcessInfoNodeFixture : public ::testing::Test
     }
 
     /// @brief Asserts that mock_report_fn_ is called with each of the given states, in the given order.
-    void expectStateTransitions(const std::vector<score::lcm::ProcessState>& states)
+    void expectStateTransitions(const std::vector<score::mw::lifecycle::ProcessState>& states)
     {
         Sequence seq;
         for (const auto state : states)
@@ -103,7 +103,7 @@ class ProcessInfoNodeFixture : public ::testing::Test
     {
         EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
         EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-            .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+            .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     }
 
     /// @brief Sets up requestTermination to synchronously deliver the OS exit notification.
@@ -121,7 +121,7 @@ class ProcessInfoNodeFixture : public ::testing::Test
     score::cpp::stop_source stop_source_{};
     std::shared_ptr<MockSafeProcessMapInserter> process_map_{std::make_shared<MockSafeProcessMapInserter>()};
     StrictMock<osal::MockIProcess> mock_processIf_{};
-    MockFunction<bool(IdentifierHash, score::lcm::ProcessState, timespec)> mock_report_fn_{};
+    MockFunction<bool(IdentifierHash, score::mw::lifecycle::ProcessState, timespec)> mock_report_fn_{};
     ReportStateFn report_fn_{mock_report_fn_.AsStdFunction()};
 };
 
@@ -138,7 +138,7 @@ TEST_F(ProcessInfoNodeStartupTest, CanConstructIdleProcessInfoNode)
     auto node = createProcessInfoNode();
 
     ASSERT_THAT(node->getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
     ASSERT_THAT(node->getPid(), Eq(0));
     ASSERT_THAT(node->active(), IsFalse());
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
@@ -159,7 +159,7 @@ TEST_F(ProcessInfoNodeStartupTest, CanStartNonReportingProcess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, CanStartReportingProcess_ReportsRunningInTime)
@@ -169,14 +169,14 @@ TEST_F(ProcessInfoNodeStartupTest, CanStartReportingProcess_ReportsRunningInTime
     auto node = createProcessInfoNode(osal::CommsType::kReporting);
     expectSuccessfulProcessLaunch();
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
-    expectStateTransitions({score::lcm::ProcessState::kStarting, score::lcm::ProcessState::kRunning});
+    expectStateTransitions({score::mw::lifecycle::ProcessState::kStarting, score::mw::lifecycle::ProcessState::kRunning});
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, OsForkFails_ReturnsErrorBeforeReady)
@@ -192,7 +192,7 @@ TEST_F(ProcessInfoNodeStartupTest, OsForkFails_ReturnsErrorBeforeReady)
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kFailed));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kFailed));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
@@ -205,7 +205,7 @@ TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
     auto node = createProcessInfoNode(osal::CommsType::kNoComms);
     EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-        .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kInsertionError));
+        .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError));
     // The error handler calls terminateProcess(), which sends SIGTERM; simulate the OS ack.
     expectOsAcknowledgesTermination(node.get());
 
@@ -213,7 +213,7 @@ TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kFailed));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kFailed));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, SelfTerminating_ExitsBeforeMapInsert_ReturnsSuccess)
@@ -232,13 +232,13 @@ TEST_F(ProcessInfoNodeStartupTest, SelfTerminating_ExitsBeforeMapInsert_ReturnsS
             }),
             Return(osal::OsalReturnType::kSuccess)));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-        .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kYield));
+        .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, ActivateAlreadyActiveNode_ReturnsSuccess)
@@ -254,7 +254,7 @@ TEST_F(ProcessInfoNodeStartupTest, ActivateAlreadyActiveNode_ReturnsSuccess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsTrue());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 // Bundles process crashes and timeouts that occur during activate(), before the ready condition is reached.
@@ -274,15 +274,15 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ProcesssTerminated_OnWaitForkRunningTime
     // Simulate the OS handler reporting the killed process's exit once termination is requested.
     expectOsAcknowledgesTermination(node.get());
     expectStateTransitions(
-        {score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminating,
-         score::lcm::ProcessState::kTerminated});
+        {score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminating,
+         score::mw::lifecycle::ProcessState::kTerminated});
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kActivationTimedOut));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_NoRestarts)
@@ -301,13 +301,13 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_NoRe
                 node->tryHandleTermination(-1);
             }),
             Return(osal::OsalReturnType::kFail)));
-    expectStateTransitions({score::lcm::ProcessState::kStarting, score::lcm::ProcessState::kTerminated});
+    expectStateTransitions({score::mw::lifecycle::ProcessState::kStarting, score::mw::lifecycle::ProcessState::kTerminated});
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_WithRestartAttempts)
@@ -326,7 +326,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_With
         .WillRepeatedly(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
         .Times(kTotalAttempts)
-        .WillRepeatedly(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+        .WillRepeatedly(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     // Simulate the OS handler detecting the crash on every attempt, while the process is still waiting to reach
     // kRunning.
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _))
@@ -337,20 +337,20 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_With
             }),
             Return(osal::OsalReturnType::kFail)));
     expectStateTransitions(
-        {score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminated,
-         score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminated,
-         score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminated,
-         score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminated});
+        {score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminated,
+         score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminated,
+         score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminated,
+         score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminated});
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_NoRestarts)
@@ -368,13 +368,13 @@ TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_N
             InvokeWithoutArgs([node = node.get()] {
                 node->tryHandleTermination(-1);
             }),
-            Return(score::lcm::internal::SafeProcessMapReturnType::kOk)));
+            Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk)));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_WithRestartAttempts)
@@ -397,13 +397,13 @@ TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_W
             InvokeWithoutArgs([node = node.get()] {
                 node->tryHandleTermination(-1);
             }),
-            Return(score::lcm::internal::SafeProcessMapReturnType::kOk)));
+            Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk)));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, TimeoutThenSuccess_WithRestarts)
@@ -418,24 +418,24 @@ TEST_F(ProcessInfoNodeStartupCrashTest, TimeoutThenSuccess_WithRestarts)
     EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).Times(2).WillRepeatedly(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
         .Times(2)
-        .WillRepeatedly(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+        .WillRepeatedly(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _))
         .WillOnce(Return(osal::OsalReturnType::kFail))
         .WillOnce(Return(osal::OsalReturnType::kSuccess));
     // Simulate the OS handler reporting the killed process's exit on the first (timed-out) attempt.
     expectOsAcknowledgesTermination(node.get());
     expectStateTransitions(
-        {score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kTerminating,
-         score::lcm::ProcessState::kTerminated,
-         score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kRunning});
+        {score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kTerminating,
+         score::mw::lifecycle::ProcessState::kTerminated,
+         score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kRunning});
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 // Bundles unexpected terminations that occur after the ready condition has been reached.
@@ -453,7 +453,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, ProcesssCrashed_AfterReadyCondi
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorAfterReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminatingProcess_ExitsWithoutTerminationRequest)
@@ -470,7 +470,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminatingProcess_ExitsWit
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kWaiting));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_TerminatedReadyCondition_CleanExit_ReturnsSuccess)
@@ -495,7 +495,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_TerminatedReady
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_CrashAfterReady_ReturnsErrorAfterReady)
@@ -513,7 +513,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_CrashAfterReady
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorAfterReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 // Bundles succeess and failures cases when deactivating a process
@@ -530,10 +530,10 @@ TEST_F(ProcessInfoNodeDeactivationTest, CanTerminateNonSelfTerminatingProcess)
 
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
     expectStateTransitions(
-        {score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kRunning,
-         score::lcm::ProcessState::kTerminating,
-         score::lcm::ProcessState::kTerminated});
+        {score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kRunning,
+         score::mw::lifecycle::ProcessState::kTerminating,
+         score::mw::lifecycle::ProcessState::kTerminated});
 
     auto node = createRunningProcessInfoNode(osal::CommsType::kReporting);
     // Simulate the OS handler reporting the process's exit once termination is requested.
@@ -544,7 +544,7 @@ TEST_F(ProcessInfoNodeDeactivationTest, CanTerminateNonSelfTerminatingProcess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsFalse());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
 }
 
 // Bundles tests for the explicit move constructor, which is required because the class holds atomics.
@@ -564,7 +564,7 @@ TEST_F(ProcessInfoNodeMoveTest, MoveConstruct_IdleNode_PreservesObservableState)
     ProcessInfoNode moved{std::move(*source)};
 
     ASSERT_THAT(moved.getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(moved.getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(moved.getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
     ASSERT_THAT(moved.active(), IsFalse());
     ASSERT_THAT(moved.getPid(), Eq(0));
     ASSERT_THAT(moved.getControlClientChannel(), IsNull());
@@ -578,13 +578,13 @@ TEST_F(ProcessInfoNodeMoveTest, MoveConstruct_RunningNode_PreservesAtomicState)
         "moved node reports the running state and is active.");
 
     auto source = createRunningProcessInfoNode(osal::CommsType::kNoComms);
-    ASSERT_THAT(source->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(source->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
     ASSERT_THAT(source->active(), IsTrue());
 
     ProcessInfoNode moved{std::move(*source)};
 
     ASSERT_THAT(moved.getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(moved.getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(moved.getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
     ASSERT_THAT(moved.active(), IsTrue());
 }
 
@@ -597,10 +597,10 @@ TEST_F(ProcessInfoNodeDeactivationTest, ProcessIgnoresSigterm_ForcedWithSigkill)
 
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
     expectStateTransitions(
-        {score::lcm::ProcessState::kStarting,
-         score::lcm::ProcessState::kRunning,
-         score::lcm::ProcessState::kTerminating,
-         score::lcm::ProcessState::kTerminated});
+        {score::mw::lifecycle::ProcessState::kStarting,
+         score::mw::lifecycle::ProcessState::kRunning,
+         score::mw::lifecycle::ProcessState::kTerminating,
+         score::mw::lifecycle::ProcessState::kTerminated});
 
     auto node = createRunningProcessInfoNode_TermTimeout(std::chrono::milliseconds{0});
     EXPECT_CALL(mock_processIf_, requestTermination(_)).WillOnce(Return(osal::OsalReturnType::kSuccess));
@@ -617,5 +617,5 @@ TEST_F(ProcessInfoNodeDeactivationTest, ProcessIgnoresSigterm_ForcedWithSigkill)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsFalse());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
 }

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
@@ -176,16 +176,7 @@ void changeSecurityPolicy(const score::mw::lifecycle::internal::osal::OsalConfig
 
 }  // namespace
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 OsalReturnType ProcessLauncher::startProcess(ProcessID* pid, IpcCommsP* block, const OsalConfig* config)
@@ -584,10 +575,4 @@ OsalReturnType ProcessLauncher::waitForkRunning(IpcCommsP sync, std::chrono::mil
     return result;
 }
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
@@ -44,11 +44,11 @@ constexpr int kPosixSuccess = 0;
 namespace
 {
 
-using score::lcm::internal::signal_safe_log;
-using score::lcm::internal::signal_safe_log_errno;
-using score::lcm::internal::osal::CommsType;
-using score::lcm::internal::osal::IpcCommsSync;
-using score::lcm::internal::osal::sysexit;
+using score::mw::lifecycle::internal::signal_safe_log;
+using score::mw::lifecycle::internal::signal_safe_log_errno;
+using score::mw::lifecycle::internal::osal::CommsType;
+using score::mw::lifecycle::internal::osal::IpcCommsSync;
+using score::mw::lifecycle::internal::osal::sysexit;
 
 /// @brief Applies the given limit.
 /// @details The implementation should be async signal safe.
@@ -81,7 +81,7 @@ void setLimit(const int resource, const std::size_t amount, const std::string_vi
 }
 
 /// @details The implementation should be async signal safe.
-void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
+void handleComms(score::mw::lifecycle::internal::osal::ChildProcessConfig& param)
 {
     // kNoComms !fd3 & !fd4
     // kReporting  fd3 & !fd4
@@ -135,7 +135,7 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
 }
 
 /// @details The implementation should be async signal safe.
-void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig& config)
+void changeCurrentWorkingDirectory(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     // working_dir_ is set by python configuration generator in lifecycle_config.py, so it should always be valid.
     // If not, chdir will fail anyway and we will log an error and exit.
@@ -147,7 +147,7 @@ void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig&
 }
 
 /// @details The implementation should be async signal safe.
-void implementMemoryResourceLimits(const score::lcm::internal::osal::OsalConfig& config)
+void implementMemoryResourceLimits(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     setLimit(RLIMIT_DATA, config.resource_limits_.data_, "RLIMIT_DATA");
     setLimit(RLIMIT_AS, config.resource_limits_.as_, "RLIMIT_AS");
@@ -161,11 +161,11 @@ void implementMemoryResourceLimits(const score::lcm::internal::osal::OsalConfig&
 }
 
 /// @details The implementation should be async signal safe.
-void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
+void changeSecurityPolicy(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     if (config.security_policy_ != "")
     {
-        if (score::lcm::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
+        if (score::mw::lifecycle::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
         {
             static_cast<void>(
                 signal_safe_log_errno(errno, "changeSecurityPolicy(", config.security_policy_, ") failed"));
@@ -263,7 +263,7 @@ OsalReturnType ProcessLauncher::startProcess(ProcessID* pid, IpcCommsP* block, c
 bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& config)
 {
     bool comms_result = true;
-    char shm_name[static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize)];
+    char shm_name[static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize)];
     size_t length = sizeof(IpcCommsSync);
 
     if (CommsType::kControlClient == config.comms_type_)
@@ -273,7 +273,7 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
 
     static_cast<void>(snprintf(
         shm_name,
-        static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize),
+        static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize),
         "/ipc_shared_mem%u",
         shm_name_counter++));
 
@@ -282,7 +282,7 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
     if (fd < 0)
     {
         LM_LOG_ERROR() << "shm_open failed:" << config.executable_path_
-                       << "Unable to open shared memory object. Error:" << score::lcm::internal::errno_message(errno);
+                       << "Unable to open shared memory object. Error:" << score::mw::lifecycle::internal::errno_message(errno);
         comms_result = false;
     }
     else
@@ -294,7 +294,7 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
             comms_result = false;
             LM_LOG_ERROR() << "ftruncate failed:" << config.executable_path_
                            << "Unable to set size of shared memory file descriptor. Error:"
-                           << score::lcm::internal::errno_message(errno);
+                           << score::mw::lifecycle::internal::errno_message(errno);
         }
 
         if (config.comms_type_ == CommsType::kControlClient)
@@ -473,7 +473,7 @@ OsalReturnType ProcessLauncher::requestTermination(ProcessID pid)
         else
         {
             LM_LOG_ERROR() << "SIGTERM failed: Unable to send SIGTERM to process ID" << pid
-                           << ". Error:" << score::lcm::internal::errno_message(errno);
+                           << ". Error:" << score::mw::lifecycle::internal::errno_message(errno);
         }
     }
     else
@@ -530,7 +530,7 @@ OsalReturnType ProcessLauncher::waitForTermination(osal::ProcessID& pid, int32_t
     {
         /// exiting with pid == 0 is perfectly normal behaviour when all process groups are in the Off state.
         LM_LOG_DEBUG() << "wait failed: Unable to wait for any child process to terminate. Error:"
-                       << score::lcm::internal::errno_message(errno);
+                       << score::mw::lifecycle::internal::errno_message(errno);
     }
 
     return result;
@@ -572,7 +572,7 @@ OsalReturnType ProcessLauncher::waitForkRunning(IpcCommsP sync, std::chrono::mil
         else
         {
             LM_LOG_WARN() << "Skipping semaphore deinitialization - shared memory region appears invalid: "
-                          << score::lcm::internal::errno_message(errno);
+                          << score::mw::lifecycle::internal::errno_message(errno);
         }
     }
     else

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.hpp
@@ -17,16 +17,7 @@
 #include "score/mw/launch_manager/process_group_manager/iprocess.hpp"
 #include <atomic>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief POSIX implementation of IProcess, managing child processes via fork/exec.
@@ -82,12 +73,6 @@ class ProcessLauncher final : public IProcess
     std::atomic_uint32_t shm_name_counter = {0};
 };
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // PROCESS_LAUNCHER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
@@ -17,13 +17,7 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace score::mw::lifecycle::internal;
@@ -312,8 +306,4 @@ SafeProcessMapReturnType SafeProcessMap::insertIfNotTerminated(osal::ProcessID k
     return static_cast<SafeProcessMapReturnType>(search(key, {0, object}));
 }
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
@@ -26,6 +26,8 @@ namespace lcm
 namespace internal
 {
 
+using namespace score::mw::lifecycle::internal;
+
 SafeProcessMap::SafeProcessMap(uint32_t capacity, IComponentController& termination_handler)
     : items_(std::make_unique<ProcessTreeNode[]>(capacity)), termination_handler_(termination_handler)
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
@@ -28,13 +28,13 @@ namespace lcm
 namespace internal
 {
 
-using namespace score::mw::lifecycle::internal;
+
 
 /// @brief Struct representing data in a map item
 struct ProcessInfoData
 {
     int32_t status_ = -1;        ///< Exit status for process
-    IComponent* pin_ = nullptr;  ///< Pointer to the termination callback associated with this item.
+    score::mw::lifecycle::internal::IComponent* pin_ = nullptr;  ///< Pointer to the termination callback associated with this item.
 };
 /// @brief Struct representing an item in the map.
 struct ProcessTreeNode
@@ -81,7 +81,7 @@ class SafeProcessMapInserter
     ///         kYield if the key was found (indicating the process has terminated), and updated with the provided
     ///         object, kInsertionError if an error occurred during insertion (e.g., out of memory), or kInvalidIdError
     ///         if the provided process ID (`key`) is not valid ( < 0).
-    virtual SafeProcessMapReturnType insertIfNotTerminated(osal::ProcessID key, IComponent* object) = 0;
+    virtual SafeProcessMapReturnType insertIfNotTerminated(osal::ProcessID key, score::mw::lifecycle::internal::IComponent* object) = 0;
 };
 
 /// @brief The SafeProcessMap class provides a thread-safe mapping of unique process IDs (ProcessID) to
@@ -112,7 +112,7 @@ class SafeProcessMap final : public SafeProcessMapInserter
 
     /// @brief Inserts a process into the map if it has not already terminated.
     /// @see SafeProcessMapInserter::insertIfNotTerminated() for details
-    SafeProcessMapReturnType insertIfNotTerminated(osal::ProcessID key, IComponent* object) override;
+    SafeProcessMapReturnType insertIfNotTerminated(osal::ProcessID key, score::mw::lifecycle::internal::IComponent* object) override;
 
   private:
     /// @brief Searches for a process with the given process ID (key) in the map.

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
@@ -19,13 +19,7 @@
 #include <atomic>
 #include <cstdint>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 
@@ -222,10 +216,6 @@ class SafeProcessMap final : public SafeProcessMapInserter
     score::mw::lifecycle::internal::IComponentController& termination_handler_;
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif  /// SAFE_PROCESS_MAP_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
@@ -93,7 +93,7 @@ class SafeProcessMap final : public SafeProcessMapInserter
     /// @brief Constructs a SafeProcessMap.
     /// @param capacity The maximum number of entries the map can hold.
     /// @param termination_handler Called when a terminated process is matched with its component.
-    SafeProcessMap(uint32_t capacity, IComponentController& termination_handler);
+    SafeProcessMap(uint32_t capacity, score::mw::lifecycle::internal::IComponentController& termination_handler);
 
     /// @brief Destructor to clean up resources used by the SafeProcessMap object.
     ~SafeProcessMap() = default;
@@ -219,7 +219,7 @@ class SafeProcessMap final : public SafeProcessMapInserter
     /// It initially starts with LINK_NO_VALUE, indicating no valid position.
     uint32_t rover_{LINK_NO_VALUE};
 
-    IComponentController& termination_handler_;
+    score::mw::lifecycle::internal::IComponentController& termination_handler_;
 };
 
 }  // namespace internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safeprocessmap_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safeprocessmap_UT.cpp
@@ -24,7 +24,7 @@
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 
 using namespace testing;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 namespace
 {
@@ -83,15 +83,15 @@ TEST_F(SafeProcessMapTest, FindTerminatedWithNegativePidReturnsInvalid)
 {
     RecordProperty(
         "Description",
-        "findTerminated returns -score::lcm::internal::SafeProcessMapReturnType::kUndefined "
+        "findTerminated returns -score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined "
         "for a negative "
         "process ID.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(-1, 1000);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(-1, 1000);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedInsertsEntryWhenPidNotPresent)
@@ -100,10 +100,10 @@ TEST_F(SafeProcessMapTest, FindTerminatedInsertsEntryWhenPidNotPresent)
         "Description", "findTerminated inserts an entry and returns kYield (1) when the PID is not in the map.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 0);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 0);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedMatchesExistingInsertAndCallsCallback)
@@ -118,8 +118,8 @@ TEST_F(SafeProcessMapTest, FindTerminatedMatchesExistingInsertAndCallsCallback)
     EXPECT_CALL(controller, terminated(Ref(callback_), 42));
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 42);
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 42);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 // --- insertIfNotTerminated ---
@@ -129,10 +129,10 @@ TEST_F(SafeProcessMapTest, InsertIntoEmptyTreeReturnsZero)
     RecordProperty("Description", "insertIfNotTerminated returns kOk (0) when inserting into an empty tree.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(2000, &callback_);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(2000, &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 TEST_F(SafeProcessMapTest, InsertMatchesExistingFindTerminatedEntry)
@@ -147,10 +147,10 @@ TEST_F(SafeProcessMapTest, InsertMatchesExistingFindTerminatedEntry)
     EXPECT_CALL(controller, terminated(Ref(callback_), 0));
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(1000, &callback_);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(1000, &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 TEST_F(SafeProcessMapTest, InsertMultipleNodesThenFindTerminatedRemovesAll)
@@ -168,7 +168,7 @@ TEST_F(SafeProcessMapTest, InsertMultipleNodesThenFindTerminatedRemovesAll)
     // when / then
     for (uint32_t j = 1; j <= kCapacity; ++j)
     {
-        EXPECT_EQ(sut_.findTerminated(static_cast<int32_t>(j), 0), score::lcm::internal::SafeProcessMapReturnType::kOk);
+        EXPECT_EQ(sut_.findTerminated(static_cast<int32_t>(j), 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 }
 
@@ -184,15 +184,15 @@ TEST_F(SafeProcessMapTest, InsertBeyondCapacityReturnsOutOfMemory)
     {
         EXPECT_EQ(
             sut_.insertIfNotTerminated(static_cast<int32_t>(i), &callbacks[i]),
-            score::lcm::internal::SafeProcessMapReturnType::kOk);
+            score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result =
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result =
         sut_.insertIfNotTerminated(static_cast<int32_t>(kCapacity + 1), &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kInsertionError);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError);
 }
 
 // --- Anomalous (PID reuse) cases ---
@@ -205,8 +205,8 @@ TEST_F(SafeProcessMapTest, InsertSamePidTwiceYieldsUntilFindTerminatedResolves)
 
     // given
     std::atomic_bool first_done{false};
-    score::lcm::internal::SafeProcessMapReturnType ret1 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
-    score::lcm::internal::SafeProcessMapReturnType ret2 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret1 = score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret2 = score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
 
     NiceMock<MockComponent> cb;
 
@@ -222,15 +222,15 @@ TEST_F(SafeProcessMapTest, InsertSamePidTwiceYieldsUntilFindTerminatedResolves)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // then — first succeeded, second is still blocked
-    EXPECT_EQ(ret1, score::lcm::internal::SafeProcessMapReturnType::kOk);
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kUndefined);
+    EXPECT_EQ(ret1, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined);
 
     // when — resolve the anomaly
-    EXPECT_EQ(sut_.findTerminated(42, 0), score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(sut_.findTerminated(42, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     inserter.join();
 
     // then
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
@@ -242,8 +242,8 @@ TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
 
     // given
     std::atomic_bool first_done{false};
-    score::lcm::internal::SafeProcessMapReturnType ret1 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
-    score::lcm::internal::SafeProcessMapReturnType ret2 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret1 = score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret2 = score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
 
     NiceMock<MockComponent> cb;
 
@@ -259,15 +259,15 @@ TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // then — first succeeded, second is still blocked
-    EXPECT_EQ(ret1, score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kUndefined);
+    EXPECT_EQ(ret1, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined);
 
     // when — resolve the anomaly
-    EXPECT_EQ(sut_.insertIfNotTerminated(42, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.insertIfNotTerminated(42, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
     finder.join();
 
     // then
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 // --- Max depth tree ---
@@ -277,55 +277,55 @@ TEST_F(SafeProcessMapTest, FindTerminatedWorksAtMaxTreeDepth)
     RecordProperty("Description", "The binary tree handles maximum depth correctly.");
 
     // given — build a deep tree using bit patterns that always branch one way
-    EXPECT_EQ(sut_.findTerminated(0x00000000, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000001, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000002, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000003, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000007, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000000F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000001F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000003F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000007F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000000FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000001FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000003FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000007FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00001FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00003FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00007FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000FFFE, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0001FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0003FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0007FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x001FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x003FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x007FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x01FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x03FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x07FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x1FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x3FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x7FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000000, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000001, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000002, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000003, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000007, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000000F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000001F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000003F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000007F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000000FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000001FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000003FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000007FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00001FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00003FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00007FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000FFFE, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0001FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0003FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0007FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x001FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x003FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x007FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x01FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x03FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x07FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x1FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x3FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x7FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 
     // when / then — boundary values
     EXPECT_EQ(
         sut_.findTerminated(static_cast<int32_t>(0xFFFFFFFF), 0),
-        score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
     EXPECT_EQ(
         sut_.insertIfNotTerminated(static_cast<int32_t>(0xFFFFFFFF), &callback_),
-        score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
 
     // when / then — retrieve entries using insertIfNotTerminated
     NiceMock<MockComponent> cb;
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x0000FFFE, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x00010000, &cb), score::lcm::internal::SafeProcessMapReturnType::kOk);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x0001FFFF, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x00000002, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.insertIfNotTerminated(0x0000FFFE, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.insertIfNotTerminated(0x00010000, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(sut_.insertIfNotTerminated(0x0001FFFF, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.insertIfNotTerminated(0x00000002, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 // --- Multi-threaded stress tests ---
@@ -337,7 +337,7 @@ TEST_F(SafeProcessMapTest, ConcurrentInsertAndFindFromMultipleThreads)
         "Multiple threads concurrently inserting and finding terminated processes completes without error.");
 
     NiceMock<MockComponent> stubs[kNumThreads];
-    score::lcm::internal::SafeProcessMapReturnType results[kNumThreads] = {};
+    score::mw::lifecycle::internal::SafeProcessMapReturnType results[kNumThreads] = {};
 
     // when
     std::vector<std::thread> threads;
@@ -368,7 +368,7 @@ TEST_F(SafeProcessMapTest, ConcurrentInsertAndFindFromMultipleThreads)
     // then
     for (int t = 0; t < kNumThreads; ++t)
     {
-        EXPECT_EQ(results[t], score::lcm::internal::SafeProcessMapReturnType::kOk);
+        EXPECT_EQ(results[t], score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 }
 
@@ -378,7 +378,7 @@ TEST_F(SafeProcessMapTest, ConcurrentFindAndInsertFromMultipleThreads)
         "Description", "Multiple threads concurrently finding and inserting processes completes without error.");
 
     NiceMock<MockComponent> stubs[kNumThreads];
-    score::lcm::internal::SafeProcessMapReturnType results[kNumThreads] = {};
+    score::mw::lifecycle::internal::SafeProcessMapReturnType results[kNumThreads] = {};
 
     // when
     std::vector<std::thread> threads;
@@ -409,7 +409,7 @@ TEST_F(SafeProcessMapTest, ConcurrentFindAndInsertFromMultipleThreads)
     // then
     for (int t = 0; t < kNumThreads; ++t)
     {
-        EXPECT_EQ(results[t], score::lcm::internal::SafeProcessMapReturnType::kYield);
+        EXPECT_EQ(results[t], score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
     }
 }
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
@@ -284,7 +284,7 @@ class Transition
 
         /// @brief The nodes that are ready to be activated/deactivated in the current phase, in the order they were
         /// discovered.
-        score::lcm::internal::FixedSizeQueue<GraphIndex> next_nodes;
+        score::mw::lifecycle::internal::FixedSizeQueue<GraphIndex> next_nodes;
         std::size_t pending = 0;    // nodes still to reach terminal state in this phase
         Phase phase = Phase::Done;  // active vs deactivation vs finished
 
@@ -292,7 +292,7 @@ class Transition
         /// @deprecated This is a workaround for the case where two processes are started in parallel and their events
         /// processed in sequence. Both onNodeFinished() calls detect that all dependents are ready and try to enqueue
         /// successors. Detection of dependency readiness should be reworked to remove this.
-        std::bitset<static_cast<std::size_t>(score::lcm::internal::ProcessLimits::kMaxProcesses)> enqueued_set{};
+        std::bitset<static_cast<std::size_t>(score::mw::lifecycle::internal::ProcessLimits::kMaxProcesses)> enqueued_set{};
 
         State(std::size_t nodes) : next_nodes(nodes)
         {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
@@ -33,7 +33,7 @@
 
 namespace score::mw::lifecycle
 {
-using namespace score::lcm::internal;
+
 
 /// @brief What should happen to a ready node right now.
 enum class Action : std::uint8_t
@@ -284,7 +284,7 @@ class Transition
 
         /// @brief The nodes that are ready to be activated/deactivated in the current phase, in the order they were
         /// discovered.
-        FixedSizeQueue<GraphIndex> next_nodes;
+        score::lcm::internal::FixedSizeQueue<GraphIndex> next_nodes;
         std::size_t pending = 0;    // nodes still to reach terminal state in this phase
         Phase phase = Phase::Done;  // active vs deactivation vs finished
 
@@ -292,7 +292,7 @@ class Transition
         /// @deprecated This is a workaround for the case where two processes are started in parallel and their events
         /// processed in sequence. Both onNodeFinished() calls detect that all dependents are ready and try to enqueue
         /// successors. Detection of dependency readiness should be reworked to remove this.
-        std::bitset<static_cast<std::size_t>(ProcessLimits::kMaxProcesses)> enqueued_set{};
+        std::bitset<static_cast<std::size_t>(score::lcm::internal::ProcessLimits::kMaxProcesses)> enqueued_set{};
 
         State(std::size_t nodes) : next_nodes(nodes)
         {

--- a/score/launch_manager/src/daemon/src/process_group_manager/ialive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/ialive_monitor_thread.hpp
@@ -14,11 +14,7 @@
 #ifndef SCORE_LCM_IALIVE_MONITOR_THREAD_HPP_INCLUDED
 #define SCORE_LCM_IALIVE_MONITOR_THREAD_HPP_INCLUDED
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 class IAliveMonitorThread
 {
@@ -28,8 +24,6 @@ class IAliveMonitorThread
 
     virtual ~IAliveMonitorThread() = default;
 };
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
@@ -55,8 +55,8 @@ struct OsalConfig
 {
     std::string executable_path_{};                                              ///< Path to the executable.
     std::string short_name_;                                                     ///< Short name of the process
-    std::array<const char*, score::lcm::internal::kArgvArraySize> argv_{};       ///< Command-line arguments.
-    char* envp_[static_cast<std::size_t>(score::lcm::internal::kEnvArraySize)];  ///< Environment variables.
+    std::array<const char*, score::mw::lifecycle::internal::kArgvArraySize> argv_{};       ///< Command-line arguments.
+    char* envp_[static_cast<std::size_t>(score::mw::lifecycle::internal::kEnvArraySize)];  ///< Environment variables.
     std::string security_policy_{};          ///< Security policy to apply to this process
     uid_t uid_;                              ///< User ID.
     gid_t gid_;                              ///< Group ID.

--- a/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
@@ -25,16 +25,7 @@
 #include <string>
 #include <vector>
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
-{
-
-namespace osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 /// @brief Represents process limits to be applied by setrlimit()
@@ -154,12 +145,6 @@ class IProcess
     virtual OsalReturnType waitForkRunning(IpcCommsP sync, std::chrono::milliseconds timeout) = 0;
 };
 
-}  // namespace osal
-
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // PROCESS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/mock_iprocess.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/mock_iprocess.hpp
@@ -16,7 +16,7 @@
 #include "score/mw/launch_manager/process_group_manager/iprocess.hpp"
 #include <gmock/gmock.h>
 
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 class MockIProcess : public IProcess
@@ -29,6 +29,6 @@ class MockIProcess : public IProcess
     MOCK_METHOD(OsalReturnType, waitForkRunning, (IpcCommsP sync, std::chrono::milliseconds timeout), (override));
 };
 
-}  // namespace score::lcm::internal::osal
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // MOCK_IPROCESS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
@@ -21,10 +21,10 @@
 #include "score/mw/launch_manager/process_group_manager/ialive_monitor_thread.hpp"
 #include "score/mw/launch_manager/process_group_manager/process_group_manager.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm::internal::osal;
+using namespace score::mw::lifecycle::internal::osal;
 
 static std::atomic_bool em_cancelled{false};
 
@@ -41,8 +41,8 @@ void ProcessGroupManager::cancel()
 ProcessGroupManager::ProcessGroupManager(
     std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
     std::shared_ptr<IRecoveryClient> recovery_client,
-    std::unique_ptr<score::lcm::IProcessStateNotifier> process_state_notifier,
-    std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog)
+    std::unique_ptr<score::mw::lifecycle::IProcessStateNotifier> process_state_notifier,
+    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog)
     : configuration_(),
       process_interface_(),
       process_map_(nullptr),
@@ -128,7 +128,7 @@ bool ProcessGroupManager::initialize(const Config& config)
     // Watchdog config may not be available if no watchdog is configured
     if (watchdog_config.has_value())
     {
-        if (!watchdog_->init(watchdog_config.value(), score::lcm::internal::kMainLoopCycleTimeNs))
+        if (!watchdog_->init(watchdog_config.value(), score::mw::lifecycle::internal::kMainLoopCycleTimeNs))
         {
             LM_LOG_ERROR() << "Watchdog initialization failed";
             return false;
@@ -171,11 +171,11 @@ bool ProcessGroupManager::initializeControlClientHandler()
     // The name is removed from the file system after creation, memory
     // is mapped and a pointer stored, the FD is kept open.
     ControlClientChannel::nudgeControlClientHandler_ = nullptr;
-    char shm_name[static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize)];
+    char shm_name[static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize)];
 
     static_cast<void>(snprintf(
         shm_name,
-        static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize),
+        static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize),
         "/_nudge~._.~me_"));  // random name
     int fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0U);
 
@@ -331,7 +331,7 @@ bool ProcessGroupManager::run()
 
             // Wait for a graph-relevant event (activation/deactivation completion or
             // unexpected termination). All Graph state mutations happen here, on the main thread.
-            if (event_queue_->waitForEvents(std::chrono::milliseconds(score::lcm::internal::kMainLoopCycleTimeMs)))
+            if (event_queue_->waitForEvents(std::chrono::milliseconds(score::mw::lifecycle::internal::kMainLoopCycleTimeMs)))
             {
                 processComponentEvents();
             }
@@ -882,4 +882,4 @@ std::shared_ptr<ProcessGroupManager::WorkerQueue> ProcessGroupManager::getWorker
     return worker_jobs_;
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
@@ -39,11 +39,11 @@
 #include "score/mw/launch_manager/recovery_client/recovery_client.hpp"
 #include "score/mw/launch_manager/watchdog/IWatchdogIf.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using ConfigurationType = ConfigurationAdapter;
-using Config = score::mw::launch_manager::configuration::Config;
+using Config = score::mw::lifecycle::configuration::Config;
 
 /// @brief ProcessGroupManager provides the core functionality of LCM.
 /// Software that is deployed to the machine, should be managed through Process Groups.
@@ -77,8 +77,8 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     ProcessGroupManager(
         std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
         std::shared_ptr<IRecoveryClient> recovery_client,
-        std::unique_ptr<score::lcm::IProcessStateNotifier> process_state_notifier,
-        std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog);
+        std::unique_ptr<score::mw::lifecycle::IProcessStateNotifier> process_state_notifier,
+        std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog);
 
     /// @brief Initializes the process group manager.
     /// Loads the flat configuration through ConfigurationManager.
@@ -152,7 +152,7 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     ///          if no more free shared memory, the PosixProcess is not sent.
     /// @param[in]   f_posixProcess   The PosixProcess to be queued
     /// @returns True on success, false for failure (corresponding to kCommunicationError).
-    bool queuePosixProcess(const score::lcm::PosixProcess& f_posixProcess)
+    bool queuePosixProcess(const score::mw::lifecycle::PosixProcess& f_posixProcess)
     {
         return process_state_notifier_->queuePosixProcess(f_posixProcess);
     }
@@ -318,7 +318,7 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     std::shared_ptr<Graph> machine_process_group_{nullptr};
 
     /// @brief Process state notifier object used to send data to PHM
-    std::unique_ptr<score::lcm::IProcessStateNotifier> process_state_notifier_;
+    std::unique_ptr<score::mw::lifecycle::IProcessStateNotifier> process_state_notifier_;
 
     std::unique_ptr<IAliveMonitorThread> alive_monitor_thread_;
 
@@ -330,12 +330,12 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     /// on the main thread, so all Graph state mutations happen from a single thread.
     std::unique_ptr<ComponentEventQueue> event_queue_;
 
-    std::shared_ptr<score::lcm::IRecoveryClient> recovery_client_{};
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recovery_client_{};
 
     /// @brief The watchdog serviced during the main loop. May be nullptr in legacy configuration.
-    std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog_;
+    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog_;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  /// PROCESSGROUPMANAGER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.cpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.cpp
@@ -29,30 +29,29 @@ ProcessStateReceiver::~ProcessStateReceiver() noexcept
 
 score::Result<std::optional<PosixProcess>> ProcessStateReceiver::getNextChangedPosixProcess() noexcept
 {
-    score::lcm::PosixProcess changedProcess;
+    score::mw::lifecycle::PosixProcess changedProcess;
     if (ring_buffer_->getOverflowFlag())
     {
         LM_LOG_ERROR() << "ProcessStateReceiver::getNextChangedPosixProcess: Overflow occurred, "
                           "will be reported as kCommunicationError";
-        return score::Result<std::optional<score::lcm::PosixProcess>>{
+        return score::Result<std::optional<score::mw::lifecycle::PosixProcess>>{
             score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
     }
 
     if (ring_buffer_->empty())
     {
-        return score::Result<std::optional<score::lcm::PosixProcess>>{std::nullopt};
+        return score::Result<std::optional<score::mw::lifecycle::PosixProcess>>{std::nullopt};
     }
 
     auto res = ring_buffer_->tryDequeue(changedProcess);
     if (res)
     {
-        return score::Result<std::optional<score::lcm::PosixProcess>>{changedProcess};
+        return score::Result<std::optional<score::mw::lifecycle::PosixProcess>>{changedProcess};
     }
     else
     {
-        return score::Result<std::optional<score::lcm::PosixProcess>>{
+        return score::Result<std::optional<score::mw::lifecycle::PosixProcess>>{
             score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kGeneralError)};
     }
 }
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.cpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.cpp
@@ -14,10 +14,7 @@
 #include "score/mw/launch_manager/process_state_client/details/process_state_receiver.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 ProcessStateReceiver::ProcessStateReceiver(BufferP ring_buffer) noexcept : ring_buffer_(ring_buffer)
 {

--- a/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.hpp
@@ -17,10 +17,7 @@
 #include "ipc_dropin/ringbuffer.hpp"
 #include "score/mw/launch_manager/process_state_client/iprocess_state_receiver.hpp"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 using BufferP = std::shared_ptr<ipc_dropin::RingBuffer<
@@ -65,8 +62,6 @@ class ProcessStateReceiver final : public IProcessStateReceiver
     BufferP ring_buffer_{};
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // PROCESSSTATERECEIVER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/details/process_state_receiver.hpp
@@ -24,8 +24,8 @@ namespace lcm
 {
 
 using BufferP = std::shared_ptr<ipc_dropin::RingBuffer<
-    static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-    static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>;
+    static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+    static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>;
 
 /// @brief ProcessStateReceiver implementation for handling the information about current state of each Process.
 class ProcessStateReceiver final : public IProcessStateReceiver

--- a/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_notifier.hpp
@@ -37,7 +37,7 @@ class IProcessStateNotifier
 
     /// @brief Construct and return the Process State Receiver instance used to receive process state changes.
     /// @return Process State Receiver instance
-    virtual std::unique_ptr<score::lcm::IProcessStateReceiver> constructReceiver() = 0;
+    virtual std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver> constructReceiver() = 0;
 
     /// @brief Writes via IPC the latests Process State change, so that PHM can be informed about it.
     /// @details the PosixProcess structure should be complete at his moment. That means:
@@ -45,7 +45,7 @@ class IProcessStateNotifier
     ///          if no more free shared memory, the PosixProcess is not sent.
     /// @param[in]   f_posixProcess   The PosixProcess to be queued
     /// @returns True on success, false for failure (corresponding to kCommunicationError).
-    virtual bool queuePosixProcess(const score::lcm::PosixProcess& f_posixProcess) noexcept = 0;
+    virtual bool queuePosixProcess(const score::mw::lifecycle::PosixProcess& f_posixProcess) noexcept = 0;
 };
 
 }  // namespace lcm

--- a/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_notifier.hpp
@@ -16,10 +16,7 @@
 #include "score/mw/launch_manager/process_state_client/iprocess_state_receiver.hpp"
 #include "score/mw/launch_manager/process_state_client/posix_process.hpp"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 ///
@@ -48,8 +45,6 @@ class IProcessStateNotifier
     virtual bool queuePosixProcess(const score::mw::lifecycle::PosixProcess& f_posixProcess) noexcept = 0;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_receiver.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/iprocess_state_receiver.hpp
@@ -20,10 +20,7 @@
 
 #include "score/mw/launch_manager/process_state_client/posix_process.hpp"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 /// @brief IProcessStateReceiver interface for handling the information about each Process current state.
@@ -41,8 +38,6 @@ class IProcessStateReceiver
     virtual score::Result<std::optional<PosixProcess>> getNextChangedPosixProcess() noexcept = 0;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_state_client/posix_process.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/posix_process.hpp
@@ -18,10 +18,7 @@
 #include <cstdint>
 #include <ctime>  // for definition of "timespec"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 /// @brief Represents the state of a modelled process.
@@ -74,8 +71,6 @@ enum class BufferConstants : size_t
     BUFFER_QUEUE_SIZE = 4096UL  // Ringbuffer queue size
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // POSIXPROCESS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_state_client/posix_process.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/posix_process.hpp
@@ -51,7 +51,7 @@ struct PosixProcess
     /// @brief Stores the Modelled Process ID as IdentifierHash.
     /// @details This ID is assigned by using a hash algorithm on the string of the path.
     ///
-    score::lcm::IdentifierHash id;
+    score::mw::lifecycle::IdentifierHash id;
 
     /// @brief Stores the current ProcessState of the posix process.
     /// @details This state is assigned by the Launch Manager whenever the posix process changes it current state.
@@ -60,7 +60,7 @@ struct PosixProcess
 
     /// @brief Stores the ProcessGroupState ID in which the Process is active as IdentifierHash.
     /// @details This ID is assigned by using a hash algorithm on the string of the path.
-    score::lcm::IdentifierHash processGroupStateId;
+    score::mw::lifecycle::IdentifierHash processGroupStateId;
 
     /// @brief Stores the timestamp based on the system clock when storing the new change of this posix process.
     /// @details the timestamp is stored as timespec, since it can deliver precision in nanoseconds.

--- a/score/launch_manager/src/daemon/src/process_state_client/process_state_client_ut.cpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/process_state_client_ut.cpp
@@ -16,10 +16,10 @@
 #include <memory>
 
 using namespace testing;
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
-using score::lcm::ProcessStateReceiver;
-using score::lcm::internal::ProcessStateNotifier;
+using score::mw::lifecycle::ProcessStateReceiver;
+using score::mw::lifecycle::internal::ProcessStateNotifier;
 
 class ProcessStateClient_UT : public ::testing::Test
 {
@@ -56,9 +56,9 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcess_Succeeds)
         "This test verifies that a single PosixProcess can be successfully queued using the "
         "ProcessStateNotifier and retrieved using the ProcessStateReceiver.");
     PosixProcess process1{
-        .id = score::lcm::IdentifierHash("Process1"),
-        .processStateId = score::lcm::ProcessState::kRunning,
-        .processGroupStateId = score::lcm::IdentifierHash("PGState1"),
+        .id = score::mw::lifecycle::IdentifierHash("Process1"),
+        .processStateId = score::mw::lifecycle::ProcessState::kRunning,
+        .processGroupStateId = score::mw::lifecycle::IdentifierHash("PGState1"),
         .systemClockTimestamp = {},
     };
 
@@ -90,9 +90,9 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueMaxNumberOfProcesses_Succe
     for (size_t i = 0; i < static_cast<size_t>(BufferConstants::BUFFER_QUEUE_SIZE); ++i)
     {
         PosixProcess process{
-            .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
-            .processStateId = score::lcm::ProcessState::kRunning,
-            .processGroupStateId = score::lcm::IdentifierHash("PGState" + std::to_string(i)),
+            .id = score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)),
+            .processStateId = score::mw::lifecycle::ProcessState::kRunning,
+            .processGroupStateId = score::mw::lifecycle::IdentifierHash("PGState" + std::to_string(i)),
             .systemClockTimestamp = {},
         };
         bool queued = notifier_->queuePosixProcess(process);
@@ -105,7 +105,7 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueMaxNumberOfProcesses_Succe
         auto result = receiver_->getNextChangedPosixProcess();
         ASSERT_TRUE(result.has_value());
         ASSERT_TRUE(result->has_value());
-        EXPECT_EQ(result->value().id, score::lcm::IdentifierHash("Process" + std::to_string(i)));
+        EXPECT_EQ(result->value().id, score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)));
     }
 
     // Ensure no more processes are queued
@@ -121,9 +121,9 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcessTooMany_Fails)
         "This test verifies that attempting to queue a PosixProcess when the buffer is already at maximum capacity "
         "results in a failure, and that no additional processes can be retrieved from the receiver.");
     PosixProcess process1{
-        .id = score::lcm::IdentifierHash("Process1"),
-        .processStateId = score::lcm::ProcessState::kRunning,
-        .processGroupStateId = score::lcm::IdentifierHash("PGState1"),
+        .id = score::mw::lifecycle::IdentifierHash("Process1"),
+        .processStateId = score::mw::lifecycle::ProcessState::kRunning,
+        .processGroupStateId = score::mw::lifecycle::IdentifierHash("PGState1"),
         .systemClockTimestamp = {},
     };
 
@@ -131,9 +131,9 @@ TEST_F(ProcessStateClient_UT, ProcessStateClient_QueueOneProcessTooMany_Fails)
     for (size_t i = 0; i < static_cast<size_t>(BufferConstants::BUFFER_QUEUE_SIZE); ++i)
     {
         PosixProcess proc{
-            .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
-            .processStateId = score::lcm::ProcessState::kRunning,
-            .processGroupStateId = score::lcm::IdentifierHash("PGState" + std::to_string(i)),
+            .id = score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)),
+            .processStateId = score::mw::lifecycle::ProcessState::kRunning,
+            .processGroupStateId = score::mw::lifecycle::IdentifierHash("PGState" + std::to_string(i)),
             .systemClockTimestamp = {},
         };
         bool queued = notifier_->queuePosixProcess(proc);

--- a/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.cpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.cpp
@@ -15,18 +15,14 @@
 #include "score/mw/launch_manager/common/log.hpp"
 #include "score/mw/launch_manager/process_state_client/details/process_state_receiver.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 ProcessStateNotifier::ProcessStateNotifier() noexcept
 {
     ring_buffer_ = std::make_shared<ipc_dropin::RingBuffer<
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>();
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>();
 
     ring_buffer_->initialize();
 }
@@ -35,7 +31,7 @@ ProcessStateNotifier::~ProcessStateNotifier() noexcept
 {
 }
 
-bool ProcessStateNotifier::queuePosixProcess(const score::lcm::PosixProcess& f_posixProcess) noexcept
+bool ProcessStateNotifier::queuePosixProcess(const score::mw::lifecycle::PosixProcess& f_posixProcess) noexcept
 {
     bool ret = true;
     if (ring_buffer_->tryEnqueue(f_posixProcess))
@@ -50,11 +46,9 @@ bool ProcessStateNotifier::queuePosixProcess(const score::lcm::PosixProcess& f_p
     return ret;
 }
 
-std::unique_ptr<score::lcm::IProcessStateReceiver> ProcessStateNotifier::constructReceiver()
+std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver> ProcessStateNotifier::constructReceiver()
 {
-    return std::make_unique<score::lcm::ProcessStateReceiver>(ring_buffer_);
+    return std::make_unique<score::mw::lifecycle::ProcessStateReceiver>(ring_buffer_);
 }
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.hpp
@@ -17,13 +17,7 @@
 #include "ipc_dropin/ringbuffer.hpp"
 #include "score/mw/launch_manager/process_state_client/iprocess_state_notifier.hpp"
 
-namespace score
-{
-
-namespace lcm
-{
-
-namespace internal
+namespace score::mw::lifecycle::internal
 {
 
 ///
@@ -78,9 +72,5 @@ class ProcessStateNotifier final : public IProcessStateNotifier
         ring_buffer_{};
 };
 
-}  // namespace internal
-
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle::internal
 #endif

--- a/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/process_state_client/process_state_notifier.hpp
@@ -60,7 +60,7 @@ class ProcessStateNotifier final : public IProcessStateNotifier
 
     /// @brief Construct and return the Process State Receiver instance used to receive process state changes.
     /// @return Process State Receiver instance
-    std::unique_ptr<score::lcm::IProcessStateReceiver> constructReceiver() override;
+    std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver> constructReceiver() override;
 
     /// @brief Writes via IPC the latests Process State change, so that PHM can be informed about it.
     /// @details the PosixProcess structure should be complete at his moment. That means:
@@ -68,13 +68,13 @@ class ProcessStateNotifier final : public IProcessStateNotifier
     ///          if no more free shared memory, the PosixProcess is not sent.
     /// @param[in]   f_posixProcess   The PosixProcess to be queued
     /// @returns True on success, false for failure (corresponding to kCommunicationError).
-    bool queuePosixProcess(const score::lcm::PosixProcess& f_posixProcess) noexcept override;
+    bool queuePosixProcess(const score::mw::lifecycle::PosixProcess& f_posixProcess) noexcept override;
 
   private:
     /// @brief ipc_dropin::RingBuffer through which we retrieve process state updates from LCM
     std::shared_ptr<ipc_dropin::RingBuffer<
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>
         ring_buffer_{};
 };
 

--- a/score/launch_manager/src/daemon/src/recovery_client/irecovery_client.h
+++ b/score/launch_manager/src/daemon/src/recovery_client/irecovery_client.h
@@ -16,9 +16,7 @@
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 #include <functional>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 /// @brief The RecoveryClient allows the AliveMonitor component to report supervision failures to the
@@ -27,7 +25,7 @@ namespace lcm
 class IRecoveryClient
 {
   public:
-    using RecoveryRequestCallback = std::function<void(const score::lcm::IdentifierHash&)>;
+    using RecoveryRequestCallback = std::function<void(const score::mw::lifecycle::IdentifierHash&)>;
 
     IRecoveryClient() noexcept = default;
     virtual ~IRecoveryClient() noexcept = default;
@@ -44,9 +42,8 @@ class IRecoveryClient
     /// @details Invokes the registered callback with the provided process identifier.
     /// @param process_identifier The process that requires recovery.
     /// @return true if a callback was registered and invoked, false otherwise.
-    virtual bool sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept = 0;
+    virtual bool sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept = 0;
 };
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
@@ -14,9 +14,7 @@
 
 #include <utility>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 void RecoveryClient::setRecoveryRequestCallback(RecoveryRequestCallback callback) noexcept
@@ -25,7 +23,7 @@ void RecoveryClient::setRecoveryRequestCallback(RecoveryRequestCallback callback
     callback_ = std::move(callback);
 }
 
-bool RecoveryClient::sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept
+bool RecoveryClient::sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept
 {
     std::lock_guard<std::mutex> lock(callback_mutex_);
     if (!callback_)
@@ -35,5 +33,4 @@ bool RecoveryClient::sendRecoveryRequest(const score::lcm::IdentifierHash& proce
     callback_(process_identifier);
     return true;
 }
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client.hpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client.hpp
@@ -17,9 +17,7 @@
 
 #include "score/mw/launch_manager/recovery_client/irecovery_client.h"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 class RecoveryClient final : public IRecoveryClient
@@ -33,13 +31,12 @@ class RecoveryClient final : public IRecoveryClient
     RecoveryClient& operator=(RecoveryClient&&) = delete;
 
     void setRecoveryRequestCallback(RecoveryRequestCallback callback) noexcept override;
-    bool sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept override;
+    bool sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept override;
 
   private:
     mutable std::mutex callback_mutex_;
     RecoveryRequestCallback callback_;
 };
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
@@ -16,9 +16,7 @@
 
 #include "score/mw/launch_manager/recovery_client/recovery_client.hpp"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 class RecoveryClientTest : public ::testing::Test
@@ -103,5 +101,4 @@ TEST_F(RecoveryClientTest, ReRegisteringCallbackReplacesPreviousCallback)
     EXPECT_EQ(callback2_calls, 1U);
 }
 
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -18,14 +18,12 @@
 
 #include <cstdint>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 struct WatchdogConfig;
 }
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 namespace watchdog
 {
@@ -56,7 +54,7 @@ class IWatchdogIf
     /// The main loop cycle time must be strictly less than the minimum watchdog timeout to ensure that
     /// the watchdog timeout cannot expire during an unblocked run of the main loop.
     static_assert(
-        score::lcm::internal::kMainLoopCycleTimeMs < kTimeoutMinMillis,
+        score::mw::lifecycle::internal::kMainLoopCycleTimeMs < kTimeoutMinMillis,
         "Main loop cycle time must be less than the minimum watchdog timeout");
 
     /// @brief Destructor.
@@ -79,7 +77,7 @@ class IWatchdogIf
     /// @return Status of configuration. True if watchdog configuration is valid and has been successfully taken over
     /// by the Watchdog Interface library, false otherwise.
     virtual bool init(
-        const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept = 0;
 
     /// @brief Activate the watchdog.
@@ -137,7 +135,6 @@ class IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
@@ -15,9 +15,7 @@
 
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 namespace watchdog
 {
@@ -28,5 +26,4 @@ std::unique_ptr<IWatchdogIf> createWatchdog()
 }
 
 }  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
@@ -18,9 +18,7 @@
 
 #include <memory>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 namespace watchdog
 {
@@ -30,7 +28,6 @@ namespace watchdog
 std::unique_ptr<IWatchdogIf> createWatchdog();
 
 }  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
@@ -18,9 +18,9 @@
 #include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-using score::lcm::watchdog::createWatchdog;
-using score::lcm::watchdog::IWatchdogIf;
-using score::lcm::watchdog::WatchdogImpl;
+using score::mw::lifecycle::watchdog::createWatchdog;
+using score::mw::lifecycle::watchdog::IWatchdogIf;
+using score::mw::lifecycle::watchdog::WatchdogImpl;
 
 class WatchdogFactoryTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -19,9 +19,7 @@
 #include "score/mw/launch_manager/configuration/config.hpp"
 #include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 namespace watchdog
 {
@@ -55,7 +53,7 @@ WatchdogImpl::WatchdogImpl(score::os::Ioctl& ioctl, score::os::Fcntl& fcntl, sco
 }
 
 bool WatchdogImpl::init(
-    const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+    const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
     std::int64_t cycle_time_ns) noexcept
 {
     bool isSuccess{true};
@@ -453,7 +451,7 @@ bool WatchdogImpl::validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, co
 void WatchdogImpl::waitForever() const noexcept
 {
     // This code cannot be covered in tests, as it blocks execution forever
-    const score::lcm::saf::timers::OsClockInterface clock{};
+    const score::mw::lifecycle::saf::timers::OsClockInterface clock{};
     struct timespec sleeptime = {};
     sleeptime.tv_sec = 1;
     sleeptime.tv_nsec = 0;
@@ -468,5 +466,4 @@ void WatchdogImpl::waitForever() const noexcept
 #endif
 
 }  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -24,9 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace score
-{
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 namespace watchdog
@@ -70,7 +68,7 @@ class WatchdogImpl : public IWatchdogIf
 
     /// @copydoc IWatchdogIf::init()
     bool init(
-        const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept override;
 
     /// @copydoc IWatchdogIf::enable()
@@ -235,7 +233,6 @@ class WatchdogImpl : public IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -32,9 +32,9 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::StrEq;
 
-using score::lcm::watchdog::IWatchdogIf;
-using score::lcm::watchdog::WatchdogImpl;
-using score::mw::launch_manager::configuration::WatchdogConfig;
+using score::mw::lifecycle::watchdog::IWatchdogIf;
+using score::mw::lifecycle::watchdog::WatchdogImpl;
+using score::mw::lifecycle::configuration::WatchdogConfig;
 
 namespace
 {

--- a/score/launch_manager/src/execution_error_event.h
+++ b/score/launch_manager/src/execution_error_event.h
@@ -18,10 +18,7 @@
 
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-namespace score
-{
-
-namespace lcm
+namespace score::mw::lifecycle
 {
 
 /// @brief Represents the execution error.
@@ -41,8 +38,6 @@ struct ExecutionErrorEvent final
     IdentifierHash processGroup;
 };
 
-}  // namespace lcm
-
-}  // namespace score
+}  // namespace score::mw::lifecycle
 
 #endif  // SCORE_LCM_EXECUTION_ERROR_EVENT_H_

--- a/score/launch_manager/src/lifecycle_client/src/details/report_running_impl.cpp
+++ b/score/launch_manager/src/lifecycle_client/src/details/report_running_impl.cpp
@@ -25,7 +25,7 @@
 #include "score/mw/lifecycle/execution_error.h"
 #include "score/mw/lifecycle/lifecycle_client/details/report_running_impl.hpp"
 
-using namespace score::lcm::internal::osal;
+using namespace score::mw::lifecycle::internal::osal;
 
 namespace score::mw::lifecycle
 {
@@ -103,7 +103,7 @@ score::Result<std::monostate> ReportRunningImpl::reportKRunningtoDaemon() const 
         return comms_error;
     }
 
-    if (sync->reply_sync_.timedWait(score::lcm::internal::kMaxRunningDelay) == OsalReturnType::kFail)
+    if (sync->reply_sync_.timedWait(score::mw::lifecycle::internal::kMaxRunningDelay) == OsalReturnType::kFail)
     {
         LM_LOG_ERROR() << "[Lifecycle Client] Launch Manager failed to acknowledge kRunning report.";
 


### PR DESCRIPTION
## Description

Removed all `using namespace` declarations from header files and qualified the affected symbols explicitly.

## Related ticket

closes #411 (improvement ticket)