### PR TITLE
Normalise namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 Checks: ' -*, bugprone-*, cert-*, clang-analyzer-core.*, clang-analyzer-cplusplus.*, clang-analyzer-security.*, cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast, hicpp-* '
 WarningsAsErrors: 'bugprone-*,cert-*,clang-analyzer-*,hicpp-*'
 CheckOptions:
-  - key: 'hicpp-special-member-functions.AllowSoleDefaultDtor'
-  - value: 1 # This allows us to make interfaces that have virtual destructor without the other functions
+  - key: hicpp-special-member-functions.AllowSoleDefaultDtor
+    value: 1 # This allows us to make interfaces that have virtual destructor without the other functions

--- a/score/launch_manager/src/alive/src/details/AliveImpl.cpp
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.cpp
@@ -34,7 +34,8 @@ AliveImpl::AliveImpl(
 
 void AliveImpl::ReportCheckpoint(std::uint32_t f_checkpointId) const noexcept(true)
 {
-    (void)ipcClient->sendEmplace(score::mw::lifecycle::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
+    (void)ipcClient->sendEmplace(
+        score::mw::lifecycle::internal::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
 }
 
 void AliveImpl::connectToPhmDaemon(void) noexcept(false)

--- a/score/launch_manager/src/alive/src/details/AliveImpl.cpp
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.cpp
@@ -34,7 +34,7 @@ AliveImpl::AliveImpl(
 
 void AliveImpl::ReportCheckpoint(std::uint32_t f_checkpointId) const noexcept(true)
 {
-    (void)ipcClient->sendEmplace(score::lcm::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
+    (void)ipcClient->sendEmplace(score::mw::lifecycle::saf::timers::OsClock::getMonotonicSystemClock(), f_checkpointId);
 }
 
 void AliveImpl::connectToPhmDaemon(void) noexcept(false)

--- a/score/launch_manager/src/alive/src/details/AliveImpl.h
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.h
@@ -32,10 +32,10 @@ class AliveImpl
 {
   public:
     /// @brief The element that is sent via IPC
-    using CheckpointBufferElement = score::mw::lifecycle::saf::ifappl::CheckpointBufferElement;
+    using CheckpointBufferElement = score::mw::lifecycle::internal::saf::ifappl::CheckpointBufferElement;
     /// @brief The IPC Connection type
-    using CheckpointIpcClient = score::mw::lifecycle::saf::ipc::
-        IpcClient<CheckpointBufferElement, score::mw::lifecycle::saf::ifappl::k_maxCheckpointBufferElements>;
+    using CheckpointIpcClient = score::mw::lifecycle::internal::saf::ipc::
+        IpcClient<CheckpointBufferElement, score::mw::lifecycle::internal::saf::ifappl::k_maxCheckpointBufferElements>;
 
     /// @brief Non-parametric constructor is not supported
     AliveImpl() = delete;

--- a/score/launch_manager/src/alive/src/details/AliveImpl.h
+++ b/score/launch_manager/src/alive/src/details/AliveImpl.h
@@ -32,10 +32,10 @@ class AliveImpl
 {
   public:
     /// @brief The element that is sent via IPC
-    using CheckpointBufferElement = score::lcm::saf::ifappl::CheckpointBufferElement;
+    using CheckpointBufferElement = score::mw::lifecycle::saf::ifappl::CheckpointBufferElement;
     /// @brief The IPC Connection type
-    using CheckpointIpcClient = score::lcm::saf::ipc::
-        IpcClient<CheckpointBufferElement, score::lcm::saf::ifappl::k_maxCheckpointBufferElements>;
+    using CheckpointIpcClient = score::mw::lifecycle::saf::ipc::
+        IpcClient<CheckpointBufferElement, score::mw::lifecycle::saf::ifappl::k_maxCheckpointBufferElements>;
 
     /// @brief Non-parametric constructor is not supported
     AliveImpl() = delete;

--- a/score/launch_manager/src/control_client/src/control_client.cpp
+++ b/score/launch_manager/src/control_client/src/control_client.cpp
@@ -36,8 +36,8 @@ score::concurrency::InterruptibleFuture<void> GetErrorFuture(ExecErrc errType) n
 
 ControlClient::ControlClient() noexcept
 {
-    static std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback =
-        []([[maybe_unused]] const score::lcm::ExecutionErrorEvent& event) {
+    static std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback =
+        []([[maybe_unused]] const score::mw::lifecycle::ExecutionErrorEvent& event) {
         };
 
     try
@@ -70,8 +70,8 @@ score::concurrency::InterruptibleFuture<void> ControlClient::ActivateRunTarget(
 
     if (control_client_impl_ != nullptr)
     {
-        static score::lcm::IdentifierHash pg_name{"MainPG"};
-        score::lcm::IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
+        static score::mw::lifecycle::IdentifierHash pg_name{"MainPG"};
+        score::mw::lifecycle::IdentifierHash pg_state{"MainPG/" + std::string(runTargetName)};
         retVal_ = control_client_impl_->SetState(pg_name, pg_state);
     }
     else

--- a/score/launch_manager/src/control_client/src/details/control_client_impl.cpp
+++ b/score/launch_manager/src/control_client/src/details/control_client_impl.cpp
@@ -30,15 +30,16 @@
 // This approach is used to avoid using switch-case statements
 // RULECHECKER_comment(1, 2, check_static_object_dynamic_initialization, "Map doesn't rely on any other static so this
 // is fine", false)
-static std::map<score::lcm::internal::ControlClientCode, score::mw::lifecycle::ExecErrc> scErrorMap = {
-    {score::lcm::internal::ControlClientCode::kSetStateInvalidArguments,
+static std::map<score::mw::lifecycle::internal::ControlClientCode, score::mw::lifecycle::ExecErrc> scErrorMap = {
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateInvalidArguments,
      score::mw::lifecycle::ExecErrc::kInvalidArguments},
-    {score::lcm::internal::ControlClientCode::kSetStateCancelled, score::mw::lifecycle::ExecErrc::kCancelled},
-    {score::lcm::internal::ControlClientCode::kSetStateFailed, score::mw::lifecycle::ExecErrc::kFailed},
-    {score::lcm::internal::ControlClientCode::kSetStateAlreadyInState, score::mw::lifecycle::ExecErrc::kAlreadyInState},
-    {score::lcm::internal::ControlClientCode::kSetStateTransitionToSameState,
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateCancelled, score::mw::lifecycle::ExecErrc::kCancelled},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateFailed, score::mw::lifecycle::ExecErrc::kFailed},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateAlreadyInState,
+     score::mw::lifecycle::ExecErrc::kAlreadyInState},
+    {score::mw::lifecycle::internal::ControlClientCode::kSetStateTransitionToSameState,
      score::mw::lifecycle::ExecErrc::kInTransitionToSameState},
-    {score::lcm::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter,
+    {score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter,
      score::mw::lifecycle::ExecErrc::kFailedUnexpectedTerminationOnEnter}};
 
 namespace score::mw::lifecycle
@@ -59,7 +60,7 @@ bool ControlClientImpl::instance_created_{false};
 std::mutex ControlClientImpl::instance_creation_mutex_{};
 
 ControlClientImpl::ControlClientImpl(
-    std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback) noexcept
+    std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback) noexcept
     : undefined_state_callback_{undefinedStateCallback},
       control_client_requests_{},
       ipc_request_semaphore_{},
@@ -80,10 +81,10 @@ ControlClientImpl::ControlClientImpl(
     }
 
     struct stat stats;
-    const auto fstat_ret = fstat(score::lcm::internal::osal::IpcCommsSync::sync_fd, &stats);
+    const auto fstat_ret = fstat(score::mw::lifecycle::internal::osal::IpcCommsSync::sync_fd, &stats);
     // Check size we have access of to avoid a crash if fd is not pointing to correct data
-    const auto needed_size =
-        sizeof(score::lcm::internal::osal::IpcCommsSync) + sizeof(score::lcm::internal::ControlClientChannel);
+    const auto needed_size = sizeof(score::mw::lifecycle::internal::osal::IpcCommsSync) +
+                             sizeof(score::mw::lifecycle::internal::ControlClientChannel);
     if (fstat_ret == -1 || stats.st_size != static_cast<off_t>(needed_size))
     {
         LM_LOG_ERROR() << "Control client channel at sync_fd is not valid!";
@@ -101,11 +102,11 @@ ControlClientImpl::ControlClientImpl(
         control_client_requests_[i].initial_machine_state_transition_request_ = false;
     }
 
-    ipc_channel_ = score::lcm::internal::ControlClientChannel::initializeControlClientChannel();
+    ipc_channel_ = score::mw::lifecycle::internal::ControlClientChannel::initializeControlClientChannel();
 
     const auto init_result = ipc_request_semaphore_.init(1U, false);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-        score::lcm::internal::osal::OsalReturnType::kSuccess == init_result,
+        score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess == init_result,
         "ControlClient semaphore initialization failed");
     ipc_response_thread_ = std::make_unique<std::thread>(&ControlClientImpl::run, this);
 }
@@ -128,7 +129,7 @@ void ControlClientImpl::run()
 {
     // creating a instance called msg for ControlClientMessage that will handle all the communication between LCM and
     // ControlClientImpl
-    score::lcm::internal::ControlClientMessage msg;
+    score::mw::lifecycle::internal::ControlClientMessage msg;
 
     // This lambda function will be used to set the error of the promise.
     // This lamdba funcitons are used to avoid code duplication.
@@ -146,7 +147,7 @@ void ControlClientImpl::run()
 
     // This lambda function will be used to set the error of the promise at unexpected termination.
     auto funcUtermination = [&]() {
-        score::lcm::ExecutionErrorEvent tmp{
+        score::mw::lifecycle::ExecutionErrorEvent tmp{
             msg.execution_error_code_,           // executionError
             msg.process_group_state_.pg_name_};  // processGroup
 
@@ -186,7 +187,7 @@ void ControlClientImpl::run()
 
     // This lambda function will be used to set the error of the promise at default error for ControlClientCode kNotSet.
     std::function<void()> funcDefaultError = [&]() {
-        if (msg.request_or_response_ != score::lcm::internal::ControlClientCode::kNotSet)
+        if (msg.request_or_response_ != score::mw::lifecycle::internal::ControlClientCode::kNotSet)
         {
             LM_LOG_WARN() << "ControlClient error. Undefined message from Launch Manager:"
                           << static_cast<int>(msg.request_or_response_);
@@ -203,52 +204,52 @@ void ControlClientImpl::run()
             {
                 switch (msg.request_or_response_)
                 {
-                    case score::lcm::internal::ControlClientCode::kSetStateInvalidArguments:
-                    case score::lcm::internal::ControlClientCode::kSetStateCancelled:
-                    case score::lcm::internal::ControlClientCode::kSetStateFailed:
-                    case score::lcm::internal::ControlClientCode::kSetStateAlreadyInState:
-                    case score::lcm::internal::ControlClientCode::kSetStateTransitionToSameState:
-                    case score::lcm::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateInvalidArguments:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateCancelled:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateFailed:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateAlreadyInState:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateTransitionToSameState:
+                    case score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTerminationOnEnter:
                         funcSetError();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kSetStateSuccess:
+                    case score::mw::lifecycle::internal::ControlClientCode::kSetStateSuccess:
                         funcSetValue();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kFailedUnexpectedTermination:
+                    case score::mw::lifecycle::internal::ControlClientCode::kFailedUnexpectedTermination:
                         funcUtermination();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateNotSet:
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateFailed:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateNotSet:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateFailed:
                         funcMcStateWrong();
                         break;
 
-                    case score::lcm::internal::ControlClientCode::kInitialMachineStateSuccess:
+                    case score::mw::lifecycle::internal::ControlClientCode::kInitialMachineStateSuccess:
                         funcMcStateSuccess();
                         break;
 
                     default:
-                        // score::lcm::internal::ControlClientCode::kNotSet is just an initialization value
+                        // score::mw::lifecycle::internal::ControlClientCode::kNotSet is just an initialization value
                         // not an error
                         funcDefaultError();
                         break;
                 }
             }
 
-            std::this_thread::sleep_for(score::lcm::internal::kControlClientBgThreadSleepTime);
+            std::this_thread::sleep_for(score::mw::lifecycle::internal::kControlClientBgThreadSleepTime);
         }
     }
 }
 
 score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
-    score::lcm::internal::ControlClientMessage& msg) noexcept
+    score::mw::lifecycle::internal::ControlClientMessage& msg) noexcept
 {
     score::concurrency::InterruptibleFuture<void> retVal_{};
 
-    if (score::lcm::internal::osal::OsalReturnType::kSuccess ==
-        ipc_request_semaphore_.timedWait(score::lcm::internal::kControlClientMaxIpcDelay))
+    if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess ==
+        ipc_request_semaphore_.timedWait(score::mw::lifecycle::internal::kControlClientMaxIpcDelay))
     {
         // first we need to check if we have empty space in control_client_requests_ array
         uint16_t i = 0U;
@@ -268,7 +269,8 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
             // 1) claim the slot and create a fresh promise for this request
             control_client_requests_[i].promise_ = score::concurrency::InterruptiblePromise<void>{};
 
-            if (score::lcm::internal::ControlClientCode::kGetInitialMachineStateRequest == msg.request_or_response_)
+            if (score::mw::lifecycle::internal::ControlClientCode::kGetInitialMachineStateRequest ==
+                msg.request_or_response_)
             {
                 // the GetInitialMachineStateTransitionResult request is a bit special
                 // and will need special treatment in bg thread servicing response_ link
@@ -300,7 +302,7 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
 
         // we definitely shouldn't forget to release semaphore
         const auto post_result = ipc_request_semaphore_.post();
-        if (score::lcm::internal::osal::OsalReturnType::kSuccess != post_result)
+        if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess != post_result)
         {
             // Invalid semaphore usage is a logic error and should be asserted.
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
@@ -326,16 +328,16 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::SendIpcMessage(
 }
 
 score::concurrency::InterruptibleFuture<void> ControlClientImpl::SetState(
-    const score::lcm::IdentifierHash& pg_name,
-    const score::lcm::IdentifierHash& pg_state) noexcept
+    const score::mw::lifecycle::IdentifierHash& pg_name,
+    const score::mw::lifecycle::IdentifierHash& pg_state) noexcept
 {
     score::concurrency::InterruptibleFuture<void> retVal_{};
 
     if (nullptr != ipc_channel_)
     {
-        score::lcm::internal::ControlClientMessage msg;
+        score::mw::lifecycle::internal::ControlClientMessage msg;
 
-        msg.request_or_response_ = score::lcm::internal::ControlClientCode::kSetStateRequest;
+        msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kSetStateRequest;
         msg.process_group_state_.pg_name_ = pg_name;
         msg.process_group_state_.pg_state_name_ = pg_state;
 
@@ -355,9 +357,9 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::GetInitialMachi
 
     if (nullptr != ipc_channel_)
     {
-        score::lcm::internal::ControlClientMessage msg;
+        score::mw::lifecycle::internal::ControlClientMessage msg;
 
-        msg.request_or_response_ = score::lcm::internal::ControlClientCode::kGetInitialMachineStateRequest;
+        msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kGetInitialMachineStateRequest;
         // pg_name_ is not used by this request
         // pg_state_name_ is not used by this request
 
@@ -371,23 +373,23 @@ score::concurrency::InterruptibleFuture<void> ControlClientImpl::GetInitialMachi
     return retVal_;
 }
 
-score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionError(
-    const score::lcm::IdentifierHash& processGroup) noexcept
+score::Result<score::mw::lifecycle::ExecutionErrorEvent> ControlClientImpl::GetExecutionError(
+    const score::mw::lifecycle::IdentifierHash& processGroup) noexcept
 {
     // default error (just in case)
-    score::Result<score::lcm::ExecutionErrorEvent> retVal_{
+    score::Result<score::mw::lifecycle::ExecutionErrorEvent> retVal_{
         score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
 
     if (nullptr != ipc_channel_)
     {
-        if (score::lcm::internal::osal::OsalReturnType::kSuccess ==
-            ipc_request_semaphore_.timedWait(score::lcm::internal::kControlClientMaxIpcDelay))
+        if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess ==
+            ipc_request_semaphore_.timedWait(score::mw::lifecycle::internal::kControlClientMaxIpcDelay))
         {
             // 1) prepare message for LCM
-            score::lcm::internal::ControlClientMessage msg;
+            score::mw::lifecycle::internal::ControlClientMessage msg;
 
             // future_id_ is not used by this request
-            msg.request_or_response_ = score::lcm::internal::ControlClientCode::kGetExecutionErrorRequest;
+            msg.request_or_response_ = score::mw::lifecycle::internal::ControlClientCode::kGetExecutionErrorRequest;
             msg.process_group_state_.pg_name_ = processGroup;
             // pg_state_name_ is not used by this request
 
@@ -398,14 +400,14 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
             switch (msg.request_or_response_)
             {
                 // GetExecutionError
-                case score::lcm::internal::ControlClientCode::kExecutionErrorInvalidArguments:
-                case score::lcm::internal::ControlClientCode::kExecutionErrorRequestFailed:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorInvalidArguments:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorRequestFailed:
                     retVal_ = score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kFailed);
                     break;
 
-                case score::lcm::internal::ControlClientCode::kExecutionErrorRequestSuccess:
+                case score::mw::lifecycle::internal::ControlClientCode::kExecutionErrorRequestSuccess:
                 {
-                    score::lcm::ExecutionErrorEvent tmp{
+                    score::mw::lifecycle::ExecutionErrorEvent tmp{
                         msg.execution_error_code_,           // executionError
                         msg.process_group_state_.pg_name_};  // processGroup
                     retVal_.emplace(std::move(tmp));
@@ -421,7 +423,7 @@ score::Result<score::lcm::ExecutionErrorEvent> ControlClientImpl::GetExecutionEr
 
             // we definitely shouldn't forget to release semaphore
             const auto post_result = ipc_request_semaphore_.post();
-            if (score::lcm::internal::osal::OsalReturnType::kSuccess != post_result)
+            if (score::mw::lifecycle::internal::osal::OsalReturnType::kSuccess != post_result)
             {
                 // Invalid semaphore usage is a logic error and should be asserted.
                 SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(

--- a/score/launch_manager/src/control_client/src/details/control_client_impl.hpp
+++ b/score/launch_manager/src/control_client/src/details/control_client_impl.hpp
@@ -77,7 +77,8 @@ class ControlClientImpl final
   public:
     ControlClientImpl() = delete;
 
-    ControlClientImpl(std::function<void(const score::lcm::ExecutionErrorEvent&)> undefinedStateCallback) noexcept;
+    ControlClientImpl(
+        std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefinedStateCallback) noexcept;
 
     // this class is not movable or copyable by definition
     ControlClientImpl(const ControlClientImpl&) = delete;
@@ -117,8 +118,8 @@ class ControlClientImpl final
     /// (e.g. Off state for MainPG)
     /// @error score::mw::lifecycle::ExecErrc::kGeneralError if any other error occurs.
     score::concurrency::InterruptibleFuture<void> SetState(
-        const score::lcm::IdentifierHash& pg_name,
-        const score::lcm::IdentifierHash& pg_state) noexcept;
+        const score::mw::lifecycle::IdentifierHash& pg_name,
+        const score::mw::lifecycle::IdentifierHash& pg_state) noexcept;
 
     /// @brief Method to retrieve result of Machine State initial transition to Startup state.
     ///
@@ -146,8 +147,8 @@ class ControlClientImpl final
     /// State.
     /// @error score::mw::lifecycle::ExecErrc::kCommunicationError if ControlClient can't communicate with Launch
     /// Manager (e.g. IPC link is down)
-    score::Result<score::lcm::ExecutionErrorEvent> GetExecutionError(
-        const score::lcm::IdentifierHash& processGroup) noexcept;
+    score::Result<score::mw::lifecycle::ExecutionErrorEvent> GetExecutionError(
+        const score::mw::lifecycle::IdentifierHash& processGroup) noexcept;
 
     ~ControlClientImpl() noexcept;
 
@@ -161,7 +162,7 @@ class ControlClientImpl final
     static std::mutex instance_creation_mutex_;
 
     /// @brief callback that ControlClient instance ask us to invoke when there is a problem with PG
-    std::function<void(const score::lcm::ExecutionErrorEvent&)> undefined_state_callback_;
+    std::function<void(const score::mw::lifecycle::ExecutionErrorEvent&)> undefined_state_callback_;
 
     /// @brief Array of active requests, that wait for completion from LCM side.
     /// When a request has been send to LCM and the answer is not immediately available,
@@ -170,7 +171,7 @@ class ControlClientImpl final
     /// answer arrives from LCM.
     std::array<
         ControlClientRequestInfo,
-        static_cast<uint16_t>(score::lcm::internal::ControlClientLimits::kControlClientMaxRequests)>
+        static_cast<uint16_t>(score::mw::lifecycle::internal::ControlClientLimits::kControlClientMaxRequests)>
         control_client_requests_;
 
     /// @brief Semaphore used to protect access to the request_ link of ControlClientChannel,
@@ -180,7 +181,7 @@ class ControlClientImpl final
     /// Please note that synchronization for control_client_requests_ is only needed, when we are booking a slot
     /// inside this array. When we are releasing a slot inside this array, this can be done without
     /// ipc_request_semaphore_ protection.
-    score::lcm::internal::osal::Semaphore ipc_request_semaphore_;
+    score::mw::lifecycle::internal::osal::Semaphore ipc_request_semaphore_;
 
     /// @brief Thread used for monitoring response_ link of ControlClientChannel.
     /// Asynchronous nature of ControlClient API means responses to ControlClient requests, will arrive at
@@ -202,7 +203,7 @@ class ControlClientImpl final
 
     /// @brief Handle to the real IPC communication channel with LCM
     /// This handle is used to perform low level communication with LCM.
-    score::lcm::internal::ControlClientChannelP ipc_channel_;
+    score::mw::lifecycle::internal::ControlClientChannelP ipc_channel_;
 
     /// @brief Helper method to send a message to LCM, through IPC link (aka request_ link).
     ///
@@ -225,7 +226,7 @@ class ControlClientImpl final
     ///
     /// @threadsafety{thread-safe}
     score::concurrency::InterruptibleFuture<void> SendIpcMessage(
-        score::lcm::internal::ControlClientMessage& msg) noexcept;
+        score::mw::lifecycle::internal::ControlClientMessage& msg) noexcept;
 };
 
 }  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal::alive
 namespace
 {
 
-using ApplicationType = score::mw::lifecycle::configuration::ApplicationType;
+using ApplicationType = score::mw::lifecycle::internal::configuration::ApplicationType;
 
 bool isSupervisedType(ApplicationType app_type)
 {
@@ -32,7 +32,7 @@ bool isSupervisedType(ApplicationType app_type)
 
 }  // namespace
 
-AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config)
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::internal::configuration::Config& config)
 {
     AliveMonitorConfig result{};
     result.evaluation_cycle_ms = config.aliveSupervision().evaluation_cycle_ms;

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal::alive
 namespace
 {
 
-using ApplicationType = score::mw::launch_manager::configuration::ApplicationType;
+using ApplicationType = score::mw::lifecycle::configuration::ApplicationType;
 
 bool isSupervisedType(ApplicationType app_type)
 {
@@ -32,7 +32,7 @@ bool isSupervisedType(ApplicationType app_type)
 
 }  // namespace
 
-AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config)
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config)
 {
     AliveMonitorConfig result{};
     result.evaluation_cycle_ms = config.aliveSupervision().evaluation_cycle_ms;

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
@@ -35,7 +35,7 @@ struct SupervisedComponentConfig
     /// @brief Component short name.
     std::string name;
     /// @brief Alive-supervision parameters.
-    std::optional<score::mw::launch_manager::configuration::ComponentAliveSupervision> alive_supervision;
+    std::optional<score::mw::lifecycle::configuration::ComponentAliveSupervision> alive_supervision;
     /// @brief Uid the component runs as.
     uid_t uid{};
 };
@@ -51,7 +51,7 @@ struct AliveMonitorConfig
 
 /// @brief Returns a copy of alive-monitor-relevant configuration.
 /// @return AliveMonitor configuration
-AliveMonitorConfig aliveMonitorConfig(const score::mw::launch_manager::configuration::Config& config);
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config);
 
 }  // namespace score::mw::lifecycle::internal::alive
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig.hpp
@@ -35,7 +35,7 @@ struct SupervisedComponentConfig
     /// @brief Component short name.
     std::string name;
     /// @brief Alive-supervision parameters.
-    std::optional<score::mw::lifecycle::configuration::ComponentAliveSupervision> alive_supervision;
+    std::optional<score::mw::lifecycle::internal::configuration::ComponentAliveSupervision> alive_supervision;
     /// @brief Uid the component runs as.
     uid_t uid{};
 };
@@ -51,7 +51,7 @@ struct AliveMonitorConfig
 
 /// @brief Returns a copy of alive-monitor-relevant configuration.
 /// @return AliveMonitor configuration
-AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::configuration::Config& config);
+AliveMonitorConfig aliveMonitorConfig(const score::mw::lifecycle::internal::configuration::Config& config);
 
 }  // namespace score::mw::lifecycle::internal::alive
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/AliveMonitorConfig_UT.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal::alive
 namespace
 {
 
-namespace cfg = score::mw::launch_manager::configuration;
+namespace cfg = configuration;
 
 cfg::ComponentConfig makeComponent(
     const std::string& name,

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -239,7 +239,7 @@ class FixedSizeVector
 };
 }  // namespace common
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/FixedSizeVector.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -239,7 +239,7 @@ class FixedSizeVector
 };
 }  // namespace common
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -125,7 +125,7 @@ class LockedVector final : private FixedSizeVector<Type>
 
 }  // namespace common
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/LockedVector.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -125,7 +125,7 @@ class LockedVector final : private FixedSizeVector<Type>
 
 }  // namespace common
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -132,7 +132,7 @@ class Observable
 
 }  // namespace common
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/Observer.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -132,7 +132,7 @@ class Observable
 
 }  // namespace common
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -75,7 +75,7 @@ class TimeSortingBuffer
     possible to classify cheap_to_copy or expensive_to_copy without referring original object.", true_no_defect) */
     bool push(
         const TimeSortedElementType& f_element_r,
-        const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp)
+        const score::mw::lifecycle::internal::saf::timers::NanoSecondType f_timestamp)
     {
         bool isSuccess{false};
         SortChainElement newElement{nullptr, nullptr, f_element_r, f_timestamp};
@@ -140,7 +140,8 @@ class TimeSortingBuffer
             nullptr};                       // Pointer to previous element, null pointer means first element (oldest)
         SortChainElement* next_p{nullptr};  // Pointer to next element, null pointer means last element (latest)
         TimeSortedElementType element{};    // Element to be sorted
-        score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  // Timestamp used for sorting the elements
+        score::mw::lifecycle::internal::saf::timers::NanoSecondType timestamp{
+            0U};  // Timestamp used for sorting the elements
     };
 
     /// Sort elements
@@ -231,7 +232,7 @@ class TimeSortingBuffer
 
 }  // namespace common
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/common/TimeSortingBuffer.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -73,7 +73,9 @@ class TimeSortingBuffer
     /// @return                     Success of push (true) sufficient space in buffer was available
     /* RULECHECKER_comment(0, 3, check_cheap_to_copy_in_parameter, "For template argument f_element_r, it is not \
     possible to classify cheap_to_copy or expensive_to_copy without referring original object.", true_no_defect) */
-    bool push(const TimeSortedElementType& f_element_r, const score::lcm::saf::timers::NanoSecondType f_timestamp)
+    bool push(
+        const TimeSortedElementType& f_element_r,
+        const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp)
     {
         bool isSuccess{false};
         SortChainElement newElement{nullptr, nullptr, f_element_r, f_timestamp};
@@ -138,7 +140,7 @@ class TimeSortingBuffer
             nullptr};                       // Pointer to previous element, null pointer means first element (oldest)
         SortChainElement* next_p{nullptr};  // Pointer to next element, null pointer means last element (latest)
         TimeSortedElementType element{};    // Element to be sorted
-        score::lcm::saf::timers::NanoSecondType timestamp{0U};  // Timestamp used for sorting the elements
+        score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  // Timestamp used for sorting the elements
     };
 
     /// Sort elements
@@ -229,7 +231,7 @@ class TimeSortingBuffer
 
 }  // namespace common
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -18,7 +18,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
 
-namespace score::mw::lifecycle::saf::daemon
+namespace score::mw::lifecycle::internal::saf::daemon
 {
 
 AliveMonitorImpl::AliveMonitorImpl(
@@ -72,4 +72,4 @@ bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept
     return m_daemon->startCyclicExec(cancel_thread);
 }
 
-}  // namespace score::mw::lifecycle::saf::daemon
+}  // namespace score::mw::lifecycle::internal::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -18,13 +18,10 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+
+
+
+namespace score::lcm::saf::daemon
 {
 
 AliveMonitorImpl::AliveMonitorImpl(
@@ -78,7 +75,7 @@ bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept
     return m_daemon->startCyclicExec(cancel_thread);
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::daemon
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.cpp
@@ -18,10 +18,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/daemon/AliveMonitorImpl.hpp"
 
-
-
-
-namespace score::lcm::saf::daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 AliveMonitorImpl::AliveMonitorImpl(
@@ -75,7 +72,4 @@ bool AliveMonitorImpl::run(std::atomic_bool& cancel_thread) noexcept
     return m_daemon->startCyclicExec(cancel_thread);
 }
 
-} // namespace score::lcm::saf::daemon
-
-
-
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 class IRecoveryClient;
@@ -33,10 +33,10 @@ namespace saf
 namespace daemon
 {
 
-using SptrIRecoveryClient = std::shared_ptr<score::lcm::IRecoveryClient>;
-using UptrISupervisionControlReceiver = std::unique_ptr<score::lcm::ISupervisionControlReceiver>;
-using UptrPhmDaemon = std::unique_ptr<score::lcm::saf::daemon::PhmDaemon>;
-using OsClock = score::lcm::saf::timers::OsClockInterface;
+using SptrIRecoveryClient = std::shared_ptr<score::mw::lifecycle::IRecoveryClient>;
+using UptrISupervisionControlReceiver = std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver>;
+using UptrPhmDaemon = std::unique_ptr<score::mw::lifecycle::saf::daemon::PhmDaemon>;
+using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
 using Config = score::mw::launch_manager::configuration::Config;
 using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
@@ -62,7 +62,7 @@ class AliveMonitorImpl : public IAliveMonitor
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -37,7 +37,7 @@ using SptrIRecoveryClient = std::shared_ptr<score::mw::lifecycle::IRecoveryClien
 using UptrISupervisionControlReceiver = std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver>;
 using UptrPhmDaemon = std::unique_ptr<score::mw::lifecycle::saf::daemon::PhmDaemon>;
 using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
-using Config = score::mw::launch_manager::configuration::Config;
+using Config = score::mw::lifecycle::configuration::Config;
 using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
 class AliveMonitorImpl : public IAliveMonitor

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/AliveMonitorImpl.hpp
@@ -27,6 +27,9 @@ namespace mw::lifecycle
 
 class IRecoveryClient;
 
+namespace internal
+{
+
 namespace saf
 {
 
@@ -35,9 +38,9 @@ namespace daemon
 
 using SptrIRecoveryClient = std::shared_ptr<score::mw::lifecycle::IRecoveryClient>;
 using UptrISupervisionControlReceiver = std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver>;
-using UptrPhmDaemon = std::unique_ptr<score::mw::lifecycle::saf::daemon::PhmDaemon>;
-using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
-using Config = score::mw::lifecycle::configuration::Config;
+using UptrPhmDaemon = std::unique_ptr<score::mw::lifecycle::internal::saf::daemon::PhmDaemon>;
+using OsClock = score::mw::lifecycle::internal::saf::timers::OsClockInterface;
+using Config = score::mw::lifecycle::internal::configuration::Config;
 using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
 class AliveMonitorImpl : public IAliveMonitor
@@ -62,6 +65,7 @@ class AliveMonitorImpl : public IAliveMonitor
 
 }  // namespace daemon
 }  // namespace saf
+}  // namespace internal
 }  // namespace mw::lifecycle
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
@@ -19,7 +19,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -43,6 +43,6 @@ class IAliveMonitor
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/IAliveMonitor.hpp
@@ -19,7 +19,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -43,6 +43,6 @@ class IAliveMonitor
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
@@ -18,10 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-
-
-
-namespace score::lcm::saf::daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 /* RULECHECKER_comment(0, 6, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const ref",
@@ -99,7 +96,4 @@ bool PhmDaemon::construct(const AliveMonitorConfig& config, const SupervisionBuf
     return isSuccess;
 }
 
-} // namespace score::lcm::saf::daemon
-
-
-
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
@@ -18,13 +18,10 @@
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+
+
+
+namespace score::lcm::saf::daemon
 {
 
 /* RULECHECKER_comment(0, 6, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const ref",
@@ -102,7 +99,7 @@ bool PhmDaemon::construct(const AliveMonitorConfig& config, const SupervisionBuf
     return isSuccess;
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::daemon
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.cpp
@@ -18,7 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score::mw::lifecycle::saf::daemon
+namespace score::mw::lifecycle::internal::saf::daemon
 {
 
 /* RULECHECKER_comment(0, 6, check_expensive_to_copy_in_parameter, "Move only types cannot be passed by const ref",
@@ -96,4 +96,4 @@ bool PhmDaemon::construct(const AliveMonitorConfig& config, const SupervisionBuf
     return isSuccess;
 }
 
-}  // namespace score::mw::lifecycle::saf::daemon
+}  // namespace score::mw::lifecycle::internal::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -29,7 +29,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -52,14 +52,14 @@ enum class EInitCode : std::int8_t
 class PhmDaemon
 {
   public:
-    using OsClock = score::lcm::saf::timers::OsClockInterface;
-    using SupervisionControlReceiver = score::lcm::ISupervisionControlReceiver;
-    using RecoveryClient = score::lcm::IRecoveryClient;
+    using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
+    using SupervisionControlReceiver = score::mw::lifecycle::ISupervisionControlReceiver;
+    using RecoveryClient = score::mw::lifecycle::IRecoveryClient;
     using SupervisionBufferConfig = factory::SupervisionBufferConfig;
-    using CycleTimer = score::lcm::saf::timers::CycleTimer;
-    using CycleTimeValidator = score::lcm::saf::timers::CycleTimeValidator;
-    using NanoSecondType = score::lcm::saf::timers::NanoSecondType;
-    using ObservableEventReader = score::lcm::saf::ifexm::ObservableEventReader;
+    using CycleTimer = score::mw::lifecycle::saf::timers::CycleTimer;
+    using CycleTimeValidator = score::mw::lifecycle::saf::timers::CycleTimeValidator;
+    using NanoSecondType = score::mw::lifecycle::saf::timers::NanoSecondType;
+    using ObservableEventReader = score::mw::lifecycle::saf::ifexm::ObservableEventReader;
     using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
     /* RULECHECKER_comment(0, 4, check_expensive_to_copy_in_parameter, "f_supervisionErrorInfo name is passed by value\
@@ -222,7 +222,7 @@ class PhmDaemon
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemon.hpp
@@ -29,7 +29,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -52,14 +52,14 @@ enum class EInitCode : std::int8_t
 class PhmDaemon
 {
   public:
-    using OsClock = score::mw::lifecycle::saf::timers::OsClockInterface;
+    using OsClock = score::mw::lifecycle::internal::saf::timers::OsClockInterface;
     using SupervisionControlReceiver = score::mw::lifecycle::ISupervisionControlReceiver;
     using RecoveryClient = score::mw::lifecycle::IRecoveryClient;
     using SupervisionBufferConfig = factory::SupervisionBufferConfig;
-    using CycleTimer = score::mw::lifecycle::saf::timers::CycleTimer;
-    using CycleTimeValidator = score::mw::lifecycle::saf::timers::CycleTimeValidator;
-    using NanoSecondType = score::mw::lifecycle::saf::timers::NanoSecondType;
-    using ObservableEventReader = score::mw::lifecycle::saf::ifexm::ObservableEventReader;
+    using CycleTimer = score::mw::lifecycle::internal::saf::timers::CycleTimer;
+    using CycleTimeValidator = score::mw::lifecycle::internal::saf::timers::CycleTimeValidator;
+    using NanoSecondType = score::mw::lifecycle::internal::saf::timers::NanoSecondType;
+    using ObservableEventReader = score::mw::lifecycle::internal::saf::ifexm::ObservableEventReader;
     using AliveMonitorConfig = score::mw::lifecycle::internal::alive::AliveMonitorConfig;
 
     /* RULECHECKER_comment(0, 4, check_expensive_to_copy_in_parameter, "f_supervisionErrorInfo name is passed by value\
@@ -222,7 +222,7 @@ class PhmDaemon
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -39,7 +39,7 @@ class PhmDaemonConfig
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/PhmDaemonConfig.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -39,7 +39,7 @@ class PhmDaemonConfig
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
@@ -18,13 +18,10 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/MonitorIfDaemon.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace daemon
+
+
+
+namespace score::lcm::saf::daemon
 {
 
 SwClusterHandler::SwClusterHandler(const std::string& f_swClusterName_r)
@@ -118,7 +115,7 @@ void SwClusterHandler::performCyclicTriggers(const timers::NanoSecondType f_sync
     evaluateSupervisions(f_syncTimestamp);
 }
 
-}  // namespace daemon
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::daemon
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
@@ -18,7 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/MonitorIfDaemon.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 
-namespace score::mw::lifecycle::saf::daemon
+namespace score::mw::lifecycle::internal::saf::daemon
 {
 
 SwClusterHandler::SwClusterHandler(const std::string& f_swClusterName_r)
@@ -112,4 +112,4 @@ void SwClusterHandler::performCyclicTriggers(const timers::NanoSecondType f_sync
     evaluateSupervisions(f_syncTimestamp);
 }
 
-}  // namespace score::mw::lifecycle::saf::daemon
+}  // namespace score::mw::lifecycle::internal::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.cpp
@@ -18,10 +18,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/MonitorIfDaemon.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/supervision/Alive.hpp"
 
-
-
-
-namespace score::lcm::saf::daemon
+namespace score::mw::lifecycle::saf::daemon
 {
 
 SwClusterHandler::SwClusterHandler(const std::string& f_swClusterName_r)
@@ -44,7 +41,7 @@ SwClusterHandler::~SwClusterHandler() = default;
    is tolerated for this function. ", true_no_defect) */
 bool SwClusterHandler::constructWorkers(
     const AliveMonitorConfig& config,
-    std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r,
     ifexm::ObservableEventReader& f_processStateReader_r,
     const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false)
 {
@@ -115,7 +112,4 @@ void SwClusterHandler::performCyclicTriggers(const timers::NanoSecondType f_sync
     evaluateSupervisions(f_syncTimestamp);
 }
 
-} // namespace score::lcm::saf::daemon
-
-
-
+}  // namespace score::mw::lifecycle::saf::daemon

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -26,7 +26,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 class IRecoveryClient;
@@ -96,7 +96,7 @@ class SwClusterHandler
     /// @return                              Construction is successful (true), otherwise failure (false)
     bool constructWorkers(
         const AliveMonitorConfig& config,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r,
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r,
         ifexm::ObservableEventReader& f_processStateReader_r,
         const factory::SupervisionBufferConfig& f_bufferConfig_r) noexcept(false);
 
@@ -141,7 +141,7 @@ class SwClusterHandler
 
 }  // namespace daemon
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/daemon/SwClusterHandler.hpp
@@ -31,6 +31,9 @@ namespace mw::lifecycle
 
 class IRecoveryClient;
 
+namespace internal
+{
+
 namespace saf
 {
 
@@ -141,6 +144,7 @@ class SwClusterHandler
 
 }  // namespace daemon
 }  // namespace saf
+}  // namespace internal
 }  // namespace mw::lifecycle
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -32,7 +32,7 @@
 #include "score/mw/launch_manager/common/alive_interface_path.hpp"
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-namespace score::mw::lifecycle::saf::factory
+namespace score::mw::lifecycle::internal::saf::factory
 {
 
 using BufferConfig = SupervisionBufferConfig;
@@ -317,4 +317,4 @@ IdentifierHash FlatCfgFactory::getProcessId(const SupervisedComponentConfig& com
     return IdentifierHash{comp.name};
 }
 
-}  // namespace score::mw::lifecycle::saf::factory
+}  // namespace score::mw::lifecycle::internal::saf::factory

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -32,16 +32,13 @@
 #include "score/mw/launch_manager/common/alive_interface_path.hpp"
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-
-
-
-namespace score::lcm::saf::factory
+namespace score::mw::lifecycle::saf::factory
 {
 
 using BufferConfig = SupervisionBufferConfig;
-using RecoveryClient = score::lcm::IRecoveryClient;
+using RecoveryClient = score::mw::lifecycle::IRecoveryClient;
 using NanoSecondType = saf::timers::NanoSecondType;
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 FlatCfgFactory::FlatCfgFactory(const BufferConfig& f_bufferConfig_r) : IPhmFactory(), bufferConfig_r(f_bufferConfig_r)
 {
@@ -129,7 +126,7 @@ bool FlatCfgFactory::createAliveIfIpcs(std::vector<ifappl::CheckpointIpcServer>&
 
         for (const auto& comp : supervised_components_)
         {
-            const std::string pathInterface = score::lcm::internal::aliveInterfacePath(comp.name);
+            const std::string pathInterface = score::mw::lifecycle::internal::aliveInterfacePath(comp.name);
             f_interfaceIpcs_r.emplace_back();
             const std::int32_t configuredUid = static_cast<std::int32_t>(comp.uid);
             isSuccess = initIpcServerWithUidBasedAccess(f_interfaceIpcs_r.back(), pathInterface, configuredUid);
@@ -320,7 +317,4 @@ IdentifierHash FlatCfgFactory::getProcessId(const SupervisedComponentConfig& com
     return IdentifierHash{comp.name};
 }
 
-} // namespace score::lcm::saf::factory
-
-
-
+}  // namespace score::mw::lifecycle::saf::factory

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.cpp
@@ -32,13 +32,10 @@
 #include "score/mw/launch_manager/common/alive_interface_path.hpp"
 #include "score/mw/launch_manager/common/identifier_hash.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace factory
+
+
+
+namespace score::lcm::saf::factory
 {
 
 using BufferConfig = SupervisionBufferConfig;
@@ -323,7 +320,7 @@ IdentifierHash FlatCfgFactory::getProcessId(const SupervisedComponentConfig& com
     return IdentifierHash{comp.name};
 }
 
-}  // namespace factory
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::factory
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
@@ -33,7 +33,7 @@ class ControlClient;
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -125,7 +125,7 @@ class FlatCfgFactory : public IPhmFactory
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/FlatCfgFactory.hpp
@@ -25,7 +25,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 class ControlClient;
 }
@@ -33,7 +33,7 @@ class ControlClient;
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -97,13 +97,13 @@ class FlatCfgFactory : public IPhmFactory
         std::vector<supervision::Alive>& f_alive_r,
         std::vector<ifappl::Checkpoint>& f_checkpoints_r,
         std::vector<ifexm::ObservableEvent>& f_processStates_r,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r) override;
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r) override;
 
   private:
     /// @brief Get process id based on ASR path of process
     /// @param[in] comp  Reference to component configuration
     /// @return          process id
-    static score::lcm::IdentifierHash getProcessId(const SupervisedComponentConfig& comp) noexcept(true);
+    static score::mw::lifecycle::IdentifierHash getProcessId(const SupervisedComponentConfig& comp) noexcept(true);
 
     /// @brief Create IPC Channel with uid-based access permission
     /// @details Only the given uid will ge granted r/w access, no group will be granted access
@@ -125,7 +125,7 @@ class FlatCfgFactory : public IPhmFactory
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
@@ -19,7 +19,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 class IRecoveryClient;
 }
@@ -27,7 +27,7 @@ class IRecoveryClient;
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -119,12 +119,12 @@ class IPhmFactory
         std::vector<supervision::Alive>& f_alive_r,
         std::vector<ifappl::Checkpoint>& f_checkpoints_r,
         std::vector<ifexm::ObservableEvent>& f_processStates_r,
-        std::shared_ptr<score::lcm::IRecoveryClient> f_recoveryClient_r) = 0;
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> f_recoveryClient_r) = 0;
 };
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/IPhmFactory.hpp
@@ -27,7 +27,7 @@ class IRecoveryClient;
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -124,7 +124,7 @@ class IPhmFactory
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -61,7 +61,7 @@ class StaticConfig
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/factory/StaticConfig.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -61,7 +61,7 @@ class StaticConfig
 
 }  // namespace factory
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
@@ -13,10 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/Checkpoint.hpp"
 
-
-
-
-namespace score::lcm::saf::ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 Checkpoint::Checkpoint(
@@ -76,7 +73,4 @@ const ifexm::ObservableEvent* Checkpoint::getProcess(void) const noexcept(true)
     return processState;
 }
 
-} // namespace score::lcm::saf::ifappl
-
-
-
+}  // namespace score::mw::lifecycle::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
@@ -13,13 +13,10 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/Checkpoint.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+
+
+
+namespace score::lcm::saf::ifappl
 {
 
 Checkpoint::Checkpoint(
@@ -79,7 +76,7 @@ const ifexm::ObservableEvent* Checkpoint::getProcess(void) const noexcept(true)
     return processState;
 }
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::ifappl
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.cpp
@@ -13,7 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/ifappl/Checkpoint.hpp"
 
-namespace score::mw::lifecycle::saf::ifappl
+namespace score::mw::lifecycle::internal::saf::ifappl
 {
 
 Checkpoint::Checkpoint(
@@ -73,4 +73,4 @@ const ifexm::ObservableEvent* Checkpoint::getProcess(void) const noexcept(true)
     return processState;
 }
 
-}  // namespace score::mw::lifecycle::saf::ifappl
+}  // namespace score::mw::lifecycle::internal::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
@@ -25,7 +25,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -78,12 +78,12 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
 
     /// @brief Get timestamp
     /// @return NanoSecondType  Timestamp value of the reported checkpoint in [nano seconds]
-    score::mw::lifecycle::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
+    score::mw::lifecycle::internal::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
 
     /// @brief Push data to checkpoint observer
     /// @details Push the checkpoint timestamp to the checkpoint observer to notify it was reported
     /// @param [in] f_timestamp     Timestamp value captured when the checkpoint was reported in [nano seconds]
-    void pushData(const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp) noexcept(true);
+    void pushData(const score::mw::lifecycle::internal::saf::timers::NanoSecondType f_timestamp) noexcept(true);
 
     /// @brief Set data loss event
     /// @details Set data loss event in the checkpoint observer
@@ -116,12 +116,12 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
     bool isDataLossEvent;
 
     /// @brief Timestamp value in [nano seconds]
-    score::mw::lifecycle::saf::timers::NanoSecondType timestamp;
+    score::mw::lifecycle::internal::saf::timers::NanoSecondType timestamp;
 };
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/Checkpoint.hpp
@@ -25,7 +25,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -78,12 +78,12 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
 
     /// @brief Get timestamp
     /// @return NanoSecondType  Timestamp value of the reported checkpoint in [nano seconds]
-    score::lcm::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
+    score::mw::lifecycle::saf::timers::NanoSecondType getTimestamp(void) const noexcept(true);
 
     /// @brief Push data to checkpoint observer
     /// @details Push the checkpoint timestamp to the checkpoint observer to notify it was reported
     /// @param [in] f_timestamp     Timestamp value captured when the checkpoint was reported in [nano seconds]
-    void pushData(const score::lcm::saf::timers::NanoSecondType f_timestamp) noexcept(true);
+    void pushData(const score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp) noexcept(true);
 
     /// @brief Set data loss event
     /// @details Set data loss event in the checkpoint observer
@@ -116,12 +116,12 @@ class Checkpoint : public saf::common::Observable<Checkpoint>
     bool isDataLossEvent;
 
     /// @brief Timestamp value in [nano seconds]
-    score::lcm::saf::timers::NanoSecondType timestamp;
+    score::mw::lifecycle::saf::timers::NanoSecondType timestamp;
 };
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -42,8 +42,8 @@ constexpr uint16_t k_maxCheckpointBufferElements{512U};
 required for Vector and IPC APIs", true_no_defect) */
 struct CheckpointBufferElement final
 {
-    score::lcm::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
-    uint32_t checkpointId{0U};                              ///< Checkpoint ID
+    score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
+    uint32_t checkpointId{0U};                                        ///< Checkpoint ID
 
     /// @brief Default constructor needed for storage in vector
     CheckpointBufferElement() = default;
@@ -51,7 +51,9 @@ struct CheckpointBufferElement final
     /// @brief Constructor for usage with emplace
     /// @param [in] f_timestamp The checkpoint timestamp
     /// @param [in] f_checkpointId  The checkpoint id
-    CheckpointBufferElement(score::lcm::saf::timers::NanoSecondType f_timestamp, uint32_t f_checkpointId) noexcept(true)
+    CheckpointBufferElement(
+        score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp,
+        uint32_t f_checkpointId) noexcept(true)
         : timestamp(f_timestamp), checkpointId(f_checkpointId)
     {
     }
@@ -62,7 +64,7 @@ using CheckpointIpcServer = ipc::IpcServer<CheckpointBufferElement, k_maxCheckpo
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/DataStructures.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -42,8 +42,8 @@ constexpr uint16_t k_maxCheckpointBufferElements{512U};
 required for Vector and IPC APIs", true_no_defect) */
 struct CheckpointBufferElement final
 {
-    score::mw::lifecycle::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
-    uint32_t checkpointId{0U};                                        ///< Checkpoint ID
+    score::mw::lifecycle::internal::saf::timers::NanoSecondType timestamp{0U};  ///< Timestamp
+    uint32_t checkpointId{0U};                                                  ///< Checkpoint ID
 
     /// @brief Default constructor needed for storage in vector
     CheckpointBufferElement() = default;
@@ -52,7 +52,7 @@ struct CheckpointBufferElement final
     /// @param [in] f_timestamp The checkpoint timestamp
     /// @param [in] f_checkpointId  The checkpoint id
     CheckpointBufferElement(
-        score::mw::lifecycle::saf::timers::NanoSecondType f_timestamp,
+        score::mw::lifecycle::internal::saf::timers::NanoSecondType f_timestamp,
         uint32_t f_checkpointId) noexcept(true)
         : timestamp(f_timestamp), checkpointId(f_checkpointId)
     {
@@ -64,7 +64,7 @@ using CheckpointIpcServer = ipc::IpcServer<CheckpointBufferElement, k_maxCheckpo
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
@@ -18,7 +18,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ObservableEvent.hpp"
 
-namespace score::mw::lifecycle::saf::ifappl
+namespace score::mw::lifecycle::internal::saf::ifappl
 {
 
 MonitorIfDaemon::MonitorIfDaemon(CheckpointIpcServer& f_ipcServer_r, const char* f_interfaceName_p)
@@ -195,4 +195,4 @@ void MonitorIfDaemon::pushOverflowInfoToCheckpointObservers(void) const
     }
 }
 
-}  // namespace score::mw::lifecycle::saf::ifappl
+}  // namespace score::mw::lifecycle::internal::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
@@ -18,10 +18,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ObservableEvent.hpp"
 
-
-
-
-namespace score::lcm::saf::ifappl
+namespace score::mw::lifecycle::saf::ifappl
 {
 
 MonitorIfDaemon::MonitorIfDaemon(CheckpointIpcServer& f_ipcServer_r, const char* f_interfaceName_p)
@@ -43,7 +40,7 @@ void MonitorIfDaemon::updateData(const ifexm::ObservableEvent& f_observable_r) n
 {
     switch (f_observable_r.event.eventType)
     {
-        case score::lcm::SupervisionEventType::kActivation:
+        case score::mw::lifecycle::SupervisionEventType::kActivation:
             if (isDeactivateRequest)
             {
                 isProcessRestarted = true;
@@ -51,7 +48,7 @@ void MonitorIfDaemon::updateData(const ifexm::ObservableEvent& f_observable_r) n
             isActivateRequest = true;
             isDeactivateRequest = false;
             break;
-        case score::lcm::SupervisionEventType::kDeactivation:
+        case score::mw::lifecycle::SupervisionEventType::kDeactivation:
             isDeactivateRequest = true;
             break;
     }
@@ -198,7 +195,4 @@ void MonitorIfDaemon::pushOverflowInfoToCheckpointObservers(void) const
     }
 }
 
-} // namespace score::lcm::saf::ifappl
-
-
-
+}  // namespace score::mw::lifecycle::saf::ifappl

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.cpp
@@ -18,13 +18,10 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/ifexm/ObservableEvent.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifappl
+
+
+
+namespace score::lcm::saf::ifappl
 {
 
 MonitorIfDaemon::MonitorIfDaemon(CheckpointIpcServer& f_ipcServer_r, const char* f_interfaceName_p)
@@ -201,7 +198,7 @@ void MonitorIfDaemon::pushOverflowInfoToCheckpointObservers(void) const
     }
 }
 
-}  // namespace ifappl
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::ifappl
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -95,7 +95,8 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
     /// @brief Check for new data
     /// @details Check Alive interface for new data from application side
     /// @param [in]  f_syncTimestamp    Timestamp till data shall be read, newer data will not be considered
-    void checkForNewData(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp) noexcept(true);
+    void checkForNewData(const score::mw::lifecycle::internal::saf::timers::NanoSecondType f_syncTimestamp) noexcept(
+        true);
 
   private:
     /// @brief Check if checkpoint ring buffer overflow has occurred
@@ -118,7 +119,8 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
     /// @details The checkpoint ring buffer data is pushed to checkpoint specific objects.
     /// @param [in]  f_syncTimestamp        Timestamp till data shall be read, newer data will not be considered
     /// @returns True if reading data from IPC channel and pushing data to observers was successful, else false
-    bool pushNewDataToCheckpointObservers(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp);
+    bool pushNewDataToCheckpointObservers(
+        const score::mw::lifecycle::internal::saf::timers::NanoSecondType f_syncTimestamp);
 
     /// @brief Push a single checkpoint to observers
     /// @param[in] f_elem_r The checkpoint to push to observers
@@ -156,7 +158,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -95,7 +95,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
     /// @brief Check for new data
     /// @details Check Alive interface for new data from application side
     /// @param [in]  f_syncTimestamp    Timestamp till data shall be read, newer data will not be considered
-    void checkForNewData(const score::lcm::saf::timers::NanoSecondType f_syncTimestamp) noexcept(true);
+    void checkForNewData(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp) noexcept(true);
 
   private:
     /// @brief Check if checkpoint ring buffer overflow has occurred
@@ -118,7 +118,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
     /// @details The checkpoint ring buffer data is pushed to checkpoint specific objects.
     /// @param [in]  f_syncTimestamp        Timestamp till data shall be read, newer data will not be considered
     /// @returns True if reading data from IPC channel and pushing data to observers was successful, else false
-    bool pushNewDataToCheckpointObservers(const score::lcm::saf::timers::NanoSecondType f_syncTimestamp);
+    bool pushNewDataToCheckpointObservers(const score::mw::lifecycle::saf::timers::NanoSecondType f_syncTimestamp);
 
     /// @brief Push a single checkpoint to observers
     /// @param[in] f_elem_r The checkpoint to push to observers
@@ -156,7 +156,7 @@ class MonitorIfDaemon : public common::Observer<ifexm::ObservableEvent>
 
 }  // namespace ifappl
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-namespace score::mw::lifecycle::saf
+namespace score::mw::lifecycle::internal::saf
 {
 
 namespace
@@ -425,4 +425,4 @@ TEST_F(MonitorIfDaemonTest, InactiveOverflow_ProcessRestartFlag_ClearedAfterNoti
     fix.monitor.checkForNewData(mockClock());  // no new restart -> no additional notification
 }
 
-}  // namespace score::mw::lifecycle::saf
+}  // namespace score::mw::lifecycle::internal::saf

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifappl/MonitorIfDaemon_UT.cpp
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-namespace score::lcm::saf
+namespace score::mw::lifecycle::saf
 {
 
 namespace
@@ -80,7 +80,7 @@ struct MonitorIfDaemonFixture
     void activateProcess(long ts)
     {
         processState.event.systemClockTimestamp.tv_nsec = ts;
-        processState.event.eventType = score::lcm::SupervisionEventType::kActivation;
+        processState.event.eventType = score::mw::lifecycle::SupervisionEventType::kActivation;
         processState.pushData();
     }
 
@@ -88,7 +88,7 @@ struct MonitorIfDaemonFixture
     void deactivateProcess(long ts)
     {
         processState.event.systemClockTimestamp.tv_nsec = ts;
-        processState.event.eventType = score::lcm::SupervisionEventType::kDeactivation;
+        processState.event.eventType = score::mw::lifecycle::SupervisionEventType::kDeactivation;
         processState.pushData();
     }
 
@@ -425,4 +425,4 @@ TEST_F(MonitorIfDaemonTest, InactiveOverflow_ProcessRestartFlag_ClearedAfterNoti
     fix.monitor.checkForNewData(mockClock());  // no new restart -> no additional notification
 }
 
-}  // namespace score::lcm::saf
+}  // namespace score::mw::lifecycle::saf

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.cpp
@@ -15,7 +15,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -34,5 +34,5 @@ void ObservableEvent::pushData(void) noexcept
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.cpp
@@ -15,7 +15,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -34,5 +34,5 @@ void ObservableEvent::pushData(void) noexcept
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -71,7 +71,7 @@ class ObservableEvent : public saf::common::Observable<ObservableEvent>
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEvent.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -71,7 +71,7 @@ class ObservableEvent : public saf::common::Observable<ObservableEvent>
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
@@ -15,7 +15,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score::mw::lifecycle::saf::ifexm
+namespace score::mw::lifecycle::internal::saf::ifexm
 {
 
 ObservableEventReader::ObservableEventReader(std::unique_ptr<LcmSupervisionControlReceiver> f_observable_event_receiver)
@@ -123,4 +123,4 @@ bool ObservableEventReader::pushUpdateTill(
     return isSyncTimestampReached;
 }
 
-}  // namespace score::mw::lifecycle::saf::ifexm
+}  // namespace score::mw::lifecycle::internal::saf::ifexm

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
@@ -15,13 +15,10 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace ifexm
+
+
+
+namespace score::lcm::saf::ifexm
 {
 
 ObservableEventReader::ObservableEventReader(std::unique_ptr<LcmSupervisionControlReceiver> f_observable_event_receiver)
@@ -129,7 +126,7 @@ bool ObservableEventReader::pushUpdateTill(
     return isSyncTimestampReached;
 }
 
-}  // namespace ifexm
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::ifexm
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.cpp
@@ -15,10 +15,7 @@
 #include "score/launch_manager/src/daemon/src/common/log.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-
-
-
-namespace score::lcm::saf::ifexm
+namespace score::mw::lifecycle::saf::ifexm
 {
 
 ObservableEventReader::ObservableEventReader(std::unique_ptr<LcmSupervisionControlReceiver> f_observable_event_receiver)
@@ -126,7 +123,4 @@ bool ObservableEventReader::pushUpdateTill(
     return isSyncTimestampReached;
 }
 
-} // namespace score::lcm::saf::ifexm
-
-
-
+}  // namespace score::mw::lifecycle::saf::ifexm

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -36,8 +36,8 @@ namespace ifexm
 class ObservableEventReader
 {
   public:
-    using LcmSupervisionEvent = score::lcm::SupervisionEvent;
-    using LcmSupervisionControlReceiver = score::lcm::ISupervisionControlReceiver;
+    using LcmSupervisionEvent = score::mw::lifecycle::SupervisionEvent;
+    using LcmSupervisionControlReceiver = score::mw::lifecycle::ISupervisionControlReceiver;
 
     /// @brief Constructor
     /// @param [in] f_observable_event_receiver   Process state receiver implementation
@@ -93,7 +93,7 @@ class ObservableEventReader
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ifexm/ObservableEventReader.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -93,7 +93,7 @@ class ObservableEventReader
 
 }  // namespace ifexm
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -176,7 +176,7 @@ class IpcBase
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcBase.hpp
@@ -21,7 +21,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -176,7 +176,7 @@ class IpcBase
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -102,7 +102,7 @@ class IpcClient final : public IpcBase<Payload, MaxNumberElements, Socket>
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcClient.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -102,7 +102,7 @@ class IpcClient final : public IpcBase<Payload, MaxNumberElements, Socket>
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
@@ -28,7 +28,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -213,7 +213,7 @@ class IpcServer final : public IpcBase<Payload, MaxNumberElements, Socket>
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/ipc/IpcServer.hpp
@@ -28,7 +28,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -213,7 +213,7 @@ class IpcServer final : public IpcBase<Payload, MaxNumberElements, Socket>
 
 }  // namespace ipc
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
@@ -21,7 +21,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score::mw::lifecycle::saf::supervision
+namespace score::mw::lifecycle::internal::saf::supervision
 {
 
 Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
@@ -48,7 +48,7 @@ Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
 }
 
 // coverity[exn_spec_violation:FALSE] std::length_error is not thrown from push() which uses fixed-size-vector
-void Alive::updateData(const score::mw::lifecycle::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
+void Alive::updateData(const score::mw::lifecycle::internal::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
 {
     timers::NanoSecondType timestamp{f_observable_r.getTimestamp()};
 
@@ -594,4 +594,4 @@ timers::NanoSecondType Alive::getTimestampOfUpdateEvent(const TimeSortedUpdateEv
     return timestamp;
 }
 
-}  // namespace score::mw::lifecycle::saf::supervision
+}  // namespace score::mw::lifecycle::internal::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
@@ -21,10 +21,7 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-
-
-
-namespace score::lcm::saf::supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
@@ -51,7 +48,7 @@ Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
 }
 
 // coverity[exn_spec_violation:FALSE] std::length_error is not thrown from push() which uses fixed-size-vector
-void Alive::updateData(const score::lcm::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
+void Alive::updateData(const score::mw::lifecycle::saf::ifappl::Checkpoint& f_observable_r) noexcept(true)
 {
     timers::NanoSecondType timestamp{f_observable_r.getTimestamp()};
 
@@ -265,11 +262,11 @@ Alive::EUpdateEventType Alive::getAliveEventType(
     if (std::holds_alternative<SupervisionEventSnapshot>(f_updateEvent))
     {
         const auto& snapshot = std::get<SupervisionEventSnapshot>(f_updateEvent);
-        if (snapshot.eventType == score::lcm::SupervisionEventType::kActivation)
+        if (snapshot.eventType == score::mw::lifecycle::SupervisionEventType::kActivation)
         {
             return EUpdateEventType::kActivation;
         }
-        if (snapshot.eventType == score::lcm::SupervisionEventType::kDeactivation)
+        if (snapshot.eventType == score::mw::lifecycle::SupervisionEventType::kDeactivation)
         {
             return EUpdateEventType::kDeactivation;
         }
@@ -597,7 +594,4 @@ timers::NanoSecondType Alive::getTimestampOfUpdateEvent(const TimeSortedUpdateEv
     return timestamp;
 }
 
-} // namespace score::lcm::saf::supervision
-
-
-
+}  // namespace score::mw::lifecycle::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.cpp
@@ -21,13 +21,10 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 #include "score/mw/launch_manager/alive_monitor/details/timers/Timers_OsClock.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+
+
+
+namespace score::lcm::saf::supervision
 {
 
 Alive::Alive(const AliveSupervisionCfg& f_aliveCfg_r)
@@ -600,7 +597,7 @@ timers::NanoSecondType Alive::getTimestampOfUpdateEvent(const TimeSortedUpdateEv
     return timestamp;
 }
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::supervision
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
@@ -27,7 +27,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -127,7 +127,7 @@ class Alive : public ISupervision,
   private:
     /// @brief The pointer is only stored for the identification of a checkpoint observer. It can be further used for
     /// accessing const members only.
-    using CheckpointIdentifier = const score::mw::lifecycle::saf::ifappl::Checkpoint*;
+    using CheckpointIdentifier = const score::mw::lifecycle::internal::saf::ifappl::Checkpoint*;
 
     /// @brief Time sorted checkpoint snapshot
     struct CheckpointSnapshot final
@@ -287,7 +287,7 @@ class Alive : public ISupervision,
     bool setReferenceCycleTimestamps(timers::NanoSecondType f_baseValue) noexcept(true);
 
     /// @brief Alive reference cycle in [nano seconds]
-    const score::mw::lifecycle::saf::timers::NanoSecondType k_aliveReferenceCycle;
+    const score::mw::lifecycle::internal::saf::timers::NanoSecondType k_aliveReferenceCycle;
 
     /// @brief Minimum allowed alive indications
     const uint32_t k_minAliveIndications;
@@ -341,12 +341,12 @@ class Alive : public ISupervision,
 
     /// @brief Time sorting buffer for update events in alive supervision
     /// @details This buffer sorts all process events and checkpoint events in the same buffer.
-    score::mw::lifecycle::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
+    score::mw::lifecycle::internal::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
 };
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive.hpp
@@ -27,7 +27,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -127,7 +127,7 @@ class Alive : public ISupervision,
   private:
     /// @brief The pointer is only stored for the identification of a checkpoint observer. It can be further used for
     /// accessing const members only.
-    using CheckpointIdentifier = const score::lcm::saf::ifappl::Checkpoint*;
+    using CheckpointIdentifier = const score::mw::lifecycle::saf::ifappl::Checkpoint*;
 
     /// @brief Time sorted checkpoint snapshot
     struct CheckpointSnapshot final
@@ -146,7 +146,7 @@ class Alive : public ISupervision,
         timers::NanoSecondType timestamp{UINT64_MAX};
         /// @brief Supervision event type that triggered this snapshot
         // cppcheck-suppress unusedStructMember
-        score::lcm::SupervisionEventType eventType{score::lcm::SupervisionEventType::kDeactivation};
+        score::mw::lifecycle::SupervisionEventType eventType{score::mw::lifecycle::SupervisionEventType::kDeactivation};
     };
 
     /// @brief Sync snapshot stores sync timestamp in the time sorting buffer
@@ -287,7 +287,7 @@ class Alive : public ISupervision,
     bool setReferenceCycleTimestamps(timers::NanoSecondType f_baseValue) noexcept(true);
 
     /// @brief Alive reference cycle in [nano seconds]
-    const score::lcm::saf::timers::NanoSecondType k_aliveReferenceCycle;
+    const score::mw::lifecycle::saf::timers::NanoSecondType k_aliveReferenceCycle;
 
     /// @brief Minimum allowed alive indications
     const uint32_t k_minAliveIndications;
@@ -305,10 +305,10 @@ class Alive : public ISupervision,
     const uint32_t k_failedSupervisionCyclesTolerance;
 
     /// @brief Recovery client invoked when supervision expires (null means recovery is disabled)
-    std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient_p;
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient_p;
 
     /// @brief Identifier of the supervised process, sent via recovery client when supervision expires
-    const score::lcm::IdentifierHash processIdentifier_;
+    const score::mw::lifecycle::IdentifierHash processIdentifier_;
 
     /// @brief Set to true when sendRecoveryRequest fails (ring buffer full)
     bool recoveryEnqueueFailed_{false};
@@ -341,12 +341,12 @@ class Alive : public ISupervision,
 
     /// @brief Time sorting buffer for update events in alive supervision
     /// @details This buffer sorts all process events and checkpoint events in the same buffer.
-    score::lcm::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
+    score::mw::lifecycle::saf::common::TimeSortingBuffer<TimeSortedUpdateEvent> timeSortingUpdateEventBuffer;
 };
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
@@ -26,7 +26,7 @@
 
 using namespace testing;
 
-using EStatus = score::mw::lifecycle::saf::supervision::Alive::EStatus;
+using EStatus = score::mw::lifecycle::internal::saf::supervision::Alive::EStatus;
 
 namespace
 {
@@ -58,7 +58,7 @@ struct AliveFixture
         uint32_t failedCyclesTolerance = 0U;
         uint32_t minIndications = 1U;
         uint32_t maxIndications = 3U;
-        score::mw::lifecycle::saf::timers::NanoSecondType referenceCycleNs = 1000U;
+        score::mw::lifecycle::internal::saf::timers::NanoSecondType referenceCycleNs = 1000U;
 
         Builder& withFailedCyclesTolerance(uint32_t val)
         {
@@ -75,7 +75,7 @@ struct AliveFixture
             maxIndications = val;
             return *this;
         }
-        Builder& withReferenceCycleNs(score::mw::lifecycle::saf::timers::NanoSecondType val)
+        Builder& withReferenceCycleNs(score::mw::lifecycle::internal::saf::timers::NanoSecondType val)
         {
             referenceCycleNs = val;
             return *this;
@@ -91,14 +91,14 @@ struct AliveFixture
 
     std::shared_ptr<MockRecoveryClient> mockClient = std::make_shared<MockRecoveryClient>();
 
-    score::mw::lifecycle::saf::ifexm::ObservableEvent processState;
-    score::mw::lifecycle::saf::ifappl::Checkpoint checkpoint;
+    score::mw::lifecycle::internal::saf::ifexm::ObservableEvent processState;
+    score::mw::lifecycle::internal::saf::ifappl::Checkpoint checkpoint;
 
-    std::unique_ptr<score::mw::lifecycle::saf::supervision::Alive> alive;
+    std::unique_ptr<score::mw::lifecycle::internal::saf::supervision::Alive> alive;
 
     explicit AliveFixture(const Builder& bld) : processState(kProcessId), checkpoint(kCheckpointName, 1U, &processState)
     {
-        score::mw::lifecycle::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
+        score::mw::lifecycle::internal::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
         cfg.cfgName_p = "test_alive";
         cfg.aliveReferenceCycle = bld.referenceCycleNs;
         cfg.minAliveIndications = bld.minIndications;
@@ -110,7 +110,7 @@ struct AliveFixture
         cfg.recoveryClient = mockClient;
         cfg.processIdentifier = kProcessIdentifier;
 
-        alive = std::make_unique<score::mw::lifecycle::saf::supervision::Alive>(cfg);
+        alive = std::make_unique<score::mw::lifecycle::internal::saf::supervision::Alive>(cfg);
         processState.attachObserver(*alive);
     }
 
@@ -131,7 +131,7 @@ struct AliveFixture
     }
 
     /// Report one alive heartbeat checkpoint at the given timestamp.
-    void reportHeartbeat(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
+    void reportHeartbeat(score::mw::lifecycle::internal::saf::timers::NanoSecondType timestamp)
     {
         checkpoint.pushData(timestamp);
     }

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/Alive_UT.cpp
@@ -26,23 +26,23 @@
 
 using namespace testing;
 
-using EStatus = score::lcm::saf::supervision::Alive::EStatus;
+using EStatus = score::mw::lifecycle::saf::supervision::Alive::EStatus;
 
 namespace
 {
 
-class MockRecoveryClient : public score::lcm::IRecoveryClient
+class MockRecoveryClient : public score::mw::lifecycle::IRecoveryClient
 {
   public:
     MOCK_METHOD(
         void,
         setRecoveryRequestCallback,
-        (score::lcm::IRecoveryClient::RecoveryRequestCallback callback),
+        (score::mw::lifecycle::IRecoveryClient::RecoveryRequestCallback callback),
         (noexcept, override));
     MOCK_METHOD(
         bool,
         sendRecoveryRequest,
-        (const score::lcm::IdentifierHash& process_group_identifier),
+        (const score::mw::lifecycle::IdentifierHash& process_group_identifier),
         (noexcept, override));
 };
 
@@ -50,7 +50,7 @@ class MockRecoveryClient : public score::lcm::IRecoveryClient
 /// Owns all supporting objects so they outlive the Alive.
 struct AliveFixture
 {
-    inline static const score::lcm::IdentifierHash kProcessId{"42U"};
+    inline static const score::mw::lifecycle::IdentifierHash kProcessId{"42U"};
     static constexpr char kCheckpointName[] = "test_cp";
 
     struct Builder
@@ -58,7 +58,7 @@ struct AliveFixture
         uint32_t failedCyclesTolerance = 0U;
         uint32_t minIndications = 1U;
         uint32_t maxIndications = 3U;
-        score::lcm::saf::timers::NanoSecondType referenceCycleNs = 1000U;
+        score::mw::lifecycle::saf::timers::NanoSecondType referenceCycleNs = 1000U;
 
         Builder& withFailedCyclesTolerance(uint32_t val)
         {
@@ -75,7 +75,7 @@ struct AliveFixture
             maxIndications = val;
             return *this;
         }
-        Builder& withReferenceCycleNs(score::lcm::saf::timers::NanoSecondType val)
+        Builder& withReferenceCycleNs(score::mw::lifecycle::saf::timers::NanoSecondType val)
         {
             referenceCycleNs = val;
             return *this;
@@ -87,18 +87,18 @@ struct AliveFixture
         }
     };
 
-    const score::lcm::IdentifierHash kProcessIdentifier{"test_proc"};
+    const score::mw::lifecycle::IdentifierHash kProcessIdentifier{"test_proc"};
 
     std::shared_ptr<MockRecoveryClient> mockClient = std::make_shared<MockRecoveryClient>();
 
-    score::lcm::saf::ifexm::ObservableEvent processState;
-    score::lcm::saf::ifappl::Checkpoint checkpoint;
+    score::mw::lifecycle::saf::ifexm::ObservableEvent processState;
+    score::mw::lifecycle::saf::ifappl::Checkpoint checkpoint;
 
-    std::unique_ptr<score::lcm::saf::supervision::Alive> alive;
+    std::unique_ptr<score::mw::lifecycle::saf::supervision::Alive> alive;
 
     explicit AliveFixture(const Builder& bld) : processState(kProcessId), checkpoint(kCheckpointName, 1U, &processState)
     {
-        score::lcm::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
+        score::mw::lifecycle::saf::supervision::AliveSupervisionCfg cfg{checkpoint};
         cfg.cfgName_p = "test_alive";
         cfg.aliveReferenceCycle = bld.referenceCycleNs;
         cfg.minAliveIndications = bld.minIndications;
@@ -110,7 +110,7 @@ struct AliveFixture
         cfg.recoveryClient = mockClient;
         cfg.processIdentifier = kProcessIdentifier;
 
-        alive = std::make_unique<score::lcm::saf::supervision::Alive>(cfg);
+        alive = std::make_unique<score::mw::lifecycle::saf::supervision::Alive>(cfg);
         processState.attachObserver(*alive);
     }
 
@@ -118,7 +118,7 @@ struct AliveFixture
     void activateProcess(long ts)
     {
         processState.event.systemClockTimestamp.tv_nsec = ts;
-        processState.event.eventType = score::lcm::SupervisionEventType::kActivation;
+        processState.event.eventType = score::mw::lifecycle::SupervisionEventType::kActivation;
         processState.pushData();
     }
 
@@ -126,12 +126,12 @@ struct AliveFixture
     void deactivateProcess(long ts)
     {
         processState.event.systemClockTimestamp.tv_nsec = ts;
-        processState.event.eventType = score::lcm::SupervisionEventType::kDeactivation;
+        processState.event.eventType = score::mw::lifecycle::SupervisionEventType::kDeactivation;
         processState.pushData();
     }
 
     /// Report one alive heartbeat checkpoint at the given timestamp.
-    void reportHeartbeat(score::lcm::saf::timers::NanoSecondType timestamp)
+    void reportHeartbeat(score::mw::lifecycle::saf::timers::NanoSecondType timestamp)
     {
         checkpoint.pushData(timestamp);
     }

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
@@ -13,7 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/supervision/ISupervision.hpp"
 
-namespace score::mw::lifecycle::saf::supervision
+namespace score::mw::lifecycle::internal::saf::supervision
 {
 
 ISupervision::ISupervision(const char* const f_supervisionConfigName_p) : k_cfgName(f_supervisionConfigName_p)
@@ -27,4 +27,4 @@ std::string_view ISupervision::getConfigName(void) const noexcept
     return k_cfgName;
 }
 
-}  // namespace score::mw::lifecycle::saf::supervision
+}  // namespace score::mw::lifecycle::internal::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
@@ -13,10 +13,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/supervision/ISupervision.hpp"
 
-
-
-
-namespace score::lcm::saf::supervision
+namespace score::mw::lifecycle::saf::supervision
 {
 
 ISupervision::ISupervision(const char* const f_supervisionConfigName_p) : k_cfgName(f_supervisionConfigName_p)
@@ -30,7 +27,4 @@ std::string_view ISupervision::getConfigName(void) const noexcept
     return k_cfgName;
 }
 
-} // namespace score::lcm::saf::supervision
-
-
-
+}  // namespace score::mw::lifecycle::saf::supervision

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.cpp
@@ -13,13 +13,10 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/supervision/ISupervision.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace supervision
+
+
+
+namespace score::lcm::saf::supervision
 {
 
 ISupervision::ISupervision(const char* const f_supervisionConfigName_p) : k_cfgName(f_supervisionConfigName_p)
@@ -33,7 +30,7 @@ std::string_view ISupervision::getConfigName(void) const noexcept
     return k_cfgName;
 }
 
-}  // namespace supervision
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::supervision
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -83,7 +83,7 @@ class ISupervision
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/ISupervision.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -83,7 +83,7 @@ class ISupervision
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -97,7 +97,7 @@ class AliveSupervisionCfg final
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/supervision/SupervisionCfg.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -65,9 +65,9 @@ class AliveSupervisionCfg final
     saf::ifappl::Checkpoint& checkpoint_r;
 
     /// Recovery client to invoke when supervision expires
-    std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient{};
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient{};
     /// Identifier of the supervised process, sent via recovery client when supervision expires
-    score::lcm::IdentifierHash processIdentifier{};
+    score::mw::lifecycle::IdentifierHash processIdentifier{};
 
     /// Default destructor
     ~AliveSupervisionCfg() = default;
@@ -97,7 +97,7 @@ class AliveSupervisionCfg final
 
 }  // namespace supervision
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
@@ -12,13 +12,10 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+
+
+
+namespace score::lcm::saf::timers
 {
 
 int64_t CycleTimeValidator::getMonotonicClockAccuracy(
@@ -59,7 +56,7 @@ int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     return intervalNs;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::timers
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
@@ -12,14 +12,11 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 
-
-
-
-namespace score::lcm::saf::timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 int64_t CycleTimeValidator::getMonotonicClockAccuracy(
-    const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     struct timespec clockResolution{};
     int64_t accuracyNs{-1};
@@ -35,11 +32,12 @@ int64_t CycleTimeValidator::getMonotonicClockAccuracy(
 
 int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     const int64_t f_requested_interval_ns,
-    const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     int64_t intervalNs{-1};  // start with an invalid value
 
-    const int64_t accuracyNs{score::lcm::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
+    const int64_t accuracyNs{
+        score::mw::lifecycle::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
 
     if (0 < accuracyNs)
     {
@@ -56,7 +54,4 @@ int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     return intervalNs;
 }
 
-} // namespace score::lcm::saf::timers
-
-
-
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.cpp
@@ -12,11 +12,11 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimeValidator.hpp"
 
-namespace score::mw::lifecycle::saf::timers
+namespace score::mw::lifecycle::internal::saf::timers
 {
 
 int64_t CycleTimeValidator::getMonotonicClockAccuracy(
-    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::internal::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     struct timespec clockResolution{};
     int64_t accuracyNs{-1};
@@ -32,12 +32,12 @@ int64_t CycleTimeValidator::getMonotonicClockAccuracy(
 
 int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     const int64_t f_requested_interval_ns,
-    const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
+    const score::mw::lifecycle::internal::saf::timers::OsClockInterface& f_clock_sys) noexcept(true)
 {
     int64_t intervalNs{-1};  // start with an invalid value
 
     const int64_t accuracyNs{
-        score::mw::lifecycle::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
+        score::mw::lifecycle::internal::saf::timers::CycleTimeValidator::getMonotonicClockAccuracy(f_clock_sys)};
 
     if (0 < accuracyNs)
     {
@@ -54,4 +54,4 @@ int64_t CycleTimeValidator::adjustCycleTimeOnClockAccuracy(
     return intervalNs;
 }
 
-}  // namespace score::mw::lifecycle::saf::timers
+}  // namespace score::mw::lifecycle::internal::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -34,8 +34,8 @@ class CycleTimeValidator
     /// @brief Get the monotonic clock accuracy in nanoseconds
     /// @param[in] f_clock_sys Interface to access the system clock functionality
     /// @return nanoseconds or -1 if receiving the clock resolution fails
-    static int64_t getMonotonicClockAccuracy(const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(
-        true);
+    static int64_t getMonotonicClockAccuracy(
+        const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
 
     /// @brief Adjust a given time interval based on the clock accuracy of
     /// the monotonic clock.
@@ -47,12 +47,12 @@ class CycleTimeValidator
     /// - -1 if retrieving the system's clock resolution failed
     static int64_t adjustCycleTimeOnClockAccuracy(
         const int64_t f_requested_interval_ns,
-        const score::lcm::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
+        const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
 };
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimeValidator.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -35,7 +35,7 @@ class CycleTimeValidator
     /// @param[in] f_clock_sys Interface to access the system clock functionality
     /// @return nanoseconds or -1 if receiving the clock resolution fails
     static int64_t getMonotonicClockAccuracy(
-        const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
+        const score::mw::lifecycle::internal::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
 
     /// @brief Adjust a given time interval based on the clock accuracy of
     /// the monotonic clock.
@@ -47,12 +47,12 @@ class CycleTimeValidator
     /// - -1 if retrieving the system's clock resolution failed
     static int64_t adjustCycleTimeOnClockAccuracy(
         const int64_t f_requested_interval_ns,
-        const score::mw::lifecycle::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
+        const score::mw::lifecycle::internal::saf::timers::OsClockInterface& f_clock_sys) noexcept(true);
 };
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
@@ -13,13 +13,10 @@
 #include "score/mw/launch_manager/alive_monitor/details/timers/CycleTimer.hpp"
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+
+
+
+namespace score::lcm::saf::timers
 {
 /* RULECHECKER_comment(0, 3, check_static_object_zero_initialization, "As per rule definition, \
 using constexpr enforces constant initialization by the compiler", false) */
@@ -98,7 +95,7 @@ void CycleTimer::handleNanoSecOverflow() noexcept(true)
     }
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::timers
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
@@ -14,15 +14,13 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-
-
-namespace score::lcm::saf::timers
+namespace score::mw::lifecycle::saf::timers
 {
 /* RULECHECKER_comment(0, 3, check_static_object_zero_initialization, "As per rule definition, \
 using constexpr enforces constant initialization by the compiler", false) */
 constexpr int CycleTimer::kDeadlineAlreadyOver;
 
-CycleTimer::CycleTimer(const score::lcm::saf::timers::OsClockInterface* f_osInterface) noexcept
+CycleTimer::CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept
     : osInterface{f_osInterface}, sleepIntervalNs{0}, deadline{}
 {
     static_cast<void>(0U);
@@ -95,7 +93,4 @@ void CycleTimer::handleNanoSecOverflow() noexcept(true)
     }
 }
 
-} // namespace score::lcm::saf::timers
-
-
-
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.cpp
@@ -14,13 +14,13 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score::mw::lifecycle::saf::timers
+namespace score::mw::lifecycle::internal::saf::timers
 {
 /* RULECHECKER_comment(0, 3, check_static_object_zero_initialization, "As per rule definition, \
 using constexpr enforces constant initialization by the compiler", false) */
 constexpr int CycleTimer::kDeadlineAlreadyOver;
 
-CycleTimer::CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept
+CycleTimer::CycleTimer(const score::mw::lifecycle::internal::saf::timers::OsClockInterface* f_osInterface) noexcept
     : osInterface{f_osInterface}, sleepIntervalNs{0}, deadline{}
 {
     static_cast<void>(0U);
@@ -93,4 +93,4 @@ void CycleTimer::handleNanoSecOverflow() noexcept(true)
     }
 }
 
-}  // namespace score::mw::lifecycle::saf::timers
+}  // namespace score::mw::lifecycle::internal::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -47,7 +47,7 @@ class CycleTimer
     /// @brief Sets the interface for performing the OS clock system calls.
     /// @param[in] f_osInterface OS clock interface to access clock_nanosleep() and clock_gettime() via
     /// OsClockInterface. The pointer allows the interface exchange to enhance testability.
-    explicit CycleTimer(const score::lcm::saf::timers::OsClockInterface* f_osInterface) noexcept;
+    explicit CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept;
 
     /// @brief Initialize the time interval object and check for internal errors, which prevent from incorrect
     /// execution.
@@ -130,7 +130,7 @@ class CycleTimer
     void handleNanoSecOverflow() noexcept;
 
     /// @brief Interface to perform system calls such as clock_nanosleep()
-    const score::lcm::saf::timers::OsClockInterface* osInterface;
+    const score::mw::lifecycle::saf::timers::OsClockInterface* osInterface;
 
     /// @brief Cycle time interval value in nanoseconds
     ///
@@ -145,7 +145,7 @@ class CycleTimer
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/CycleTimer.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -47,7 +47,7 @@ class CycleTimer
     /// @brief Sets the interface for performing the OS clock system calls.
     /// @param[in] f_osInterface OS clock interface to access clock_nanosleep() and clock_gettime() via
     /// OsClockInterface. The pointer allows the interface exchange to enhance testability.
-    explicit CycleTimer(const score::mw::lifecycle::saf::timers::OsClockInterface* f_osInterface) noexcept;
+    explicit CycleTimer(const score::mw::lifecycle::internal::saf::timers::OsClockInterface* f_osInterface) noexcept;
 
     /// @brief Initialize the time interval object and check for internal errors, which prevent from incorrect
     /// execution.
@@ -130,7 +130,7 @@ class CycleTimer
     void handleNanoSecOverflow() noexcept;
 
     /// @brief Interface to perform system calls such as clock_nanosleep()
-    const score::mw::lifecycle::saf::timers::OsClockInterface* osInterface;
+    const score::mw::lifecycle::internal::saf::timers::OsClockInterface* osInterface;
 
     /// @brief Cycle time interval value in nanoseconds
     ///
@@ -145,7 +145,7 @@ class CycleTimer
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -106,7 +106,7 @@ class OsClockInterface
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/OsClockInterface.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -106,7 +106,7 @@ class OsClockInterface
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
@@ -15,13 +15,10 @@
 
 #include <limits>
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+
+
+
+namespace score::lcm::saf::timers
 {
 
 NanoSecondType TimeConversion::convertToNanoSec(const timespec f_timespec) noexcept(true)
@@ -72,7 +69,7 @@ double TimeConversion::convertNanoSecToMilliSec(const NanoSecondType f_timeValue
     return milliSeconds;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::timers
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
@@ -15,10 +15,7 @@
 
 #include <limits>
 
-
-
-
-namespace score::lcm::saf::timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 NanoSecondType TimeConversion::convertToNanoSec(const timespec f_timespec) noexcept(true)
@@ -69,7 +66,4 @@ double TimeConversion::convertNanoSecToMilliSec(const NanoSecondType f_timeValue
     return milliSeconds;
 }
 
-} // namespace score::lcm::saf::timers
-
-
-
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.cpp
@@ -15,7 +15,7 @@
 
 #include <limits>
 
-namespace score::mw::lifecycle::saf::timers
+namespace score::mw::lifecycle::internal::saf::timers
 {
 
 NanoSecondType TimeConversion::convertToNanoSec(const timespec f_timespec) noexcept(true)
@@ -66,4 +66,4 @@ double TimeConversion::convertNanoSecToMilliSec(const NanoSecondType f_timeValue
     return milliSeconds;
 }
 
-}  // namespace score::mw::lifecycle::saf::timers
+}  // namespace score::mw::lifecycle::internal::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -71,7 +71,7 @@ class TimeConversion
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion.hpp
@@ -23,7 +23,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -71,7 +71,7 @@ class TimeConversion
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
@@ -20,8 +20,8 @@
 
 using namespace testing;
 
-using score::mw::lifecycle::saf::timers::NanoSecondType;
-using score::mw::lifecycle::saf::timers::TimeConversion;
+using score::mw::lifecycle::internal::saf::timers::NanoSecondType;
+using score::mw::lifecycle::internal::saf::timers::TimeConversion;
 
 namespace
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/TimeConversion_UT.cpp
@@ -20,8 +20,8 @@
 
 using namespace testing;
 
-using score::lcm::saf::timers::NanoSecondType;
-using score::lcm::saf::timers::TimeConversion;
+using score::mw::lifecycle::saf::timers::NanoSecondType;
+using score::mw::lifecycle::saf::timers::TimeConversion;
 
 namespace
 {

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
@@ -21,13 +21,10 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace saf
-{
-namespace timers
+
+
+
+namespace score::lcm::saf::timers
 {
 
 NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
@@ -56,7 +53,7 @@ NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
     return result;
 }
 
-}  // namespace timers
-}  // namespace saf
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::saf::timers
+
+
+

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
@@ -21,7 +21,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-namespace score::mw::lifecycle::saf::timers
+namespace score::mw::lifecycle::internal::saf::timers
 {
 
 NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
@@ -50,4 +50,4 @@ NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
     return result;
 }
 
-}  // namespace score::mw::lifecycle::saf::timers
+}  // namespace score::mw::lifecycle::internal::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.cpp
@@ -21,10 +21,7 @@
 
 #include "score/mw/launch_manager/alive_monitor/details/timers/TimeConversion.hpp"
 
-
-
-
-namespace score::lcm::saf::timers
+namespace score::mw::lifecycle::saf::timers
 {
 
 NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
@@ -53,7 +50,4 @@ NanoSecondType OsClock::getMonotonicSystemClock(void) noexcept(true)
     return result;
 }
 
-} // namespace score::lcm::saf::timers
-
-
-
+}  // namespace score::mw::lifecycle::saf::timers

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace saf
 {
@@ -55,7 +55,7 @@ class OsClock
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
+++ b/score/launch_manager/src/daemon/src/alive_monitor/details/timers/Timers_OsClock.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace saf
 {
@@ -55,7 +55,7 @@ class OsClock
 
 }  // namespace timers
 }  // namespace saf
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/common/alive_interface_path.hpp
+++ b/score/launch_manager/src/daemon/src/common/alive_interface_path.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -30,7 +30,7 @@ inline std::string aliveInterfacePath(const std::string& component_name)
 }
 
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif  // ALIVE_INTERFACE_PATH_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
@@ -20,7 +20,7 @@ namespace
 // that links this library gets diagnostic output on assertion failure without any
 // explicit setup call.
 const bool kAssertionHandlerRegistered = []() noexcept {
-    score::mw::lifecycle::common::registerAssertionHandler();
+    score::mw::lifecycle::internal::common::registerAssertionHandler();
     return true;
 }();
 

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.cpp
@@ -20,7 +20,7 @@ namespace
 // that links this library gets diagnostic output on assertion failure without any
 // explicit setup call.
 const bool kAssertionHandlerRegistered = []() noexcept {
-    score::lcm::common::registerAssertionHandler();
+    score::mw::lifecycle::common::registerAssertionHandler();
     return true;
 }();
 

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace score::lcm::common
+namespace score::mw::lifecycle::common
 {
 
 inline void registerAssertionHandler() noexcept
@@ -38,6 +38,6 @@ inline void registerAssertionHandler() noexcept
     });
 }
 
-}  // namespace score::lcm::common
+}  // namespace score::mw::lifecycle::common
 
 #endif  // ASSERTION_HANDLER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
+++ b/score/launch_manager/src/daemon/src/common/assertion_handler.hpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace score::mw::lifecycle::common
+namespace score::mw::lifecycle::internal::common
 {
 
 inline void registerAssertionHandler() noexcept
@@ -38,6 +38,6 @@ inline void registerAssertionHandler() noexcept
     });
 }
 
-}  // namespace score::mw::lifecycle::common
+}  // namespace score::mw::lifecycle::internal::common
 
 #endif  // ASSERTION_HANDLER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/concurrency_error_domain.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <ostream>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 enum class ConcurrencyErrc : std::uint8_t
@@ -52,12 +52,12 @@ inline std::ostream& operator<<(std::ostream& os, ConcurrencyErrc errc) noexcept
     }
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #ifdef LC_LOG_SCORE_MW_LOG
 #include "score/mw/log/logger.h"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& os, ConcurrencyErrc errc) noexcept
@@ -77,7 +77,7 @@ inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& os, Conc
     }
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // LC_LOG_SCORE_MW_LOG
 

--- a/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <vector>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Fixed-size FIFO queue
@@ -126,6 +126,6 @@ class FixedSizeQueue
     std::vector<std::optional<T>> slots_;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // FIXED_SIZED_QUEUE_HPP_INCLUDE

--- a/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/fixed_size_queue_test.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class FixedSizeQueueTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue.hpp
@@ -30,7 +30,7 @@
 #include "score/mw/launch_manager/osal/semaphore.hpp"
 #include <score/expected.hpp>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 // this is based on https://github.com/rigtorp/MPMCQueue
 
@@ -305,6 +305,6 @@ class MPMCConcurrentQueue
     osal::Semaphore m_spaces{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // MPMC_CONCURRENT_QUEUE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_benchmark.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_benchmark.cpp
@@ -20,7 +20,7 @@
 #include <thread>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 constexpr std::uint64_t g_items_per_prod = 10'000;
 

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpmc_concurrent_queue_test.cpp
@@ -24,7 +24,7 @@
 #include <tuple>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class MPMCConcurrentQueueTest_Basic : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue.hpp
@@ -29,7 +29,7 @@
 #include <score/assert.hpp>
 #include <score/expected.hpp>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Fixed-capacity queue for the multi-producer / single-consumer case,
@@ -176,6 +176,6 @@ class MpscBoundedQueue
     std::thread::id consumer_thread_id_{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // MPSC_BOUNDED_QUEUE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue_test.cpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/mpsc_bounded_queue_test.cpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 class MpscBoundedQueueTest_Basic : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace score::mw::lifecycle::internal;
@@ -117,6 +117,6 @@ class WorkerThread final
     std::vector<std::unique_ptr<std::thread>> worker_threads_{};
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // WORKER_THREAD_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
+++ b/score/launch_manager/src/daemon/src/common/concurrency/workerthread.hpp
@@ -25,8 +25,6 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::mw::lifecycle::internal;
-
 /// @brief Templated worker thread pool for executing jobs from a queue.
 /// This class manages a pool of worker threads that continuously retrieve and execute jobs
 /// from an MPMCConcurrentQueue until the pool is stopped or destructed.

--- a/score/launch_manager/src/daemon/src/common/constants.hpp
+++ b/score/launch_manager/src/daemon/src/common/constants.hpp
@@ -21,7 +21,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -77,7 +77,7 @@ enum class ProcessLimits : std::uint32_t
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
@@ -16,10 +16,9 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace score
-{
 
-namespace lcm
+
+namespace score::lcm
 {
 
 // Please note that a lot of the following info, would normally belong to identifier_hash.hpp file.
@@ -133,6 +132,6 @@ std::mutex& IdentifierHash::get_registry_mutex()
     return registry_mutex;
 }
 
-}  // namespace lcm
+} // namespace score::lcm
 
-}  // namespace score
+

--- a/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash.cpp
@@ -16,9 +16,7 @@
 #include <mutex>
 #include <unordered_map>
 
-
-
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 // Please note that a lot of the following info, would normally belong to identifier_hash.hpp file.
@@ -132,6 +130,4 @@ std::mutex& IdentifierHash::get_registry_mutex()
     return registry_mutex;
 }
 
-} // namespace score::lcm
-
-
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/common/identifier_hash.hpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash.hpp
@@ -22,7 +22,7 @@
 #include <string_view>
 #include <unordered_map>
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 /// @file identifier_hash.hpp
@@ -168,12 +168,12 @@ inline std::ostream& operator<<(std::ostream& stream, const IdentifierHash& id_h
     return stream;
 }
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #ifdef LC_LOG_SCORE_MW_LOG
 #include "score/mw/log/logger.h"
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& stream, const IdentifierHash& id_hash) noexcept(
@@ -193,7 +193,7 @@ inline score::mw::log::LogStream& operator<<(score::mw::log::LogStream& stream, 
     return stream;
 }
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #endif  // LC_LOG_SCORE_MW_LOG
 

--- a/score/launch_manager/src/daemon/src/common/identifier_hash_UT.cpp
+++ b/score/launch_manager/src/daemon/src/common/identifier_hash_UT.cpp
@@ -20,7 +20,7 @@
 using namespace testing;
 using std::stringstream;
 
-using score::lcm::IdentifierHash;
+using score::mw::lifecycle::IdentifierHash;
 
 class IdentifierHashTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/common/log.hpp
+++ b/score/launch_manager/src/daemon/src/common/log.hpp
@@ -27,7 +27,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -48,7 +48,7 @@ inline score::mw::log::Logger& _getLmLogger() noexcept
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 
@@ -60,7 +60,7 @@ inline score::mw::log::Logger& _getLmLogger() noexcept
 #include <iostream>
 #include <string>
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 enum class LogLevel
@@ -270,11 +270,11 @@ inline Logger& _getLmLogger() noexcept
     return log;
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // LC_LOG_SCORE_MW_LOG
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 /// @brief Returns a string_view of the errno error message.
@@ -284,13 +284,13 @@ inline std::string_view errno_message(const int err) noexcept(true)
     return std::string_view{std::strerror(err)};
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 // wrapper macros for Launch Manager
-#define LM_LOG_FATAL() (score::lcm::internal::_getLmLogger().LogFatal())
-#define LM_LOG_ERROR() (score::lcm::internal::_getLmLogger().LogError())
-#define LM_LOG_WARN()  (score::lcm::internal::_getLmLogger().LogWarn())
-#define LM_LOG_INFO()  (score::lcm::internal::_getLmLogger().LogInfo())
-#define LM_LOG_DEBUG() (score::lcm::internal::_getLmLogger().LogDebug())
+#define LM_LOG_FATAL() (score::mw::lifecycle::internal::_getLmLogger().LogFatal())
+#define LM_LOG_ERROR() (score::mw::lifecycle::internal::_getLmLogger().LogError())
+#define LM_LOG_WARN()  (score::mw::lifecycle::internal::_getLmLogger().LogWarn())
+#define LM_LOG_INFO()  (score::mw::lifecycle::internal::_getLmLogger().LogInfo())
+#define LM_LOG_DEBUG() (score::mw::lifecycle::internal::_getLmLogger().LogDebug())
 
 #endif  // LCM_LOG_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
+++ b/score/launch_manager/src/daemon/src/common/process_group_state_id.hpp
@@ -19,7 +19,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -31,13 +31,13 @@ namespace internal
 // have user-declared constructor. The rule doesn’t apply.", false)
 struct ProcessGroupStateID final
 {
-    score::lcm::IdentifierHash pg_name_;        ///< Name of the process group.
-    score::lcm::IdentifierHash pg_state_name_;  ///< Name of the process group state.
+    score::mw::lifecycle::IdentifierHash pg_name_;        ///< Name of the process group.
+    score::mw::lifecycle::IdentifierHash pg_state_name_;  ///< Name of the process group state.
 };
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/common/signal_safe_log.hpp
+++ b/score/launch_manager/src/daemon/src/common/signal_safe_log.hpp
@@ -92,7 +92,7 @@ class signal_safe_buffer
 
 }  // namespace
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 template <typename... T>
@@ -125,6 +125,6 @@ template <typename... T>
 #endif
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif

--- a/score/launch_manager/src/daemon/src/common/signal_safe_log_UT.cpp
+++ b/score/launch_manager/src/daemon/src/common/signal_safe_log_UT.cpp
@@ -16,8 +16,8 @@
 #include "score/mw/launch_manager/common/signal_safe_log.hpp"
 
 using namespace testing;
-using score::lcm::internal::signal_safe_log;
-using score::lcm::internal::signal_safe_log_errno;
+using score::mw::lifecycle::internal::signal_safe_log;
+using score::mw::lifecycle::internal::signal_safe_log_errno;
 
 class signal_safe_log_test : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/configuration/config.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config.hpp
@@ -20,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 enum class ApplicationType : uint8_t
@@ -290,6 +290,6 @@ class ConfigBuilder
     std::optional<WatchdogConfig> watchdog_;
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // CONFIG_HPP

--- a/score/launch_manager/src/daemon/src/configuration/config.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config.hpp
@@ -20,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 enum class ApplicationType : uint8_t
@@ -290,6 +290,6 @@ class ConfigBuilder
     std::optional<WatchdogConfig> watchdog_;
 };
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration
 
 #endif  // CONFIG_HPP

--- a/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
@@ -20,7 +20,7 @@
 #include <score/expected.hpp>
 #include <cstdint>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 /// @brief Abstract interface for loading Launch Manager configuration from a file.
@@ -53,6 +53,6 @@ class IConfigLoader
     [[nodiscard]] virtual score::cpp::expected<Config, Error> load(const score::filesystem::Path& path) = 0;
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/config_loader.hpp
@@ -20,7 +20,7 @@
 #include <score/expected.hpp>
 #include <cstdint>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 /// @brief Abstract interface for loading Launch Manager configuration from a file.
@@ -53,6 +53,6 @@ class IConfigLoader
     [[nodiscard]] virtual score::cpp::expected<Config, Error> load(const score::filesystem::Path& path) = 0;
 };
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration
 
 #endif  // CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <set>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 namespace
@@ -560,4 +560,4 @@ std::optional<const ProcessGroup*> ConfigurationAdapter::getProcessGroupByNameAn
     return std::nullopt;
 }
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
@@ -32,22 +32,22 @@ constexpr uint32_t kDefaultProcessExecutionError = 1U;
 
 uint64_t defaultProcessorAffinityMask()
 {
-    return (1ULL << score::lcm::internal::osal::getNumCores()) - 1ULL;
+    return (1ULL << score::mw::lifecycle::internal::osal::getNumCores()) - 1ULL;
 }
 }  // namespace
 
-score::lcm::internal::osal::CommsType ConfigurationAdapter::mapApplicationType(ApplicationType app_type) const
+score::mw::lifecycle::internal::osal::CommsType ConfigurationAdapter::mapApplicationType(ApplicationType app_type) const
 {
     switch (app_type)
     {
         case ApplicationType::Reporting:
         case ApplicationType::ReportingAndSupervised:
-            return score::lcm::internal::osal::CommsType::kReporting;
+            return score::mw::lifecycle::internal::osal::CommsType::kReporting;
         case ApplicationType::StateManager:
-            return score::lcm::internal::osal::CommsType::kControlClient;
+            return score::mw::lifecycle::internal::osal::CommsType::kControlClient;
         case ApplicationType::Native:
         default:
-            return score::lcm::internal::osal::CommsType::kNoComms;
+            return score::mw::lifecycle::internal::osal::CommsType::kNoComms;
     }
 }
 
@@ -62,7 +62,8 @@ void ConfigurationAdapter::deinitialize()
     {
         for (auto& process : process_group.processes_)
         {
-            for (size_t i = 0U; i < score::lcm::internal::kArgvArraySize && process.startup_config_.argv_[i] != nullptr;
+            for (size_t i = 0U;
+                 i < score::mw::lifecycle::internal::kArgvArraySize && process.startup_config_.argv_[i] != nullptr;
                  ++i)
             {
                 free(const_cast<char*>(process.startup_config_.argv_[i]));
@@ -81,7 +82,7 @@ void ConfigurationAdapter::deinitialize()
 
 void ConfigurationAdapter::fillStartupConfigFromDeployment(
     const ComponentConfig& comp,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     const auto& deploy = comp.deployment_config;
     const auto& props = comp.component_properties;
@@ -112,7 +113,7 @@ void ConfigurationAdapter::fillStartupConfigFromDeployment(
 
 void ConfigurationAdapter::fillStartupArguments(
     const ComponentProperties& props,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     // strdup() returns nullptr on OOM. On this embedded target, OOM during daemon
     // startup is unrecoverable — the OS will terminate the process.
@@ -120,8 +121,10 @@ void ConfigurationAdapter::fillStartupArguments(
     startup.argv_[arg_index++] = strdup(startup.executable_path_.c_str());
 
     assert(
-        props.process_arguments.size() <= score::lcm::internal::kMaxArg && "Too many process arguments for argv array");
-    size_t max_args = std::min(props.process_arguments.size(), static_cast<size_t>(score::lcm::internal::kMaxArg));
+        props.process_arguments.size() <= score::mw::lifecycle::internal::kMaxArg &&
+        "Too many process arguments for argv array");
+    size_t max_args =
+        std::min(props.process_arguments.size(), static_cast<size_t>(score::mw::lifecycle::internal::kMaxArg));
     for (size_t i = 0U; i < max_args; ++i)
     {
         startup.argv_[arg_index++] = strdup(props.process_arguments[i].c_str());
@@ -130,15 +133,15 @@ void ConfigurationAdapter::fillStartupArguments(
 
 size_t ConfigurationAdapter::fillStartupEnvironment(
     const DeploymentConfig& deploy,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     size_t env_index = 0U;
 
     assert(
-        deploy.environmental_variables.size() + 1U <= score::lcm::internal::kMaxEnv &&
+        deploy.environmental_variables.size() + 1U <= score::mw::lifecycle::internal::kMaxEnv &&
         "Too many environmental variables for envp array");
     size_t max_env =
-        std::min(deploy.environmental_variables.size(), static_cast<size_t>(score::lcm::internal::kMaxEnv));
+        std::min(deploy.environmental_variables.size(), static_cast<size_t>(score::mw::lifecycle::internal::kMaxEnv));
     size_t env_count = 0;
     for (const auto& ev : deploy.environmental_variables)
     {
@@ -158,18 +161,18 @@ size_t ConfigurationAdapter::fillStartupEnvironment(
 void ConfigurationAdapter::appendAliveInterfaceEnvironment(
     const ComponentConfig& comp,
     size_t& env_index,
-    score::lcm::internal::osal::OsalConfig& startup) const
+    score::mw::lifecycle::internal::osal::OsalConfig& startup) const
 {
     bool is_supervised =
         comp.component_properties.application_profile.application_type == ApplicationType::ReportingAndSupervised ||
         comp.component_properties.application_profile.application_type == ApplicationType::StateManager;
-    if (!is_supervised || env_index >= static_cast<size_t>(score::lcm::internal::kMaxEnv))
+    if (!is_supervised || env_index >= static_cast<size_t>(score::mw::lifecycle::internal::kMaxEnv))
     {
         return;
     }
 
     std::string iface_path =
-        std::string(kAliveInterfaceEnvName) + "=" + score::lcm::internal::aliveInterfacePath(comp.name);
+        std::string(kAliveInterfaceEnvName) + "=" + score::mw::lifecycle::internal::aliveInterfacePath(comp.name);
     startup.envp_[env_index++] = strdup(iface_path.c_str());
 }
 
@@ -200,7 +203,7 @@ DependencyList ConfigurationAdapter::buildDependencyList(const ComponentProperti
     for (const auto& dep_name : props.depends_on)
     {
         Dependency dep{};
-        dep.process_state_ = score::lcm::ProcessState::kRunning;
+        dep.process_state_ = score::mw::lifecycle::ProcessState::kRunning;
 
         auto dep_it = component_by_name_.find(dep_name);
         if (dep_it != component_by_name_.end())
@@ -209,8 +212,8 @@ DependencyList ConfigurationAdapter::buildDependencyList(const ComponentProperti
             if (dep_props.ready_condition.has_value())
             {
                 dep.process_state_ = dep_props.ready_condition->process_state == ProcessState::Running
-                                         ? score::lcm::ProcessState::kRunning
-                                         : score::lcm::ProcessState::kTerminated;
+                                         ? score::mw::lifecycle::ProcessState::kRunning
+                                         : score::mw::lifecycle::ProcessState::kTerminated;
             }
         }
 
@@ -388,7 +391,7 @@ bool ConfigurationAdapter::buildFromConfig(const Config& config)
     process_groups_.push_back(std::move(pg));
     process_group_names_.push_back(pg_name);
 
-    main_pg_startup_state_ = score::lcm::internal::ProcessGroupStateID{
+    main_pg_startup_state_ = score::mw::lifecycle::internal::ProcessGroupStateID{
         pg_name, IdentifierHash{std::string("MainPG/") + initial_run_target_name}};
 
     LM_LOG_DEBUG() << "ConfigurationAdapter: Built configuration with " << process_groups_[0].processes_.size()
@@ -446,7 +449,8 @@ IdentifierHash ConfigurationAdapter::getNameOfRecoveryState(const IdentifierHash
     return IdentifierHash{"Recovery"};
 }
 
-std::optional<const score::lcm::internal::ProcessGroupStateID*> ConfigurationAdapter::getMainPGStartupState() const
+std::optional<const score::mw::lifecycle::internal::ProcessGroupStateID*> ConfigurationAdapter::getMainPGStartupState()
+    const
 {
     if (!process_groups_.empty())
     {
@@ -458,7 +462,7 @@ std::optional<const score::lcm::internal::ProcessGroupStateID*> ConfigurationAda
 }
 
 std::optional<const std::vector<uint32_t>*> ConfigurationAdapter::getProcessIndexesList(
-    const score::lcm::internal::ProcessGroupStateID& pg_state_id) const
+    const score::mw::lifecycle::internal::ProcessGroupStateID& pg_state_id) const
 {
     auto state = getProcessGroupStateByID(pg_state_id);
     if (state)
@@ -520,7 +524,7 @@ ProcessGroup* ConfigurationAdapter::getProcessGroupByID(const IdentifierHash& pg
 }
 
 ProcessGroupState* ConfigurationAdapter::getProcessGroupStateByID(
-    const score::lcm::internal::ProcessGroupStateID& pg_id) const
+    const score::mw::lifecycle::internal::ProcessGroupStateID& pg_id) const
 {
     ProcessGroup* pg = getProcessGroupByID(pg_id.pg_name_);
     if (pg)

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.cpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <set>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 namespace
@@ -560,4 +560,4 @@ std::optional<const ProcessGroup*> ConfigurationAdapter::getProcessGroupByNameAn
     return std::nullopt;
 }
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 using IdentifierHash = score::mw::lifecycle::IdentifierHash;
@@ -155,18 +155,18 @@ class ConfigurationAdapter final
         static_cast<IdentifierHash>("MainPG/Startup")};
 };
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 // Aliases for backward compatibility with score::mw::lifecycle::internal consumers
 namespace score::mw::lifecycle::internal
 {
-using ConfigurationAdapter = score::mw::launch_manager::configuration::ConfigurationAdapter;
-using OsProcess = score::mw::launch_manager::configuration::OsProcess;
-using DependencyList = score::mw::launch_manager::configuration::DependencyList;
-using ProcessGroup = score::mw::launch_manager::configuration::ProcessGroup;
-using ProcessGroupState = score::mw::launch_manager::configuration::ProcessGroupState;
-using PgManagerConfig = score::mw::launch_manager::configuration::PgManagerConfig;
-using Dependency = score::mw::launch_manager::configuration::Dependency;
+using ConfigurationAdapter = score::mw::lifecycle::configuration::ConfigurationAdapter;
+using OsProcess = score::mw::lifecycle::configuration::OsProcess;
+using DependencyList = score::mw::lifecycle::configuration::DependencyList;
+using ProcessGroup = score::mw::lifecycle::configuration::ProcessGroup;
+using ProcessGroupState = score::mw::lifecycle::configuration::ProcessGroupState;
+using PgManagerConfig = score::mw::lifecycle::configuration::PgManagerConfig;
+using Dependency = score::mw::lifecycle::configuration::Dependency;
 }  // namespace score::mw::lifecycle::internal
 
 #endif  // CONFIGURATIONADAPTER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 struct PgManagerConfig final
@@ -153,18 +153,18 @@ class ConfigurationAdapter final
         static_cast<IdentifierHash>("MainPG/Startup")};
 };
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration
 
 // Aliases for backward compatibility with score::mw::lifecycle::internal consumers
 namespace score::mw::lifecycle::internal
 {
-using ConfigurationAdapter = score::mw::lifecycle::configuration::ConfigurationAdapter;
-using OsProcess = score::mw::lifecycle::configuration::OsProcess;
-using DependencyList = score::mw::lifecycle::configuration::DependencyList;
-using ProcessGroup = score::mw::lifecycle::configuration::ProcessGroup;
-using ProcessGroupState = score::mw::lifecycle::configuration::ProcessGroupState;
-using PgManagerConfig = score::mw::lifecycle::configuration::PgManagerConfig;
-using Dependency = score::mw::lifecycle::configuration::Dependency;
+using ConfigurationAdapter = score::mw::lifecycle::internal::configuration::ConfigurationAdapter;
+using OsProcess = score::mw::lifecycle::internal::configuration::OsProcess;
+using DependencyList = score::mw::lifecycle::internal::configuration::DependencyList;
+using ProcessGroup = score::mw::lifecycle::internal::configuration::ProcessGroup;
+using ProcessGroupState = score::mw::lifecycle::internal::configuration::ProcessGroupState;
+using PgManagerConfig = score::mw::lifecycle::internal::configuration::PgManagerConfig;
+using Dependency = score::mw::lifecycle::internal::configuration::Dependency;
 }  // namespace score::mw::lifecycle::internal
 
 #endif  // CONFIGURATIONADAPTER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
@@ -30,7 +30,7 @@
 namespace score::mw::launch_manager::configuration
 {
 
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 struct PgManagerConfig final
 {
@@ -43,7 +43,7 @@ struct PgManagerConfig final
 
 struct Dependency final
 {
-    score::lcm::ProcessState process_state_{};
+    score::mw::lifecycle::ProcessState process_state_{};
     IdentifierHash target_process_id_{};
     uint32_t os_process_index_{};
 };
@@ -54,7 +54,7 @@ struct OsProcess final
 {
     IdentifierHash process_id_{};
     uint32_t process_number_{};
-    score::lcm::internal::osal::OsalConfig startup_config_{};
+    score::mw::lifecycle::internal::osal::OsalConfig startup_config_{};
     PgManagerConfig pgm_config_{};
     DependencyList dependencies_{};
 };
@@ -92,9 +92,9 @@ class ConfigurationAdapter final
     std::optional<uint32_t> getNumberOfOsProcesses(const IdentifierHash& pg_name) const;
     IdentifierHash getNameOfOffState(const IdentifierHash& pg_name) const;
     IdentifierHash getNameOfRecoveryState(const IdentifierHash& pg_name) const;
-    std::optional<const score::lcm::internal::ProcessGroupStateID*> getMainPGStartupState() const;
+    std::optional<const score::mw::lifecycle::internal::ProcessGroupStateID*> getMainPGStartupState() const;
     std::optional<const std::vector<uint32_t>*> getProcessIndexesList(
-        const score::lcm::internal::ProcessGroupStateID& process_group_state_id) const;
+        const score::mw::lifecycle::internal::ProcessGroupStateID& process_group_state_id) const;
     std::optional<const std::vector<ProcessGroupState>*> getListOfProcessGroupStates(
         const IdentifierHash& pg_name) const;
     std::optional<const OsProcess*> getOsProcessConfiguration(const IdentifierHash& pg_name_, const uint32_t index)
@@ -109,15 +109,19 @@ class ConfigurationAdapter final
     bool buildFromConfig(const Config& config);
 
     OsProcess buildOsProcess(const ComponentConfig& comp, uint32_t process_index) const;
-    void fillStartupConfigFromDeployment(const ComponentConfig& comp, score::lcm::internal::osal::OsalConfig& startup)
-        const;
-    void fillStartupArguments(const ComponentProperties& props, score::lcm::internal::osal::OsalConfig& startup) const;
-    size_t fillStartupEnvironment(const DeploymentConfig& deploy, score::lcm::internal::osal::OsalConfig& startup)
-        const;
+    void fillStartupConfigFromDeployment(
+        const ComponentConfig& comp,
+        score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
+    void fillStartupArguments(
+        const ComponentProperties& props,
+        score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
+    size_t fillStartupEnvironment(
+        const DeploymentConfig& deploy,
+        score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
     void appendAliveInterfaceEnvironment(
         const ComponentConfig& comp,
         size_t& env_index,
-        score::lcm::internal::osal::OsalConfig& startup) const;
+        score::mw::lifecycle::internal::osal::OsalConfig& startup) const;
     PgManagerConfig buildPgManagerConfig(const ComponentConfig& comp) const;
     DependencyList buildDependencyList(const ComponentProperties& props) const;
 
@@ -134,10 +138,10 @@ class ConfigurationAdapter final
 
     static void resolveDependencyIndexes(std::vector<OsProcess>& processes);
 
-    score::lcm::internal::osal::CommsType mapApplicationType(ApplicationType app_type) const;
+    score::mw::lifecycle::internal::osal::CommsType mapApplicationType(ApplicationType app_type) const;
 
     ProcessGroup* getProcessGroupByID(const IdentifierHash& pg_name) const;
-    ProcessGroupState* getProcessGroupStateByID(const score::lcm::internal::ProcessGroupStateID& pg_id) const;
+    ProcessGroupState* getProcessGroupStateByID(const score::mw::lifecycle::internal::ProcessGroupStateID& pg_id) const;
     std::optional<const ProcessGroup*> getProcessGroupByNameAndIndex(
         const IdentifierHash& pg_name,
         const uint32_t index) const;
@@ -146,15 +150,15 @@ class ConfigurationAdapter final
     std::map<std::string, uint32_t> component_to_process_index_{};
     std::vector<ProcessGroup> process_groups_{};
     std::vector<IdentifierHash> process_group_names_{};
-    score::lcm::internal::ProcessGroupStateID main_pg_startup_state_{
+    score::mw::lifecycle::internal::ProcessGroupStateID main_pg_startup_state_{
         static_cast<IdentifierHash>("MainPG"),
         static_cast<IdentifierHash>("MainPG/Startup")};
 };
 
 }  // namespace score::mw::launch_manager::configuration
 
-// Aliases for backward compatibility with score::lcm::internal consumers
-namespace score::lcm::internal
+// Aliases for backward compatibility with score::mw::lifecycle::internal consumers
+namespace score::mw::lifecycle::internal
 {
 using ConfigurationAdapter = score::mw::launch_manager::configuration::ConfigurationAdapter;
 using OsProcess = score::mw::launch_manager::configuration::OsProcess;
@@ -163,6 +167,6 @@ using ProcessGroup = score::mw::launch_manager::configuration::ProcessGroup;
 using ProcessGroupState = score::mw::launch_manager::configuration::ProcessGroupState;
 using PgManagerConfig = score::mw::launch_manager::configuration::PgManagerConfig;
 using Dependency = score::mw::launch_manager::configuration::Dependency;
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // CONFIGURATIONADAPTER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter.hpp
@@ -30,8 +30,6 @@
 namespace score::mw::lifecycle::configuration
 {
 
-using IdentifierHash = score::mw::lifecycle::IdentifierHash;
-
 struct PgManagerConfig final
 {
     bool is_self_terminating_{};

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <string>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
@@ -572,4 +572,4 @@ TEST(ConfigurationAdapterFallbackTest, FallbackRunTargetResolvesDependenciesRecu
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
@@ -29,7 +29,7 @@ using ::testing::IsNull;
 using ::testing::Ne;
 using ::testing::NotNull;
 
-using IdentifierHash = score::lcm::IdentifierHash;
+using IdentifierHash = score::mw::lifecycle::IdentifierHash;
 
 Config makeMinimalConfig()
 {
@@ -173,7 +173,8 @@ TEST_F(ConfigurationAdapterTest, GetProcessIndexesListResolvesRunTargetDependenc
 {
     RecordProperty("Description", "getProcessIndexesList resolves RunTarget depends_on to component indexes.");
 
-    score::lcm::internal::ProcessGroupStateID startup_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Startup"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID startup_id{
+        IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Startup"}};
 
     auto result = adapter_.getProcessIndexesList(startup_id);
 
@@ -189,7 +190,8 @@ TEST_F(ConfigurationAdapterTest, GetProcessIndexesListResolvesTransitiveDependen
         "Description",
         "Full run target depends on comp_b and Startup; transitive resolution yields both component indexes.");
 
-    score::lcm::internal::ProcessGroupStateID full_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Full"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID full_id{
+        IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Full"}};
 
     auto result = adapter_.getProcessIndexesList(full_id);
 
@@ -276,7 +278,7 @@ TEST_F(ConfigurationAdapterTest, GetOsProcessDependenciesMapsComponentDependsOn)
     ASSERT_THAT(deps->size(), Eq(1U));
     EXPECT_THAT((*deps)[0].target_process_id_, Eq(IdentifierHash{"comp_a"}));
     EXPECT_THAT((*deps)[0].os_process_index_, Eq(0U));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kRunning));
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ConfigurationAdapterTest, GetOsProcessDependenciesEmptyForComponentWithNoDeps)
@@ -334,7 +336,7 @@ TEST_F(ConfigurationAdapterTest, OffStateReturnsProcessIndexesListEmpty)
 {
     RecordProperty("Description", "The Off state has no process indexes.");
 
-    score::lcm::internal::ProcessGroupStateID off_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Off"}};
+    score::mw::lifecycle::internal::ProcessGroupStateID off_id{IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/Off"}};
 
     auto result = adapter_.getProcessIndexesList(off_id);
 
@@ -412,7 +414,7 @@ TEST(ConfigurationAdapterReadyConditionTest, DependencyUsesTargetComponentReadyC
     const auto* deps = *result;
     ASSERT_THAT(deps->size(), Eq(1U));
     EXPECT_THAT((*deps)[0].target_process_id_, Eq(IdentifierHash{"comp_a"}));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kTerminated))
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kTerminated))
         << "Dependency should use comp_a's ready_condition (Terminated), not comp_b's (Running)";
 
     adapter.deinitialize();
@@ -485,7 +487,7 @@ TEST(ConfigurationAdapterReadyConditionTest, DependencyDefaultsToRunningWhenTarg
     ASSERT_TRUE(result.has_value());
     const auto* deps = *result;
     ASSERT_THAT(deps->size(), Eq(1U));
-    EXPECT_THAT((*deps)[0].process_state_, Eq(score::lcm::ProcessState::kRunning))
+    EXPECT_THAT((*deps)[0].process_state_, Eq(score::mw::lifecycle::ProcessState::kRunning))
         << "comp_a has no ready_condition, so dependency should default to Running";
 
     adapter.deinitialize();
@@ -552,7 +554,7 @@ TEST(ConfigurationAdapterFallbackTest, FallbackRunTargetResolvesDependenciesRecu
     ConfigurationAdapter adapter;
     adapter.initialize(config);
 
-    score::lcm::internal::ProcessGroupStateID fallback_id{
+    score::mw::lifecycle::internal::ProcessGroupStateID fallback_id{
         IdentifierHash{"MainPG"}, IdentifierHash{"MainPG/fallback_run_target"}};
 
     auto result = adapter.getProcessIndexesList(fallback_id);

--- a/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/configuration_adapter_UT.cpp
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <string>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 namespace
 {
@@ -572,4 +572,4 @@ TEST(ConfigurationAdapterFallbackTest, FallbackRunTargetResolvesDependenciesRecu
 }
 
 }  // namespace
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config.cpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 // --- EnvironmentVariable ---
@@ -230,4 +230,4 @@ std::optional<WatchdogConfig> Config::takeWatchdog()
     return std::move(watchdog_);
 }
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config.cpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 // --- EnvironmentVariable ---
@@ -230,4 +230,4 @@ std::optional<WatchdogConfig> Config::takeWatchdog()
     return std::move(watchdog_);
 }
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <string_view>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 namespace
 {
@@ -257,4 +257,4 @@ TEST_F(EnvironmentTest, RangeBasedForLoopWorks)
 }
 
 }  // namespace
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/config_UT.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <string_view>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
@@ -257,4 +257,4 @@ TEST_F(EnvironmentTest, RangeBasedForLoopWorks)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
@@ -24,11 +24,9 @@
 #include <cstdint>
 #include <vector>
 
+namespace fb = score::mw::lifecycle::configuration::fb;
 
-
-namespace fb = score::mw::launch_manager::configuration::fb;
-
-namespace score::mw::launch_manager::configuration::details
+namespace score::mw::lifecycle::configuration::details
 {
 
 IConfigLoader::Error mapOsError(const score::os::Error& error)
@@ -146,5 +144,4 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
     return builder.build();
 }
 
-} // namespace score::mw::launch_manager::configuration::details
-
+}  // namespace score::mw::lifecycle::configuration::details

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
@@ -24,12 +24,11 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
-{
+
 
 namespace fb = score::mw::launch_manager::configuration::fb;
 
-namespace details
+namespace score::mw::launch_manager::configuration::details
 {
 
 IConfigLoader::Error mapOsError(const score::os::Error& error)
@@ -147,5 +146,5 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
     return builder.build();
 }
 
-}  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+} // namespace score::mw::launch_manager::configuration::details
+

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader.cpp
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <vector>
 
-namespace fb = score::mw::lifecycle::configuration::fb;
+namespace fb = score::mw::lifecycle::internal::configuration::fb;
 
-namespace score::mw::lifecycle::configuration::details
+namespace score::mw::lifecycle::internal::configuration::details
 {
 
 IConfigLoader::Error mapOsError(const score::os::Error& error)
@@ -144,4 +144,4 @@ score::cpp::expected<Config, IConfigLoader::Error> parseFlatbuffer(const std::ve
     return builder.build();
 }
 
-}  // namespace score::mw::lifecycle::configuration::details
+}  // namespace score::mw::lifecycle::internal::configuration::details

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
@@ -23,12 +23,12 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::lifecycle::configuration::fb;
+namespace fb = score::mw::lifecycle::internal::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -695,4 +695,4 @@ TEST_F(FlatbufferConfigLoaderTest, MissingSchemaVersionReturnsInvalidFormat)
 }
 
 }  // namespace
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_config_loader_UT.cpp
@@ -23,12 +23,12 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -695,4 +695,4 @@ TEST_F(FlatbufferConfigLoaderTest, MissingSchemaVersionReturnsInvalidFormat)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
-namespace fb = score::mw::lifecycle::configuration::fb;
+namespace fb = score::mw::lifecycle::internal::configuration::fb;
 
 namespace
 {
@@ -653,4 +653,4 @@ score::cpp::expected<std::vector<RunTargetConfig>, IConfigLoader::Error> convert
 }
 
 }  // namespace details
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 namespace
 {
@@ -653,4 +653,4 @@ score::cpp::expected<std::vector<RunTargetConfig>, IConfigLoader::Error> convert
 }
 
 }  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 namespace details
@@ -143,6 +143,6 @@ score::cpp::expected<TargetT, IConfigLoader::Error> validateRange(int64_t value,
     const fb::Watchdog* fb_wd);
 
 }  // namespace details
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration
 
 #endif  // FLATBUFFER_TYPE_CONVERTERS_HPP

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters.hpp
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 namespace details
@@ -143,6 +143,6 @@ score::cpp::expected<TargetT, IConfigLoader::Error> validateRange(int64_t value,
     const fb::Watchdog* fb_wd);
 
 }  // namespace details
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // FLATBUFFER_TYPE_CONVERTERS_HPP

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
@@ -22,12 +22,12 @@
 #include <limits>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::lifecycle::configuration::fb;
+namespace fb = score::mw::lifecycle::internal::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -1228,4 +1228,4 @@ TEST_F(ConverterTest, ConvertEnvironmentalVariablesNullReturnsEmpty)
 }
 
 }  // namespace
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
+++ b/score/launch_manager/src/daemon/src/configuration/details/flatbuffer_type_converters_UT.cpp
@@ -22,12 +22,12 @@
 #include <limits>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 namespace
 {
 
-namespace fb = score::mw::launch_manager::configuration::fb;
+namespace fb = score::mw::lifecycle::configuration::fb;
 
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -1228,4 +1228,4 @@ TEST_F(ConverterTest, ConvertEnvironmentalVariablesNullReturnsEmpty)
 }
 
 }  // namespace
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration

--- a/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
+++ b/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
@@ -10,7 +10,7 @@
 //   Note: Without "= null", flatbuffer will return a default value and there is no way to know if it has been configured or not
 // - optional values are defined with "= null" and they are populated as std::optional in the code
 
-namespace score.mw.lifecycle.configuration.fb;
+namespace score.mw.lifecycle.internal.configuration.fb;
 
 // Specifies the level of integration between the component and the Launch Manager.
 enum ApplicationType : byte {

--- a/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
+++ b/score/launch_manager/src/daemon/src/configuration/details/lm_flatcfg.fbs
@@ -10,7 +10,7 @@
 //   Note: Without "= null", flatbuffer will return a default value and there is no way to know if it has been configured or not
 // - optional values are defined with "= null" and they are populated as std::optional in the code
 
-namespace score.mw.launch_manager.configuration.fb;
+namespace score.mw.lifecycle.configuration.fb;
 
 // Specifies the level of integration between the component and the Launch Manager.
 enum ApplicationType : byte {

--- a/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 
 /// @brief Internal helpers for FlatBuffer config parsing.
@@ -69,6 +69,6 @@ class FlatbufferConfigLoaderImpl : public IConfigLoader
 /// @brief Alias using the default buffer loader.
 using FlatbufferConfigLoader = FlatbufferConfigLoaderImpl<>;
 
-}  // namespace score::mw::lifecycle::configuration
+}  // namespace score::mw::lifecycle::internal::configuration
 
 #endif  // FLATBUFFER_CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
+++ b/score/launch_manager/src/daemon/src/configuration/flatbuffer_config_loader.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 
 /// @brief Internal helpers for FlatBuffer config parsing.
@@ -69,6 +69,6 @@ class FlatbufferConfigLoaderImpl : public IConfigLoader
 /// @brief Alias using the default buffer loader.
 using FlatbufferConfigLoader = FlatbufferConfigLoaderImpl<>;
 
-}  // namespace score::mw::launch_manager::configuration
+}  // namespace score::mw::lifecycle::configuration
 
 #endif  // FLATBUFFER_CONFIG_LOADER_HPP

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -21,13 +21,11 @@
 #include "score/mw/launch_manager/common/constants.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 void ControlClientChannel::initialize()
@@ -280,8 +278,8 @@ bool ControlClientChannel::is_initialized_ = false;
 std::condition_variable ControlClientChannel::init_cv_{};
 std::mutex ControlClientChannel::init_mutex_{};
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.cpp
@@ -21,11 +21,7 @@
 #include "score/mw/launch_manager/common/constants.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 void ControlClientChannel::initialize()
@@ -278,8 +274,4 @@ bool ControlClientChannel::is_initialized_ = false;
 std::condition_variable ControlClientChannel::init_cv_{};
 std::mutex ControlClientChannel::init_mutex_{};
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
+++ b/score/launch_manager/src/daemon/src/control/control_client_channel.hpp
@@ -25,7 +25,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -310,7 +310,7 @@ constexpr ControlClientCodeMapping stateArray[] = {
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, const char* argv[])
         //     return EXIT_FAILURE;
         // }
 
-        score::mw::launch_manager::configuration::FlatbufferConfigLoader config_loader;
+        score::mw::lifecycle::configuration::FlatbufferConfigLoader config_loader;
         auto config_result = config_loader.load(config_path);
         if (!config_result.has_value())
         {

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, const char* argv[])
         //     return EXIT_FAILURE;
         // }
 
-        score::mw::lifecycle::configuration::FlatbufferConfigLoader config_loader;
+        score::mw::lifecycle::internal::configuration::FlatbufferConfigLoader config_loader;
         auto config_result = config_loader.load(config_path);
         if (!config_result.has_value())
         {
@@ -160,13 +160,13 @@ int main(int argc, const char* argv[])
             std::make_shared<score::mw::lifecycle::RecoveryClient>()};
         auto supervision_control_notifier =
             std::make_unique<score::mw::lifecycle::internal::SupervisionControlNotifier>();
-        std::unique_ptr<score::mw::lifecycle::saf::daemon::IAliveMonitor> healthMonitor{
-            std::make_unique<score::mw::lifecycle::saf::daemon::AliveMonitorImpl>(
+        std::unique_ptr<score::mw::lifecycle::internal::saf::daemon::IAliveMonitor> healthMonitor{
+            std::make_unique<score::mw::lifecycle::internal::saf::daemon::AliveMonitorImpl>(
                 recoveryClient, supervision_control_notifier->constructReceiver(), *config_result)};
         std::unique_ptr<score::mw::lifecycle::internal::IAliveMonitorThread> aliveMonitorThread{
             std::make_unique<score::mw::lifecycle::internal::AliveMonitorThread>(std::move(healthMonitor))};
 
-        auto watchdog = score::mw::lifecycle::watchdog::createWatchdog();
+        auto watchdog = score::mw::lifecycle::internal::watchdog::createWatchdog();
         auto process_group_manager = std::make_unique<ProcessGroupManager>(
             std::move(aliveMonitorThread),
             recoveryClient,

--- a/score/launch_manager/src/daemon/src/main.cpp
+++ b/score/launch_manager/src/daemon/src/main.cpp
@@ -26,7 +26,7 @@
 #include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
 
 using namespace std;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 /// @brief Runs the LCM daemon.
 /// This function runs the LCM daemon by calling the run() method of the provided
@@ -156,15 +156,17 @@ int main(int argc, const char* argv[])
             return EXIT_FAILURE;
         }
         LM_LOG_DEBUG() << "Launch Manager Started !!!!";
-        std::shared_ptr<score::lcm::IRecoveryClient> recoveryClient{std::make_shared<score::lcm::RecoveryClient>()};
-        auto supervision_control_notifier = std::make_unique<score::lcm::internal::SupervisionControlNotifier>();
-        std::unique_ptr<score::lcm::saf::daemon::IAliveMonitor> healthMonitor{
-            std::make_unique<score::lcm::saf::daemon::AliveMonitorImpl>(
+        std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recoveryClient{
+            std::make_shared<score::mw::lifecycle::RecoveryClient>()};
+        auto supervision_control_notifier =
+            std::make_unique<score::mw::lifecycle::internal::SupervisionControlNotifier>();
+        std::unique_ptr<score::mw::lifecycle::saf::daemon::IAliveMonitor> healthMonitor{
+            std::make_unique<score::mw::lifecycle::saf::daemon::AliveMonitorImpl>(
                 recoveryClient, supervision_control_notifier->constructReceiver(), *config_result)};
-        std::unique_ptr<score::lcm::internal::IAliveMonitorThread> aliveMonitorThread{
-            std::make_unique<score::lcm::internal::AliveMonitorThread>(std::move(healthMonitor))};
+        std::unique_ptr<score::mw::lifecycle::internal::IAliveMonitorThread> aliveMonitorThread{
+            std::make_unique<score::mw::lifecycle::internal::AliveMonitorThread>(std::move(healthMonitor))};
 
-        auto watchdog = score::lcm::watchdog::createWatchdog();
+        auto watchdog = score::mw::lifecycle::watchdog::createWatchdog();
         auto process_group_manager = std::make_unique<ProcessGroupManager>(
             std::move(aliveMonitorThread),
             recoveryClient,

--- a/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
@@ -15,10 +15,7 @@
 
 #include "score/mw/launch_manager/osal/num_cores.hpp"
 
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 uint32_t getNumCores()
 {
@@ -32,7 +29,4 @@ uint32_t getNumCores()
         return static_cast<uint32_t>(res);
     }
 }
-} // namespace score::lcm::internal::osal
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/num_cores.cpp
@@ -15,13 +15,10 @@
 
 #include "score/mw/launch_manager/osal/num_cores.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
-{
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 uint32_t getNumCores()
 {
@@ -35,7 +32,7 @@ uint32_t getNumCores()
         return static_cast<uint32_t>(res);
     }
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal::osal
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
@@ -12,16 +12,13 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/osal/security_policy.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 
 int setSecurityPolicy(const char*)
@@ -29,10 +26,10 @@ int setSecurityPolicy(const char*)
     return 0;
 }
 
-}  // namespace osal
+} // namespace score::lcm::internal::osal
 
-}  // namespace internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/security_policy.cpp
@@ -12,13 +12,7 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/osal/security_policy.hpp"
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setSecurityPolicy(const char*)
@@ -26,10 +20,4 @@ int setSecurityPolicy(const char*)
     return 0;
 }
 
-} // namespace score::lcm::internal::osal
-
-
-
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
@@ -16,16 +16,13 @@
 #include "score/mw/launch_manager/osal/set_affinity.hpp"
 #include <cstdint>
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 
 std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)
@@ -44,7 +41,7 @@ std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)
     }
     return 0 == sched_setaffinity(0, sizeof(mask), &mask) ? 0 : -1;
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal::osal
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_affinity.cpp
@@ -16,13 +16,7 @@
 #include "score/mw/launch_manager/osal/set_affinity.hpp"
 #include <cstdint>
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)
@@ -41,7 +35,4 @@ std::int32_t setaffinity(std::uint64_t cpumask) noexcept(true)
     }
     return 0 == sched_setaffinity(0, sizeof(mask), &mask) ? 0 : -1;
 }
-} // namespace score::lcm::internal::osal
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
@@ -16,20 +16,11 @@
 
 #include "score/mw/launch_manager/osal/set_groups.hpp"
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 int setgroups(size_t __n, const gid_t* __groups) noexcept(true)
 {
     return ::setgroups(__n, __n ? __groups : nullptr);
 }
-} // namespace score::lcm::internal::osal
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/linux/set_groups.cpp
@@ -16,23 +16,20 @@
 
 #include "score/mw/launch_manager/osal/set_groups.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 
 int setgroups(size_t __n, const gid_t* __groups) noexcept(true)
 {
     return ::setgroups(__n, __n ? __groups : nullptr);
 }
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal::osal
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
@@ -17,16 +17,13 @@
 
 #include "score/mw/launch_manager/osal/semaphore.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 
 OsalReturnType Semaphore::init(uint32_t value, bool shared)
@@ -114,10 +111,10 @@ OsalReturnType Semaphore::wait()
     return result;
 }
 
-}  // namespace osal
+} // namespace score::lcm::internal::osal
 
-}  // namespace internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/semaphore.cpp
@@ -17,13 +17,7 @@
 
 #include "score/mw/launch_manager/osal/semaphore.hpp"
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 OsalReturnType Semaphore::init(uint32_t value, bool shared)
@@ -111,10 +105,4 @@ OsalReturnType Semaphore::wait()
     return result;
 }
 
-} // namespace score::lcm::internal::osal
-
-
-
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
@@ -13,16 +13,13 @@
 
 #include <cstdlib>
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 #if defined(__CTC__)
 /* RULECHECKER_comment(1:0,2:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
@@ -44,7 +41,7 @@ void sysexit(int status)
 /* RULECHECKER_comment(1:0,1:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
 #pragma CTC ENDSKIP
 #endif
-}  // namespace osal
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal::osal
+
+
+

--- a/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/posix/sys_exit.cpp
@@ -13,13 +13,7 @@
 
 #include <cstdlib>
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 #if defined(__CTC__)
 /* RULECHECKER_comment(1:0,2:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
@@ -41,7 +35,4 @@ void sysexit(int status)
 /* RULECHECKER_comment(1:0,1:0, check_pragma_usage, "External tooling requires pragma", true_no_defect) */
 #pragma CTC ENDSKIP
 #endif
-} // namespace score::lcm::internal::osal
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/num_cores.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/num_cores.cpp
@@ -17,7 +17,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -35,5 +35,5 @@ uint32_t getNumCores()
 }
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/security_policy.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/security_policy.cpp
@@ -17,7 +17,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -46,6 +46,6 @@ int setSecurityPolicy(const char* policy)
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_affinity.cpp
@@ -16,7 +16,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -51,5 +51,5 @@ int32_t setaffinity(uint64_t cpumask) noexcept(true)
 }
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
+++ b/score/launch_manager/src/daemon/src/osal/details/qnx/set_groups.cpp
@@ -17,7 +17,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -33,5 +33,5 @@ int setgroups(size_t __n, const gid_t* __groups) noexcept(true)
 
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
+++ b/score/launch_manager/src/daemon/src/osal/ipc_comms.hpp
@@ -23,7 +23,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -141,7 +141,7 @@ struct IpcCommsSync final
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/osal/num_cores.hpp
+++ b/score/launch_manager/src/daemon/src/osal/num_cores.hpp
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -33,7 +33,7 @@ uint32_t getNumCores();
 
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/osal/return_types.hpp
+++ b/score/launch_manager/src/daemon/src/osal/return_types.hpp
@@ -20,7 +20,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -71,7 +71,7 @@ enum class [[nodiscard]] OsalReturnType
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/osal/security_policy.hpp
+++ b/score/launch_manager/src/daemon/src/osal/security_policy.hpp
@@ -14,7 +14,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -29,6 +29,6 @@ namespace osal
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score

--- a/score/launch_manager/src/daemon/src/osal/semaphore.hpp
+++ b/score/launch_manager/src/daemon/src/osal/semaphore.hpp
@@ -22,7 +22,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -127,7 +127,7 @@ class Semaphore final
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_affinity.hpp
@@ -19,7 +19,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -41,6 +41,6 @@ namespace osal
 [[nodiscard]] int32_t setaffinity(uint64_t cpumask) noexcept(true);
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/osal/set_groups.hpp
+++ b/score/launch_manager/src/daemon/src/osal/set_groups.hpp
@@ -21,7 +21,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -38,6 +38,6 @@ namespace osal
 [[nodiscard]] std::int32_t setgroups(size_t __n, const gid_t* __groups) noexcept(true);
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
+++ b/score/launch_manager/src/daemon/src/osal/sys_exit.hpp
@@ -17,7 +17,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -32,6 +32,6 @@ namespace osal
 void sysexit(int status);
 }  // namespace osal
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
@@ -12,9 +12,7 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/process_group_manager/alive_monitor_thread.hpp"
 
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonitor> health_monitor)
@@ -24,7 +22,8 @@ AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonito
 
 bool AliveMonitorThread::start()
 {
-    score::lcm::saf::daemon::EInitCode init_status{score::lcm::saf::daemon::EInitCode::kNotInitialized};
+    score::mw::lifecycle::saf::daemon::EInitCode init_status{
+        score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized};
     alive_monitor_thread_ = std::thread([this, &init_status]() {
         const auto initResult = m_health_monitor->init();
 
@@ -51,8 +50,8 @@ void AliveMonitorThread::stop()
 }
 
 void AliveMonitorThread::notifyInitializationComplete(
-    score::lcm::saf::daemon::EInitCode& f_init_status_r,
-    const score::lcm::saf::daemon::EInitCode f_init_result)
+    score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
+    const score::mw::lifecycle::saf::daemon::EInitCode f_init_result)
 {
     {
         std::lock_guard lk(m_initialization_mutex);
@@ -61,14 +60,12 @@ void AliveMonitorThread::notifyInitializationComplete(
     m_initialization_cv.notify_all();
 }
 
-void AliveMonitorThread::waitForInitializationCompleted(score::lcm::saf::daemon::EInitCode& f_init_status_r)
+void AliveMonitorThread::waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r)
 {
     std::unique_lock lk(m_initialization_mutex);
     m_initialization_cv.wait(lk, [&f_init_status_r]() {
-        return f_init_status_r != score::lcm::saf::daemon::EInitCode::kNotInitialized;
+        return f_init_status_r != score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized;
     });
 }
 
-} // namespace score::lcm::internal
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
@@ -22,8 +22,8 @@ AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonito
 
 bool AliveMonitorThread::start()
 {
-    score::mw::lifecycle::saf::daemon::EInitCode init_status{
-        score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized};
+    score::mw::lifecycle::internal::saf::daemon::EInitCode init_status{
+        score::mw::lifecycle::internal::saf::daemon::EInitCode::kNotInitialized};
     alive_monitor_thread_ = std::thread([this, &init_status]() {
         const auto initResult = m_health_monitor->init();
 
@@ -50,8 +50,8 @@ void AliveMonitorThread::stop()
 }
 
 void AliveMonitorThread::notifyInitializationComplete(
-    score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
-    const score::mw::lifecycle::saf::daemon::EInitCode f_init_result)
+    score::mw::lifecycle::internal::saf::daemon::EInitCode& f_init_status_r,
+    const score::mw::lifecycle::internal::saf::daemon::EInitCode f_init_result)
 {
     {
         std::lock_guard lk(m_initialization_mutex);
@@ -60,11 +60,12 @@ void AliveMonitorThread::notifyInitializationComplete(
     m_initialization_cv.notify_all();
 }
 
-void AliveMonitorThread::waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r)
+void AliveMonitorThread::waitForInitializationCompleted(
+    score::mw::lifecycle::internal::saf::daemon::EInitCode& f_init_status_r)
 {
     std::unique_lock lk(m_initialization_mutex);
     m_initialization_cv.wait(lk, [&f_init_status_r]() {
-        return f_init_status_r != score::mw::lifecycle::saf::daemon::EInitCode::kNotInitialized;
+        return f_init_status_r != score::mw::lifecycle::internal::saf::daemon::EInitCode::kNotInitialized;
     });
 }
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.cpp
@@ -12,11 +12,9 @@
  ********************************************************************************/
 #include "score/mw/launch_manager/process_group_manager/alive_monitor_thread.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 AliveMonitorThread::AliveMonitorThread(std::unique_ptr<saf::daemon::IAliveMonitor> health_monitor)
@@ -71,6 +69,6 @@ void AliveMonitorThread::waitForInitializationCompleted(score::lcm::saf::daemon:
     });
 }
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -42,9 +42,9 @@ class AliveMonitorThread final : public IAliveMonitorThread
 
   private:
     void notifyInitializationComplete(
-        score::lcm::saf::daemon::EInitCode& f_init_status_r,
-        const score::lcm::saf::daemon::EInitCode f_init_result);
-    void waitForInitializationCompleted(score::lcm::saf::daemon::EInitCode& f_init_status_r);
+        score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
+        const score::mw::lifecycle::saf::daemon::EInitCode f_init_result);
+    void waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r);
 
     std::unique_ptr<saf::daemon::IAliveMonitor> m_health_monitor{nullptr};
     std::thread alive_monitor_thread_{};
@@ -54,6 +54,6 @@ class AliveMonitorThread final : public IAliveMonitorThread
 };
 
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/alive_monitor_thread.hpp
@@ -42,9 +42,9 @@ class AliveMonitorThread final : public IAliveMonitorThread
 
   private:
     void notifyInitializationComplete(
-        score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r,
-        const score::mw::lifecycle::saf::daemon::EInitCode f_init_result);
-    void waitForInitializationCompleted(score::mw::lifecycle::saf::daemon::EInitCode& f_init_status_r);
+        score::mw::lifecycle::internal::saf::daemon::EInitCode& f_init_status_r,
+        const score::mw::lifecycle::internal::saf::daemon::EInitCode f_init_result);
+    void waitForInitializationCompleted(score::mw::lifecycle::internal::saf::daemon::EInitCode& f_init_status_r);
 
     std::unique_ptr<saf::daemon::IAliveMonitor> m_health_monitor{nullptr};
     std::thread alive_monitor_thread_{};

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
@@ -23,7 +23,7 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
 /// @brief A node finished activating successfully.
 struct [[nodiscard]] ActivationSuccessful

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event.hpp
@@ -23,8 +23,6 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::mw::lifecycle;
-
 /// @brief A node finished activating successfully.
 struct [[nodiscard]] ActivationSuccessful
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue.hpp
@@ -51,7 +51,7 @@ class ComponentEventQueue final : public IComponentEventPublisherConsumer
     [[nodiscard]] bool push(ComponentEvent&& event) override
     {
         auto result = queue_.push(std::move(event));
-        if (!result.has_value() && result.error() == lcm::internal::ConcurrencyErrc::kOverflow)
+        if (!result.has_value() && result.error() == mw::lifecycle::internal::ConcurrencyErrc::kOverflow)
         {
             overflow_.store(true, std::memory_order_release);
             return false;
@@ -95,7 +95,7 @@ class ComponentEventQueue final : public IComponentEventPublisherConsumer
     }
 
   private:
-    lcm::internal::MpscBoundedQueue<ComponentEvent> queue_;
+    mw::lifecycle::internal::MpscBoundedQueue<ComponentEvent> queue_;
     std::size_t capacity_;
     std::atomic<bool> overflow_{false};
 };

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
@@ -19,8 +19,6 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::mw::lifecycle;
-
 class ComponentEventQueueTest : public ::testing::Test
 {
   protected:

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_event_queue_UT.cpp
@@ -19,7 +19,7 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
 class ComponentEventQueueTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
@@ -21,9 +21,6 @@
 
 namespace score::mw::lifecycle::internal
 {
-
-using namespace score::mw::lifecycle::internal;
-
 /// @brief Returns the IComponent reference from a variant type
 /// @details All types in the variant must implement the IComponent interface.
 inline IComponent& componentOf(std::variant<ProcessInfoNode, RunTarget>& node)

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/component_of.hpp
@@ -22,7 +22,7 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 /// @brief Returns the IComponent reference from a variant type
 /// @details All types in the variant must implement the IComponent interface.

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
@@ -23,8 +23,6 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::mw::lifecycle::internal;
-
 /// @brief Index type used to identify nodes in the graph.
 using GraphIndex = std::size_t;
 
@@ -186,7 +184,7 @@ class DependencyGraph
     std::vector<GraphNode> nodes;
 
     /// @brief Presized queue reused by single-threaded traversals.
-    FixedSizeQueue<GraphIndex> traversal_queue;
+    internal::FixedSizeQueue<GraphIndex> traversal_queue;
     /// @brief Presized visited set reused by single-threaded traversals.
     std::vector<bool> visited;
 };

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph.hpp
@@ -23,7 +23,7 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 /// @brief Index type used to identify nodes in the graph.
 using GraphIndex = std::size_t;

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
@@ -22,8 +22,6 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::mw::lifecycle;
-
 TEST(DependencyGraphTest, EmplaceAndAccessByIndex)
 {
     const std::string_view text = "AAAAA";

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/dependency_graph_UT.cpp
@@ -22,7 +22,7 @@
 namespace score::mw::lifecycle
 {
 
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
 TEST(DependencyGraphTest, EmplaceAndAccessByIndex)
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
@@ -24,13 +24,11 @@
 
 #include "score/assert.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 Graph::Graph(
@@ -709,8 +707,8 @@ std::chrono::time_point<std::chrono::steady_clock> Graph::getRequestStartTime()
     return request_start_time_;
 }
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.cpp
@@ -24,11 +24,7 @@
 
 #include "score/assert.hpp"
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 Graph::Graph(
@@ -707,8 +703,4 @@ std::chrono::time_point<std::chrono::steady_clock> Graph::getRequestStartTime()
     return request_start_time_;
 }
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -48,7 +48,7 @@ namespace mw::lifecycle
 namespace internal
 {
 
-using Config = score::mw::lifecycle::configuration::Config;
+using Config = score::mw::lifecycle::internal::configuration::Config;
 
 using WorkerQueue =
     MPMCConcurrentQueue<std::optional<ComponentTask>, static_cast<std::size_t>(ProcessLimits::kMaxProcesses)>;

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -48,7 +48,7 @@ namespace mw::lifecycle
 namespace internal
 {
 
-using Config = score::mw::launch_manager::configuration::Config;
+using Config = score::mw::lifecycle::configuration::Config;
 
 using WorkerQueue =
     MPMCConcurrentQueue<std::optional<ComponentTask>, static_cast<std::size_t>(ProcessLimits::kMaxProcesses)>;

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -48,8 +48,6 @@ namespace mw::lifecycle
 namespace internal
 {
 
-using namespace score::mw::lifecycle;
-
 using Config = score::mw::launch_manager::configuration::Config;
 
 using WorkerQueue =

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph.hpp
@@ -42,7 +42,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -428,7 +428,7 @@ class Graph final
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
@@ -23,7 +23,6 @@ namespace score::mw::lifecycle::internal
 {
 
 using namespace testing;
-using namespace score::mw::lifecycle;
 using namespace score::mw::launch_manager::configuration;
 using namespace std::chrono_literals;
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal
 {
 
 using namespace testing;
-using namespace score::mw::lifecycle::configuration;
+using namespace configuration;
 using namespace std::chrono_literals;
 
 class MockProcessMap : public SafeProcessMapInserter

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
@@ -19,7 +19,7 @@
 #include "score/mw/launch_manager/process_group_manager/mock_iprocess.hpp"
 #include "score/mw/launch_manager/supervision_control_client/mock_supervision_event_publisher.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace testing;
@@ -608,4 +608,4 @@ TEST_F(GraphUtilitiesTest, gettersSetters)
     EXPECT_LE(graph_time, after_time);
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/graph_UT.cpp
@@ -23,7 +23,7 @@ namespace score::mw::lifecycle::internal
 {
 
 using namespace testing;
-using namespace score::mw::launch_manager::configuration;
+using namespace score::mw::lifecycle::configuration;
 using namespace std::chrono_literals;
 
 class MockProcessMap : public SafeProcessMapInserter

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/itransition_result_publisher.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/itransition_result_publisher.hpp
@@ -16,7 +16,7 @@
 
 #include "score/mw/launch_manager/control/control_client_channel.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 class ITransitionResultPublisher
@@ -27,6 +27,6 @@ class ITransitionResultPublisher
     virtual ~ITransitionResultPublisher() = default;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  // SCORE_LCM_ITRANSITION_RESULT_PUBLISHER

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
@@ -13,11 +13,7 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/os_handler.hpp"
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 void OsHandler::run(void)
@@ -29,7 +25,7 @@ void OsHandler::run(void)
 
         if (result.has_value() && result.value() > 0)
         {
-            if (score::lcm::internal::SafeProcessMapReturnType::kInsertionError ==
+            if (score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError ==
                 safe_process_map_.findTerminated(result.value(), wait_status))
             {
                 LM_LOG_ERROR() << "No more resources available to track process with PID " << result.value()
@@ -46,8 +42,4 @@ void OsHandler::run(void)
     }
 }
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.cpp
@@ -13,13 +13,11 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/os_handler.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 void OsHandler::run(void)
@@ -48,8 +46,8 @@ void OsHandler::run(void)
     }
 }
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/os_handler.hpp
@@ -23,7 +23,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -92,12 +92,12 @@ class OsHandler final
     score::os::SysWait& sys_wait_;
 
     /// @brief Thread object to manage execution of the run method.
-    std::thread os_handler_{&score::lcm::internal::OsHandler::run, this};
+    std::thread os_handler_{&score::mw::lifecycle::internal::OsHandler::run, this};
 };
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/oshandler_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/oshandler_UT.cpp
@@ -27,7 +27,7 @@
 #include "score/os/mocklib/sys_wait_mock.h"
 
 using namespace testing;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 namespace
 {
@@ -152,7 +152,8 @@ TEST_F(OsHandlerTest, WaitReturnsProcessIdBeforeRegistration_LaterRegistrationRe
     // callback immediately with the saved exit status instead of creating a new live entry.
     EXPECT_CALL(ccontroller_, terminated(_, 99)).Times(1);
     EXPECT_EQ(
-        process_map_.insertIfNotTerminated(4000, &component_), score::lcm::internal::SafeProcessMapReturnType::kYield);
+        process_map_.insertIfNotTerminated(4000, &component_),
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 
     sut_.reset();
 }
@@ -170,7 +171,7 @@ TEST_F(OsHandlerTest, WaitReturnsUnknownPidWhenMapIsFull_OutOfResourcesPathDoesN
     {
         ASSERT_EQ(
             process_map_.insertIfNotTerminated(static_cast<int32_t>(i + 1U), &callbacks[i]),
-            score::lcm::internal::SafeProcessMapReturnType::kOk);
+            score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 
     EXPECT_CALL(*sys_wait_mock_, wait(_))

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager_UT.cpp
@@ -38,18 +38,18 @@ namespace
 
 using score::mw::lifecycle::MockRecoveryClient;
 using score::mw::lifecycle::MockSupervisionControlNotifier;
-using score::mw::lifecycle::watchdog::MockWatchdogIf;
+using score::mw::lifecycle::internal::watchdog::MockWatchdogIf;
 
-using score::mw::lifecycle::configuration::AliveSupervisionConfig;
-using score::mw::lifecycle::configuration::ApplicationType;
-using score::mw::lifecycle::configuration::ComponentConfig;
-using score::mw::lifecycle::configuration::Config;
-using score::mw::lifecycle::configuration::ConfigBuilder;
-using score::mw::lifecycle::configuration::FallbackRunTargetConfig;
-using score::mw::lifecycle::configuration::ProcessState;
-using score::mw::lifecycle::configuration::ReadyCondition;
-using score::mw::lifecycle::configuration::RunTargetConfig;
-using score::mw::lifecycle::configuration::WatchdogConfig;
+using score::mw::lifecycle::internal::configuration::AliveSupervisionConfig;
+using score::mw::lifecycle::internal::configuration::ApplicationType;
+using score::mw::lifecycle::internal::configuration::ComponentConfig;
+using score::mw::lifecycle::internal::configuration::Config;
+using score::mw::lifecycle::internal::configuration::ConfigBuilder;
+using score::mw::lifecycle::internal::configuration::FallbackRunTargetConfig;
+using score::mw::lifecycle::internal::configuration::ProcessState;
+using score::mw::lifecycle::internal::configuration::ReadyCondition;
+using score::mw::lifecycle::internal::configuration::RunTargetConfig;
+using score::mw::lifecycle::internal::configuration::WatchdogConfig;
 
 Config makeMinimalConfig()
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_group_manager_UT.cpp
@@ -31,25 +31,25 @@
 
 using namespace testing;
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 namespace
 {
 
-using score::lcm::MockRecoveryClient;
-using score::lcm::MockSupervisionControlNotifier;
-using score::lcm::watchdog::MockWatchdogIf;
+using score::mw::lifecycle::MockRecoveryClient;
+using score::mw::lifecycle::MockSupervisionControlNotifier;
+using score::mw::lifecycle::watchdog::MockWatchdogIf;
 
-using score::mw::launch_manager::configuration::AliveSupervisionConfig;
-using score::mw::launch_manager::configuration::ApplicationType;
-using score::mw::launch_manager::configuration::ComponentConfig;
-using score::mw::launch_manager::configuration::Config;
-using score::mw::launch_manager::configuration::ConfigBuilder;
-using score::mw::launch_manager::configuration::FallbackRunTargetConfig;
-using score::mw::launch_manager::configuration::ProcessState;
-using score::mw::launch_manager::configuration::ReadyCondition;
-using score::mw::launch_manager::configuration::RunTargetConfig;
-using score::mw::launch_manager::configuration::WatchdogConfig;
+using score::mw::lifecycle::configuration::AliveSupervisionConfig;
+using score::mw::lifecycle::configuration::ApplicationType;
+using score::mw::lifecycle::configuration::ComponentConfig;
+using score::mw::lifecycle::configuration::Config;
+using score::mw::lifecycle::configuration::ConfigBuilder;
+using score::mw::lifecycle::configuration::FallbackRunTargetConfig;
+using score::mw::lifecycle::configuration::ProcessState;
+using score::mw::lifecycle::configuration::ReadyCondition;
+using score::mw::lifecycle::configuration::RunTargetConfig;
+using score::mw::lifecycle::configuration::WatchdogConfig;
 
 Config makeMinimalConfig()
 {
@@ -134,7 +134,7 @@ class ProcessGroupManagerWatchdogTest : public Test
         auto supervision_control_notifier = std::make_unique<NiceMock<MockSupervisionControlNotifier>>();
         supervision_control_notifier_ = supervision_control_notifier.get();
         ON_CALL(*supervision_control_notifier_, constructReceiver())
-            .WillByDefault(Return(ByMove(std::unique_ptr<score::lcm::ISupervisionControlReceiver>{})));
+            .WillByDefault(Return(ByMove(std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver>{})));
         ON_CALL(*supervision_control_notifier_, reportActivation(_, _)).WillByDefault(Return(true));
         ON_CALL(*supervision_control_notifier_, reportDeactivation(_, _)).WillByDefault(Return(true));
 
@@ -155,7 +155,7 @@ class ProcessGroupManagerWatchdogTest : public Test
 
     MockAliveMonitorThread* alive_monitor_thread_{};
     MockRecoveryClient* recovery_client_{};
-    score::lcm::IRecoveryClient::RecoveryRequestCallback recovery_callback_{};
+    score::mw::lifecycle::IRecoveryClient::RecoveryRequestCallback recovery_callback_{};
     MockSupervisionControlNotifier* supervision_control_notifier_{};
     MockWatchdogIf* watchdog_{};
     std::unique_ptr<ProcessGroupManager> process_group_manager_;
@@ -228,7 +228,7 @@ TEST_F(ProcessGroupManagerWatchdogTest, GivenMinimalConfig_ExpectWatchdogFired_W
     ASSERT_TRUE(recovery_callback_);
     for (int i = 0; i < kNumRecoveryRequests; ++i)
     {
-        recovery_callback_(score::lcm::IdentifierHash{"overflow_probe"});
+        recovery_callback_(score::mw::lifecycle::IdentifierHash{"overflow_probe"});
     }
 
     auto run_result = process_group_manager_->run();
@@ -255,4 +255,4 @@ TEST_F(ProcessGroupManagerWatchdogTest, GivenMinimalConfig_ExpectWatchdogDisable
 }
 
 }  // namespace
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
@@ -18,13 +18,11 @@
 #include <score/assert.hpp>
 #include <unistd.h>
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 ProcessInfoNode::ProcessInfoNode(
@@ -448,8 +446,8 @@ ControlClientChannelP ProcessInfoNode::getControlClientChannel() const
     return std::atomic_load(&control_client_channel_);
 }
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.cpp
@@ -18,11 +18,7 @@
 #include <score/assert.hpp>
 #include <unistd.h>
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 ProcessInfoNode::ProcessInfoNode(
@@ -37,7 +33,7 @@ ProcessInfoNode::ProcessInfoNode(
       process_index_(index),
       pid_(0),
       status_(0),
-      process_state_(score::lcm::ProcessState::kIdle),
+      process_state_(score::mw::lifecycle::ProcessState::kIdle),
       ready_condition_(ready_condition),
       config_(config),
       state_publisher_(state_publisher),
@@ -46,7 +42,7 @@ ProcessInfoNode::ProcessInfoNode(
 {
 }
 
-IComponent::RequestResult ProcessInfoNode::tryReportCompletion(score::lcm::ProcessState new_state)
+IComponent::RequestResult ProcessInfoNode::tryReportCompletion(score::mw::lifecycle::ProcessState new_state)
 {
     ProcessState desired_state{};
     switch (ready_condition_)
@@ -108,18 +104,18 @@ IComponent::RequestResult ProcessInfoNode::tryReportError(ComponentError error)
     return {IComponent::RequestState::kWaiting};
 }
 
-bool ProcessInfoNode::setState(score::lcm::ProcessState new_state)
+bool ProcessInfoNode::setState(score::mw::lifecycle::ProcessState new_state)
 {
     bool success = true;
-    score::lcm::ProcessState old_state = getState();
+    score::mw::lifecycle::ProcessState old_state = getState();
 
     if (new_state > old_state || (new_state == old_state && new_state == ProcessState::kIdle))
     {
         success = process_state_.compare_exchange_strong(old_state, new_state);
     }
     else if (
-        new_state == score::lcm::ProcessState::kIdle &&
-        (old_state == score::lcm::ProcessState::kTerminated || old_state == ProcessState::kFailed))
+        new_state == score::mw::lifecycle::ProcessState::kIdle &&
+        (old_state == score::mw::lifecycle::ProcessState::kTerminated || old_state == ProcessState::kFailed))
     {
         process_state_.store(new_state);
     }
@@ -202,7 +198,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         SCORE_LANGUAGE_FUTURECPP_ASSERT_DBG_MESSAGE(
             getState() != ProcessState::kRunning, "Restart attempted even though process is running");
         // - Terminating: A termination is in progress (allowed)
-        if (!setState(score::lcm::ProcessState::kIdle))
+        if (!setState(score::mw::lifecycle::ProcessState::kIdle))
         {
             LM_LOG_WARN() << "Starting process" << this << "failed: termination in progress";
             error = ComponentError::kErrorBeforeReady;
@@ -212,7 +208,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         pid_ = 0;
         status_ = 0;
         error = std::nullopt;
-        static_cast<void>(setState(score::lcm::ProcessState::kStarting));  // Cannot fail by design
+        static_cast<void>(setState(score::mw::lifecycle::ProcessState::kStarting));  // Cannot fail by design
 
         if (osal::OsalReturnType::kSuccess ==
             process_interface_->startProcess(&pid_, &sync_, &config_->startup_config_))
@@ -228,7 +224,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
             if (!res.has_value())
             {
                 // Fatal error, do not retry
-                setState(score::lcm::ProcessState::kFailed);
+                setState(score::mw::lifecycle::ProcessState::kFailed);
                 error = res.error();
                 break;
             }
@@ -244,7 +240,7 @@ IComponent::RequestResult ProcessInfoNode::startProcess(score::cpp::stop_token s
         }
         else
         {
-            setState(score::lcm::ProcessState::kFailed);
+            setState(score::mw::lifecycle::ProcessState::kFailed);
             error = ComponentError::kErrorBeforeReady;
             break;
         }
@@ -318,10 +314,10 @@ ProcessInfoNode::handleProcessStarted(const score::cpp::stop_token& stop_token)
 {
     switch (process_map_->insertIfNotTerminated(pid_, this))
     {
-        case score::lcm::internal::SafeProcessMapReturnType::kOk:  // Normal case, entry was put in
-                                                                   // the map, process still running
+        case score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk:  // Normal case, entry was put in
+                                                                             // the map, process still running
             return handleProcessStillStarting(stop_token);
-        case score::lcm::internal::SafeProcessMapReturnType::kYield:  // Process has already exited
+        case score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield:  // Process has already exited
             return handleProcessAlreadyTerminated();
         default:  // Error case when pn == -1
             // really bad fatal error, should not happen, treat as a failure to set the state & kill the process
@@ -349,7 +345,7 @@ void ProcessInfoNode::terminateProcess(const score::cpp::stop_token& stop_token)
 {
     LM_LOG_DEBUG() << "terminating process" << process_index_ << "(" << config_->startup_config_.short_name_ << ")";
 
-    if (setState(score::lcm::ProcessState::kTerminating))
+    if (setState(score::mw::lifecycle::ProcessState::kTerminating))
     {
         handleTerminationProcess(stop_token);
     }
@@ -389,7 +385,7 @@ void ProcessInfoNode::handleForcedTermination(const score::cpp::stop_token& stop
                   << ") did not respond to SIGTERM, sending SIGKILL";
 
     while ((osal::OsalReturnType::kSuccess == process_interface_->forceTermination(pid_)) &&
-           (terminator_.timedWait(score::lcm::internal::kMaxSigKillDelay) != osal::OsalReturnType::kSuccess))
+           (terminator_.timedWait(score::mw::lifecycle::internal::kMaxSigKillDelay) != osal::OsalReturnType::kSuccess))
     {
         LM_LOG_FATAL() << "Process" << process_index_ << "(" << config_->startup_config_.short_name_
                        << ") did not respond to SIGKILL!!";
@@ -431,7 +427,7 @@ osal::ProcessID ProcessInfoNode::getPid() const
     return pid_;
 }
 
-score::lcm::ProcessState ProcessInfoNode::getState() const
+score::mw::lifecycle::ProcessState ProcessInfoNode::getState() const
 {
     return process_state_.load();
 }
@@ -446,8 +442,4 @@ ControlClientChannelP ProcessInfoNode::getControlClientChannel() const
     return std::atomic_load(&control_client_channel_);
 }
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -25,8 +25,6 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::mw::lifecycle::internal;
-
 /// @brief Represents both a process and a component in the graph.
 /// @details A ProcessInfoNode is a node in the dependency graph that represents an OS process and its associated
 /// component. It manages the lifecycle of the process, including activation, deactivation, and state reporting. The

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -22,13 +22,11 @@
 #include <score/stop_token.hpp>
 #include <atomic>
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 using namespace score::mw::lifecycle::internal;
@@ -219,10 +217,10 @@ class ProcessInfoNode final : public IComponent
     std::shared_ptr<SafeProcessMapInserter> process_map_;
 };
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node.hpp
@@ -22,11 +22,7 @@
 #include <score/stop_token.hpp>
 #include <atomic>
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using namespace score::mw::lifecycle::internal;
@@ -103,7 +99,7 @@ class ProcessInfoNode final : public IComponent
     osal::ProcessID getPid() const;
 
     /// @return The current state of this process.
-    score::lcm::ProcessState getState() const;
+    score::mw::lifecycle::ProcessState getState() const;
 
     /// @return The ControlClientChannel for this process, or nullptr if none exists.
     ControlClientChannelP getControlClientChannel() const;
@@ -113,7 +109,7 @@ class ProcessInfoNode final : public IComponent
     /// processes, also notifies the platform health manager of the state change.
     /// @param new_state The desired process state.
     /// @return True if the state was changed, false if the transition was not valid.
-    bool setState(score::lcm::ProcessState new_state);
+    bool setState(score::mw::lifecycle::ProcessState new_state);
 
     /// @brief Helper method to post on the semaphore waiting for kRunning if it exists
     void unblockSync();
@@ -125,7 +121,7 @@ class ProcessInfoNode final : public IComponent
     /// terminated, the function will only return kSuccess if the new state is kTerminated.
     /// @return Success if the ready condition is satisfied and completion is not already reported, an error if the
     /// state is unrecoverable, waiting otherwise.
-    RequestResult tryReportCompletion(score::lcm::ProcessState new_state);
+    RequestResult tryReportCompletion(score::mw::lifecycle::ProcessState new_state);
 
     /// @return The provided error if the result has not been reported yet. A waiting result otherwise.
     RequestResult tryReportError(ComponentError error);
@@ -186,7 +182,7 @@ class ProcessInfoNode final : public IComponent
     std::atomic<int32_t> status_{0};
 
     /// @brief The current state of the OS process
-    std::atomic<score::lcm::ProcessState> process_state_{score::lcm::ProcessState::kIdle};
+    std::atomic<score::mw::lifecycle::ProcessState> process_state_{score::mw::lifecycle::ProcessState::kIdle};
 
     /// @brief Flag indicating whether the Ready Condition has been satisfied.
     /// The flag is reset when deactivate() is called.
@@ -217,10 +213,6 @@ class ProcessInfoNode final : public IComponent
     std::shared_ptr<SafeProcessMapInserter> process_map_;
 };
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_info_node_UT.cpp
@@ -21,8 +21,8 @@
 #include <vector>
 
 using namespace testing;
-using namespace score::lcm::internal;
-using namespace score::lcm;
+using namespace score::mw::lifecycle::internal;
+using namespace score::mw::lifecycle;
 
 // Default ProcessIndex for testing
 constexpr uint32_t kProcessIndex = 111;
@@ -97,7 +97,7 @@ class ProcessInfoNodeFixture : public ::testing::Test
     {
         EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
         EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-            .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+            .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     }
 
     /// @brief Sets up requestTermination to synchronously deliver the OS exit notification.
@@ -131,7 +131,7 @@ TEST_F(ProcessInfoNodeStartupTest, CanConstructIdleProcessInfoNode)
     auto node = createProcessInfoNode();
 
     ASSERT_THAT(node->getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
     ASSERT_THAT(node->getPid(), Eq(0));
     ASSERT_THAT(node->active(), IsFalse());
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
@@ -152,7 +152,7 @@ TEST_F(ProcessInfoNodeStartupTest, CanStartNonReportingProcess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, CanStartReportingProcess_ReportsRunningInTime)
@@ -169,7 +169,7 @@ TEST_F(ProcessInfoNodeStartupTest, CanStartReportingProcess_ReportsRunningInTime
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->getControlClientChannel(), IsNull());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, OsForkFails_ReturnsErrorBeforeReady)
@@ -185,7 +185,7 @@ TEST_F(ProcessInfoNodeStartupTest, OsForkFails_ReturnsErrorBeforeReady)
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kFailed));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kFailed));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
@@ -198,7 +198,7 @@ TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
     auto node = createProcessInfoNode(osal::CommsType::kNoComms);
     EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).WillOnce(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-        .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kInsertionError));
+        .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError));
     // The error handler calls terminateProcess(), which sends SIGTERM; simulate the OS ack.
     expectOsAcknowledgesTermination(node.get());
 
@@ -206,7 +206,7 @@ TEST_F(ProcessInfoNodeStartupTest, MapInsertError_ReturnsErrorBeforeReady)
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kFailed));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kFailed));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, SelfTerminating_ExitsBeforeMapInsert_ReturnsSuccess)
@@ -225,13 +225,13 @@ TEST_F(ProcessInfoNodeStartupTest, SelfTerminating_ExitsBeforeMapInsert_ReturnsS
             }),
             Return(osal::OsalReturnType::kSuccess)));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
-        .WillOnce(Return(score::lcm::internal::SafeProcessMapReturnType::kYield));
+        .WillOnce(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupTest, ActivateAlreadyActiveNode_ReturnsSuccess)
@@ -247,7 +247,7 @@ TEST_F(ProcessInfoNodeStartupTest, ActivateAlreadyActiveNode_ReturnsSuccess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsTrue());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 // Bundles process crashes and timeouts that occur during activate(), before the ready condition is reached.
@@ -272,7 +272,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ProcesssTerminated_OnWaitForkRunningTime
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kActivationTimedOut));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_NoRestarts)
@@ -297,7 +297,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_NoRe
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_WithRestartAttempts)
@@ -316,7 +316,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_With
         .WillRepeatedly(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
         .Times(kTotalAttempts)
-        .WillRepeatedly(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+        .WillRepeatedly(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     // Simulate the OS handler detecting the crash on every attempt, while the process is still waiting to reach
     // kRunning.
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _))
@@ -332,7 +332,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, ReportingProcess_CrashesBeforeReady_With
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_NoRestarts)
@@ -350,13 +350,13 @@ TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_N
             InvokeWithoutArgs([node = node.get()] {
                 node->tryHandleTermination(-1);
             }),
-            Return(score::lcm::internal::SafeProcessMapReturnType::kOk)));
+            Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk)));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_WithRestartAttempts)
@@ -379,13 +379,13 @@ TEST_F(ProcessInfoNodeStartupCrashTest, NonReportingProcess_CrashesBeforeReady_W
             InvokeWithoutArgs([node = node.get()] {
                 node->tryHandleTermination(-1);
             }),
-            Return(score::lcm::internal::SafeProcessMapReturnType::kOk)));
+            Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk)));
 
     auto result = node->activate(score::cpp::stop_token{});
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorBeforeReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeStartupCrashTest, TimeoutThenSuccess_WithRestarts)
@@ -400,7 +400,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, TimeoutThenSuccess_WithRestarts)
     EXPECT_CALL(mock_processIf_, startProcess(_, _, _)).Times(2).WillRepeatedly(Return(osal::OsalReturnType::kSuccess));
     EXPECT_CALL(*process_map_, insertIfNotTerminated(_, _))
         .Times(2)
-        .WillRepeatedly(Return(score::lcm::internal::SafeProcessMapReturnType::kOk));
+        .WillRepeatedly(Return(score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk));
     EXPECT_CALL(mock_processIf_, waitForkRunning(_, _))
         .WillOnce(Return(osal::OsalReturnType::kFail))
         .WillOnce(Return(osal::OsalReturnType::kSuccess));
@@ -412,7 +412,7 @@ TEST_F(ProcessInfoNodeStartupCrashTest, TimeoutThenSuccess_WithRestarts)
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
 }
 
 // Bundles unexpected terminations that occur after the ready condition has been reached.
@@ -430,7 +430,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, ProcesssCrashed_AfterReadyCondi
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorAfterReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminatingProcess_ExitsWithoutTerminationRequest)
@@ -447,7 +447,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminatingProcess_ExitsWit
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kWaiting));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_TerminatedReadyCondition_CleanExit_ReturnsSuccess)
@@ -472,7 +472,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_TerminatedReady
 
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_CrashAfterReady_ReturnsErrorAfterReady)
@@ -490,7 +490,7 @@ TEST_F(ProcessInfoNodeUnexpectedTerminationTest, SelfTerminating_CrashAfterReady
 
     ASSERT_THAT(result.has_value(), IsFalse());
     ASSERT_THAT(result.error(), Eq(IComponent::ComponentError::kErrorAfterReady));
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kTerminated));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kTerminated));
 }
 
 // Bundles succeess and failures cases when deactivating a process
@@ -517,7 +517,7 @@ TEST_F(ProcessInfoNodeDeactivationTest, CanTerminateNonSelfTerminatingProcess)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsFalse());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
 }
 
 // Bundles tests for the explicit move constructor, which is required because the class holds atomics.
@@ -537,7 +537,7 @@ TEST_F(ProcessInfoNodeMoveTest, MoveConstruct_IdleNode_PreservesObservableState)
     ProcessInfoNode moved{std::move(*source)};
 
     ASSERT_THAT(moved.getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(moved.getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(moved.getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
     ASSERT_THAT(moved.active(), IsFalse());
     ASSERT_THAT(moved.getPid(), Eq(0));
     ASSERT_THAT(moved.getControlClientChannel(), IsNull());
@@ -551,13 +551,13 @@ TEST_F(ProcessInfoNodeMoveTest, MoveConstruct_RunningNode_PreservesAtomicState)
         "moved node reports the running state and is active.");
 
     auto source = createRunningProcessInfoNode(osal::CommsType::kNoComms);
-    ASSERT_THAT(source->getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(source->getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
     ASSERT_THAT(source->active(), IsTrue());
 
     ProcessInfoNode moved{std::move(*source)};
 
     ASSERT_THAT(moved.getIndex(), Eq(kProcessIndex));
-    ASSERT_THAT(moved.getState(), Eq(score::lcm::ProcessState::kRunning));
+    ASSERT_THAT(moved.getState(), Eq(score::mw::lifecycle::ProcessState::kRunning));
     ASSERT_THAT(moved.active(), IsTrue());
 }
 
@@ -586,5 +586,5 @@ TEST_F(ProcessInfoNodeDeactivationTest, ProcessIgnoresSigterm_ForcedWithSigkill)
     ASSERT_THAT(result.has_value(), IsTrue());
     ASSERT_THAT(result.value(), Eq(IComponent::RequestState::kSuccess));
     ASSERT_THAT(node->active(), IsFalse());
-    ASSERT_THAT(node->getState(), Eq(score::lcm::ProcessState::kIdle));
+    ASSERT_THAT(node->getState(), Eq(score::mw::lifecycle::ProcessState::kIdle));
 }

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
@@ -44,11 +44,11 @@ constexpr int kPosixSuccess = 0;
 namespace
 {
 
-using score::lcm::internal::signal_safe_log;
-using score::lcm::internal::signal_safe_log_errno;
-using score::lcm::internal::osal::CommsType;
-using score::lcm::internal::osal::IpcCommsSync;
-using score::lcm::internal::osal::sysexit;
+using score::mw::lifecycle::internal::signal_safe_log;
+using score::mw::lifecycle::internal::signal_safe_log_errno;
+using score::mw::lifecycle::internal::osal::CommsType;
+using score::mw::lifecycle::internal::osal::IpcCommsSync;
+using score::mw::lifecycle::internal::osal::sysexit;
 
 /// @brief Applies the given limit.
 /// @details The implementation should be async signal safe.
@@ -81,7 +81,7 @@ void setLimit(const int resource, const std::size_t amount, const std::string_vi
 }
 
 /// @details The implementation should be async signal safe.
-void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
+void handleComms(score::mw::lifecycle::internal::osal::ChildProcessConfig& param)
 {
     // kNoComms !fd3 & !fd4
     // kReporting  fd3 & !fd4
@@ -135,7 +135,7 @@ void handleComms(score::lcm::internal::osal::ChildProcessConfig& param)
 }
 
 /// @details The implementation should be async signal safe.
-void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig& config)
+void changeCurrentWorkingDirectory(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     // working_dir_ is set by python configuration generator in lifecycle_config.py, so it should always be valid.
     // If not, chdir will fail anyway and we will log an error and exit.
@@ -147,7 +147,7 @@ void changeCurrentWorkingDirectory(const score::lcm::internal::osal::OsalConfig&
 }
 
 /// @details The implementation should be async signal safe.
-void implementMemoryResourceLimits(const score::lcm::internal::osal::OsalConfig& config)
+void implementMemoryResourceLimits(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     setLimit(RLIMIT_DATA, config.resource_limits_.data_, "RLIMIT_DATA");
     setLimit(RLIMIT_AS, config.resource_limits_.as_, "RLIMIT_AS");
@@ -161,11 +161,11 @@ void implementMemoryResourceLimits(const score::lcm::internal::osal::OsalConfig&
 }
 
 /// @details The implementation should be async signal safe.
-void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
+void changeSecurityPolicy(const score::mw::lifecycle::internal::osal::OsalConfig& config)
 {
     if (config.security_policy_ != "")
     {
-        if (score::lcm::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
+        if (score::mw::lifecycle::internal::osal::setSecurityPolicy(config.security_policy_.c_str()) != 0)
         {
             static_cast<void>(
                 signal_safe_log_errno(errno, "changeSecurityPolicy(", config.security_policy_, ") failed"));
@@ -176,13 +176,7 @@ void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
 
 }  // namespace
 
-
-
-
-
-
-
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 OsalReturnType ProcessLauncher::startProcess(ProcessID* pid, IpcCommsP* block, const OsalConfig* config)
@@ -260,7 +254,7 @@ OsalReturnType ProcessLauncher::startProcess(ProcessID* pid, IpcCommsP* block, c
 bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& config)
 {
     bool comms_result = true;
-    char shm_name[static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize)];
+    char shm_name[static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize)];
     size_t length = sizeof(IpcCommsSync);
 
     if (CommsType::kControlClient == config.comms_type_)
@@ -270,7 +264,7 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
 
     static_cast<void>(snprintf(
         shm_name,
-        static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize),
+        static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize),
         "/ipc_shared_mem%u",
         shm_name_counter++));
 
@@ -278,8 +272,8 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
 
     if (fd < 0)
     {
-        LM_LOG_ERROR() << "shm_open failed:" << config.executable_path_
-                       << "Unable to open shared memory object. Error:" << score::lcm::internal::errno_message(errno);
+        LM_LOG_ERROR() << "shm_open failed:" << config.executable_path_ << "Unable to open shared memory object. Error:"
+                       << score::mw::lifecycle::internal::errno_message(errno);
         comms_result = false;
     }
     else
@@ -291,7 +285,7 @@ bool ProcessLauncher::setupComms(IpcCommsP& block, int& fd, const OsalConfig& co
             comms_result = false;
             LM_LOG_ERROR() << "ftruncate failed:" << config.executable_path_
                            << "Unable to set size of shared memory file descriptor. Error:"
-                           << score::lcm::internal::errno_message(errno);
+                           << score::mw::lifecycle::internal::errno_message(errno);
         }
 
         if (config.comms_type_ == CommsType::kControlClient)
@@ -470,7 +464,7 @@ OsalReturnType ProcessLauncher::requestTermination(ProcessID pid)
         else
         {
             LM_LOG_ERROR() << "SIGTERM failed: Unable to send SIGTERM to process ID" << pid
-                           << ". Error:" << score::lcm::internal::errno_message(errno);
+                           << ". Error:" << score::mw::lifecycle::internal::errno_message(errno);
         }
     }
     else
@@ -527,7 +521,7 @@ OsalReturnType ProcessLauncher::waitForTermination(osal::ProcessID& pid, int32_t
     {
         /// exiting with pid == 0 is perfectly normal behaviour when all process groups are in the Off state.
         LM_LOG_DEBUG() << "wait failed: Unable to wait for any child process to terminate. Error:"
-                       << score::lcm::internal::errno_message(errno);
+                       << score::mw::lifecycle::internal::errno_message(errno);
     }
 
     return result;
@@ -569,7 +563,7 @@ OsalReturnType ProcessLauncher::waitForkRunning(IpcCommsP sync, std::chrono::mil
         else
         {
             LM_LOG_WARN() << "Skipping semaphore deinitialization - shared memory region appears invalid: "
-                          << score::lcm::internal::errno_message(errno);
+                          << score::mw::lifecycle::internal::errno_message(errno);
         }
     }
     else
@@ -581,10 +575,4 @@ OsalReturnType ProcessLauncher::waitForkRunning(IpcCommsP sync, std::chrono::mil
     return result;
 }
 
-} // namespace score::lcm::internal::osal
-
-
-
-
-
-
+}  // namespace score::mw::lifecycle::internal::osal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.cpp
@@ -176,16 +176,13 @@ void changeSecurityPolicy(const score::lcm::internal::osal::OsalConfig& config)
 
 }  // namespace
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
-{
 
-namespace osal
+
+
+
+namespace score::lcm::internal::osal
 {
 
 OsalReturnType ProcessLauncher::startProcess(ProcessID* pid, IpcCommsP* block, const OsalConfig* config)
@@ -584,10 +581,10 @@ OsalReturnType ProcessLauncher::waitForkRunning(IpcCommsP sync, std::chrono::mil
     return result;
 }
 
-}  // namespace osal
+} // namespace score::lcm::internal::osal
 
-}  // namespace internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/process_launcher.hpp
@@ -20,7 +20,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -86,7 +86,7 @@ class ProcessLauncher final : public IProcess
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
@@ -17,11 +17,7 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 
-
-
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 SafeProcessMap::SafeProcessMap(uint32_t capacity, IComponentController& termination_handler)
@@ -308,8 +304,4 @@ SafeProcessMapReturnType SafeProcessMap::insertIfNotTerminated(osal::ProcessID k
     return static_cast<SafeProcessMapReturnType>(search(key, {0, object}));
 }
 
-} // namespace score::lcm::internal
-
-
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.cpp
@@ -17,13 +17,11 @@
 
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 
-namespace score
-{
 
-namespace lcm
-{
 
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 SafeProcessMap::SafeProcessMap(uint32_t capacity, IComponentController& termination_handler)
@@ -310,8 +308,8 @@ SafeProcessMapReturnType SafeProcessMap::insertIfNotTerminated(osal::ProcessID k
     return static_cast<SafeProcessMapReturnType>(search(key, {0, object}));
 }
 
-}  // namespace internal
+} // namespace score::lcm::internal
 
-}  // namespace lcm
 
-}  // namespace score
+
+

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
@@ -28,8 +28,6 @@ namespace mw::lifecycle
 namespace internal
 {
 
-using namespace score::mw::lifecycle::internal;
-
 /// @brief Struct representing data in a map item
 struct ProcessInfoData
 {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safe_process_map.hpp
@@ -22,7 +22,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -224,7 +224,7 @@ class SafeProcessMap final : public SafeProcessMapInserter
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/safeprocessmap_UT.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/safeprocessmap_UT.cpp
@@ -24,7 +24,7 @@
 #include "score/mw/launch_manager/process_group_manager/details/safe_process_map.hpp"
 
 using namespace testing;
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 namespace
 {
@@ -83,15 +83,15 @@ TEST_F(SafeProcessMapTest, FindTerminatedWithNegativePidReturnsInvalid)
 {
     RecordProperty(
         "Description",
-        "findTerminated returns -score::lcm::internal::SafeProcessMapReturnType::kUndefined "
+        "findTerminated returns -score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined "
         "for a negative "
         "process ID.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(-1, 1000);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(-1, 1000);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedInsertsEntryWhenPidNotPresent)
@@ -100,10 +100,10 @@ TEST_F(SafeProcessMapTest, FindTerminatedInsertsEntryWhenPidNotPresent)
         "Description", "findTerminated inserts an entry and returns kYield (1) when the PID is not in the map.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 0);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 0);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedMatchesExistingInsertAndCallsCallback)
@@ -118,8 +118,8 @@ TEST_F(SafeProcessMapTest, FindTerminatedMatchesExistingInsertAndCallsCallback)
     EXPECT_CALL(controller, terminated(Ref(callback_), 42));
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 42);
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.findTerminated(1000, 42);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 // --- insertIfNotTerminated ---
@@ -129,10 +129,10 @@ TEST_F(SafeProcessMapTest, InsertIntoEmptyTreeReturnsZero)
     RecordProperty("Description", "insertIfNotTerminated returns kOk (0) when inserting into an empty tree.");
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(2000, &callback_);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(2000, &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 TEST_F(SafeProcessMapTest, InsertMatchesExistingFindTerminatedEntry)
@@ -147,10 +147,10 @@ TEST_F(SafeProcessMapTest, InsertMatchesExistingFindTerminatedEntry)
     EXPECT_CALL(controller, terminated(Ref(callback_), 0));
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(1000, &callback_);
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result = sut_.insertIfNotTerminated(1000, &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 TEST_F(SafeProcessMapTest, InsertMultipleNodesThenFindTerminatedRemovesAll)
@@ -168,7 +168,9 @@ TEST_F(SafeProcessMapTest, InsertMultipleNodesThenFindTerminatedRemovesAll)
     // when / then
     for (uint32_t j = 1; j <= kCapacity; ++j)
     {
-        EXPECT_EQ(sut_.findTerminated(static_cast<int32_t>(j), 0), score::lcm::internal::SafeProcessMapReturnType::kOk);
+        EXPECT_EQ(
+            sut_.findTerminated(static_cast<int32_t>(j), 0),
+            score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 }
 
@@ -184,15 +186,15 @@ TEST_F(SafeProcessMapTest, InsertBeyondCapacityReturnsOutOfMemory)
     {
         EXPECT_EQ(
             sut_.insertIfNotTerminated(static_cast<int32_t>(i), &callbacks[i]),
-            score::lcm::internal::SafeProcessMapReturnType::kOk);
+            score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 
     // when
-    score::lcm::internal::SafeProcessMapReturnType result =
+    score::mw::lifecycle::internal::SafeProcessMapReturnType result =
         sut_.insertIfNotTerminated(static_cast<int32_t>(kCapacity + 1), &callback_);
 
     // then
-    EXPECT_EQ(result, score::lcm::internal::SafeProcessMapReturnType::kInsertionError);
+    EXPECT_EQ(result, score::mw::lifecycle::internal::SafeProcessMapReturnType::kInsertionError);
 }
 
 // --- Anomalous (PID reuse) cases ---
@@ -205,8 +207,10 @@ TEST_F(SafeProcessMapTest, InsertSamePidTwiceYieldsUntilFindTerminatedResolves)
 
     // given
     std::atomic_bool first_done{false};
-    score::lcm::internal::SafeProcessMapReturnType ret1 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
-    score::lcm::internal::SafeProcessMapReturnType ret2 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret1 =
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret2 =
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
 
     NiceMock<MockComponent> cb;
 
@@ -222,15 +226,15 @@ TEST_F(SafeProcessMapTest, InsertSamePidTwiceYieldsUntilFindTerminatedResolves)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // then — first succeeded, second is still blocked
-    EXPECT_EQ(ret1, score::lcm::internal::SafeProcessMapReturnType::kOk);
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kUndefined);
+    EXPECT_EQ(ret1, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined);
 
     // when — resolve the anomaly
-    EXPECT_EQ(sut_.findTerminated(42, 0), score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(sut_.findTerminated(42, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     inserter.join();
 
     // then
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
 }
 
 TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
@@ -242,8 +246,10 @@ TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
 
     // given
     std::atomic_bool first_done{false};
-    score::lcm::internal::SafeProcessMapReturnType ret1 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
-    score::lcm::internal::SafeProcessMapReturnType ret2 = score::lcm::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret1 =
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
+    score::mw::lifecycle::internal::SafeProcessMapReturnType ret2 =
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined;
 
     NiceMock<MockComponent> cb;
 
@@ -259,15 +265,15 @@ TEST_F(SafeProcessMapTest, FindTerminatedSamePidTwiceYieldsUntilInsertResolves)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // then — first succeeded, second is still blocked
-    EXPECT_EQ(ret1, score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kUndefined);
+    EXPECT_EQ(ret1, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kUndefined);
 
     // when — resolve the anomaly
-    EXPECT_EQ(sut_.insertIfNotTerminated(42, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.insertIfNotTerminated(42, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
     finder.join();
 
     // then
-    EXPECT_EQ(ret2, score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(ret2, score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 // --- Max depth tree ---
@@ -277,55 +283,59 @@ TEST_F(SafeProcessMapTest, FindTerminatedWorksAtMaxTreeDepth)
     RecordProperty("Description", "The binary tree handles maximum depth correctly.");
 
     // given — build a deep tree using bit patterns that always branch one way
-    EXPECT_EQ(sut_.findTerminated(0x00000000, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000001, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000002, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000003, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000007, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000000F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000001F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000003F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000007F, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000000FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000001FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000003FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000007FF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00000FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00001FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00003FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00007FFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0000FFFE, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0001FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0003FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0007FFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x000FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x001FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x003FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x007FFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x00FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x01FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x03FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x07FFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x0FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x1FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x3FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.findTerminated(0x7FFFFFFF, 0), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000000, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000001, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000002, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000003, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000007, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000000F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000001F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000003F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000007F, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000000FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000001FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000003FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000007FF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00000FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00001FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00003FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00007FFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0000FFFE, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0001FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0003FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0007FFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x000FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x001FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x003FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x007FFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x00FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x01FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x03FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x07FFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x0FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x1FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x3FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(sut_.findTerminated(0x7FFFFFFF, 0), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 
     // when / then — boundary values
     EXPECT_EQ(
         sut_.findTerminated(static_cast<int32_t>(0xFFFFFFFF), 0),
-        score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
     EXPECT_EQ(
         sut_.insertIfNotTerminated(static_cast<int32_t>(0xFFFFFFFF), &callback_),
-        score::lcm::internal::SafeProcessMapReturnType::kInvalidIdError);
+        score::mw::lifecycle::internal::SafeProcessMapReturnType::kInvalidIdError);
 
     // when / then — retrieve entries using insertIfNotTerminated
     NiceMock<MockComponent> cb;
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x0000FFFE, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x00010000, &cb), score::lcm::internal::SafeProcessMapReturnType::kOk);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x0001FFFF, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
-    EXPECT_EQ(sut_.insertIfNotTerminated(0x00000002, &cb), score::lcm::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(
+        sut_.insertIfNotTerminated(0x0000FFFE, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(
+        sut_.insertIfNotTerminated(0x00010000, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
+    EXPECT_EQ(
+        sut_.insertIfNotTerminated(0x0001FFFF, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
+    EXPECT_EQ(
+        sut_.insertIfNotTerminated(0x00000002, &cb), score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
 }
 
 // --- Multi-threaded stress tests ---
@@ -337,7 +347,7 @@ TEST_F(SafeProcessMapTest, ConcurrentInsertAndFindFromMultipleThreads)
         "Multiple threads concurrently inserting and finding terminated processes completes without error.");
 
     NiceMock<MockComponent> stubs[kNumThreads];
-    score::lcm::internal::SafeProcessMapReturnType results[kNumThreads] = {};
+    score::mw::lifecycle::internal::SafeProcessMapReturnType results[kNumThreads] = {};
 
     // when
     std::vector<std::thread> threads;
@@ -368,7 +378,7 @@ TEST_F(SafeProcessMapTest, ConcurrentInsertAndFindFromMultipleThreads)
     // then
     for (int t = 0; t < kNumThreads; ++t)
     {
-        EXPECT_EQ(results[t], score::lcm::internal::SafeProcessMapReturnType::kOk);
+        EXPECT_EQ(results[t], score::mw::lifecycle::internal::SafeProcessMapReturnType::kOk);
     }
 }
 
@@ -378,7 +388,7 @@ TEST_F(SafeProcessMapTest, ConcurrentFindAndInsertFromMultipleThreads)
         "Description", "Multiple threads concurrently finding and inserting processes completes without error.");
 
     NiceMock<MockComponent> stubs[kNumThreads];
-    score::lcm::internal::SafeProcessMapReturnType results[kNumThreads] = {};
+    score::mw::lifecycle::internal::SafeProcessMapReturnType results[kNumThreads] = {};
 
     // when
     std::vector<std::thread> threads;
@@ -409,7 +419,7 @@ TEST_F(SafeProcessMapTest, ConcurrentFindAndInsertFromMultipleThreads)
     // then
     for (int t = 0; t < kNumThreads; ++t)
     {
-        EXPECT_EQ(results[t], score::lcm::internal::SafeProcessMapReturnType::kYield);
+        EXPECT_EQ(results[t], score::mw::lifecycle::internal::SafeProcessMapReturnType::kYield);
     }
 }
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
@@ -33,7 +33,6 @@
 
 namespace score::mw::lifecycle
 {
-using namespace score::mw::lifecycle::internal;
 
 /// @brief What should happen to a ready node right now.
 enum class Action : std::uint8_t
@@ -284,7 +283,7 @@ class Transition
 
         /// @brief The nodes that are ready to be activated/deactivated in the current phase, in the order they were
         /// discovered.
-        FixedSizeQueue<GraphIndex> next_nodes;
+        internal::FixedSizeQueue<GraphIndex> next_nodes;
         std::size_t pending = 0;    // nodes still to reach terminal state in this phase
         Phase phase = Phase::Done;  // active vs deactivation vs finished
 
@@ -292,7 +291,7 @@ class Transition
         /// @deprecated This is a workaround for the case where two processes are started in parallel and their events
         /// processed in sequence. Both onNodeFinished() calls detect that all dependents are ready and try to enqueue
         /// successors. Detection of dependency readiness should be reworked to remove this.
-        std::bitset<static_cast<std::size_t>(ProcessLimits::kMaxProcesses)> enqueued_set{};
+        std::bitset<static_cast<std::size_t>(internal::ProcessLimits::kMaxProcesses)> enqueued_set{};
 
         State(std::size_t nodes) : next_nodes(nodes)
         {

--- a/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/details/transition.hpp
@@ -33,7 +33,7 @@
 
 namespace score::mw::lifecycle
 {
-using namespace score::lcm::internal;
+using namespace score::mw::lifecycle::internal;
 
 /// @brief What should happen to a ready node right now.
 enum class Action : std::uint8_t

--- a/score/launch_manager/src/daemon/src/process_group_manager/ialive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/ialive_monitor_thread.hpp
@@ -16,7 +16,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -29,7 +29,7 @@ class IAliveMonitorThread
     virtual ~IAliveMonitorThread() = default;
 };
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/iprocess.hpp
@@ -28,7 +28,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -53,10 +53,10 @@ struct OsalLimits
 // have user-declared constructor. The rule doesn’t apply.", false)
 struct OsalConfig
 {
-    std::string executable_path_{};                                              ///< Path to the executable.
-    std::string short_name_;                                                     ///< Short name of the process
-    std::array<const char*, score::lcm::internal::kArgvArraySize> argv_{};       ///< Command-line arguments.
-    char* envp_[static_cast<std::size_t>(score::lcm::internal::kEnvArraySize)];  ///< Environment variables.
+    std::string executable_path_{};                                                   ///< Path to the executable.
+    std::string short_name_;                                                          ///< Short name of the process
+    std::array<const char*, score::mw::lifecycle::internal::kArgvArraySize> argv_{};  ///< Command-line arguments.
+    char* envp_[static_cast<std::size_t>(score::mw::lifecycle::internal::kEnvArraySize)];  ///< Environment variables.
     std::string security_policy_{};          ///< Security policy to apply to this process
     uid_t uid_;                              ///< User ID.
     gid_t gid_;                              ///< Group ID.
@@ -158,7 +158,7 @@ class IProcess
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/process_group_manager/mock_alive_monitor_thread.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/mock_alive_monitor_thread.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace internal
 {
@@ -35,7 +35,7 @@ class MockAliveMonitorThread : public IAliveMonitorThread
 };
 
 }  // namespace internal
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif  // SCORE_LCM_IALIVE_MONITOR_THREAD_MOCK_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/mock_iprocess.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/mock_iprocess.hpp
@@ -16,7 +16,7 @@
 #include "score/mw/launch_manager/process_group_manager/iprocess.hpp"
 #include <gmock/gmock.h>
 
-namespace score::lcm::internal::osal
+namespace score::mw::lifecycle::internal::osal
 {
 
 class MockIProcess : public IProcess
@@ -29,6 +29,6 @@ class MockIProcess : public IProcess
     MOCK_METHOD(OsalReturnType, waitForkRunning, (IpcCommsP sync, std::chrono::milliseconds timeout), (override));
 };
 
-}  // namespace score::lcm::internal::osal
+}  // namespace score::mw::lifecycle::internal::osal
 
 #endif  // MOCK_IPROCESS_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
@@ -40,7 +40,7 @@ ProcessGroupManager::ProcessGroupManager(
     std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
     std::shared_ptr<IRecoveryClient> recovery_client,
     std::unique_ptr<score::mw::lifecycle::ISupervisionControlNotifier> supervision_control_notifier,
-    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog)
+    std::unique_ptr<score::mw::lifecycle::internal::watchdog::IWatchdogIf> watchdog)
     : configuration_(),
       process_interface_(),
       process_map_(nullptr),

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
@@ -21,10 +21,10 @@
 #include "score/mw/launch_manager/process_group_manager/ialive_monitor_thread.hpp"
 #include "score/mw/launch_manager/process_group_manager/process_group_manager.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
-using namespace score::lcm::internal::osal;
+using namespace score::mw::lifecycle::internal::osal;
 
 static std::atomic_bool em_cancelled{false};
 
@@ -41,8 +41,8 @@ void ProcessGroupManager::cancel()
 ProcessGroupManager::ProcessGroupManager(
     std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
     std::shared_ptr<IRecoveryClient> recovery_client,
-    std::unique_ptr<score::lcm::ISupervisionControlNotifier> supervision_control_notifier,
-    std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog)
+    std::unique_ptr<score::mw::lifecycle::ISupervisionControlNotifier> supervision_control_notifier,
+    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog)
     : configuration_(),
       process_interface_(),
       process_map_(nullptr),
@@ -128,7 +128,7 @@ bool ProcessGroupManager::initialize(const Config& config)
     // Watchdog config may not be available if no watchdog is configured
     if (watchdog_config.has_value())
     {
-        if (!watchdog_->init(watchdog_config.value(), score::lcm::internal::kMainLoopCycleTimeNs))
+        if (!watchdog_->init(watchdog_config.value(), score::mw::lifecycle::internal::kMainLoopCycleTimeNs))
         {
             LM_LOG_ERROR() << "Watchdog initialization failed";
             return false;
@@ -171,11 +171,11 @@ bool ProcessGroupManager::initializeControlClientHandler()
     // The name is removed from the file system after creation, memory
     // is mapped and a pointer stored, the FD is kept open.
     ControlClientChannel::nudgeControlClientHandler_ = nullptr;
-    char shm_name[static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize)];
+    char shm_name[static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize)];
 
     static_cast<void>(snprintf(
         shm_name,
-        static_cast<uint32_t>(score::lcm::internal::ProcessLimits::maxLocalBuffSize),
+        static_cast<uint32_t>(score::mw::lifecycle::internal::ProcessLimits::maxLocalBuffSize),
         "/_nudge~._.~me_"));  // random name
     int fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0U);
 
@@ -331,7 +331,8 @@ bool ProcessGroupManager::run()
 
             // Wait for a graph-relevant event (activation/deactivation completion or
             // unexpected termination). All Graph state mutations happen here, on the main thread.
-            if (event_queue_->waitForEvents(std::chrono::milliseconds(score::lcm::internal::kMainLoopCycleTimeMs)))
+            if (event_queue_->waitForEvents(
+                    std::chrono::milliseconds(score::mw::lifecycle::internal::kMainLoopCycleTimeMs)))
             {
                 processComponentEvents();
             }
@@ -882,4 +883,4 @@ std::shared_ptr<ProcessGroupManager::WorkerQueue> ProcessGroupManager::getWorker
     return worker_jobs_;
 }
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.cpp
@@ -24,8 +24,6 @@
 namespace score::mw::lifecycle::internal
 {
 
-using namespace score::mw::lifecycle::internal::osal;
-
 static std::atomic_bool em_cancelled{false};
 
 static void my_signal_handler(int)
@@ -209,7 +207,7 @@ bool ProcessGroupManager::initializeControlClientHandler()
                     // statement.
                     const auto osal_result = ControlClientChannel::nudgeControlClientHandler_->init(0U, true);
                     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
-                        osal_result == OsalReturnType::kSuccess, "ControlClientChannel semaphore init failed");
+                        osal_result == osal::OsalReturnType::kSuccess, "ControlClientChannel semaphore init failed");
 
                     result = true;
                 }

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
@@ -43,7 +43,7 @@ namespace score::mw::lifecycle::internal
 {
 
 using ConfigurationType = ConfigurationAdapter;
-using Config = score::mw::lifecycle::configuration::Config;
+using Config = score::mw::lifecycle::internal::configuration::Config;
 
 /// @brief ProcessGroupManager provides the core functionality of LCM.
 /// Software that is deployed to the machine, should be managed through Process Groups.
@@ -79,7 +79,7 @@ class ProcessGroupManager final : public ITransitionResultPublisher
         std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
         std::shared_ptr<IRecoveryClient> recovery_client,
         std::unique_ptr<score::mw::lifecycle::ISupervisionControlNotifier> supervision_control_notifier,
-        std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog);
+        std::unique_ptr<score::mw::lifecycle::internal::watchdog::IWatchdogIf> watchdog);
 
     /// @brief Initializes the process group manager.
     /// Loads the flat configuration through ConfigurationManager.
@@ -322,7 +322,7 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recovery_client_{};
 
     /// @brief The watchdog serviced during the main loop. May be nullptr in legacy configuration.
-    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog_;
+    std::unique_ptr<score::mw::lifecycle::internal::watchdog::IWatchdogIf> watchdog_;
 };
 
 }  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
@@ -43,7 +43,7 @@ namespace score::mw::lifecycle::internal
 {
 
 using ConfigurationType = ConfigurationAdapter;
-using Config = score::mw::launch_manager::configuration::Config;
+using Config = score::mw::lifecycle::configuration::Config;
 
 /// @brief ProcessGroupManager provides the core functionality of LCM.
 /// Software that is deployed to the machine, should be managed through Process Groups.

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_group_manager.hpp
@@ -39,7 +39,7 @@
 #include "score/mw/launch_manager/supervision_control_client/isupervision_control_notifier.hpp"
 #include "score/mw/launch_manager/watchdog/IWatchdogIf.hpp"
 
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 using ConfigurationType = ConfigurationAdapter;
@@ -78,8 +78,8 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     ProcessGroupManager(
         std::unique_ptr<IAliveMonitorThread> alive_monitor_thread,
         std::shared_ptr<IRecoveryClient> recovery_client,
-        std::unique_ptr<score::lcm::ISupervisionControlNotifier> supervision_control_notifier,
-        std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog);
+        std::unique_ptr<score::mw::lifecycle::ISupervisionControlNotifier> supervision_control_notifier,
+        std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog);
 
     /// @brief Initializes the process group manager.
     /// Loads the flat configuration through ConfigurationManager.
@@ -307,7 +307,7 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     std::shared_ptr<Graph> machine_process_group_{nullptr};
 
     /// @brief Process state notifier object used to send data to PHM
-    std::unique_ptr<score::lcm::ISupervisionControlNotifier> supervision_control_notifier_;
+    std::unique_ptr<score::mw::lifecycle::ISupervisionControlNotifier> supervision_control_notifier_;
 
     std::unique_ptr<IAliveMonitorThread> alive_monitor_thread_;
 
@@ -319,12 +319,12 @@ class ProcessGroupManager final : public ITransitionResultPublisher
     /// on the main thread, so all Graph state mutations happen from a single thread.
     std::unique_ptr<ComponentEventQueue> event_queue_;
 
-    std::shared_ptr<score::lcm::IRecoveryClient> recovery_client_{};
+    std::shared_ptr<score::mw::lifecycle::IRecoveryClient> recovery_client_{};
 
     /// @brief The watchdog serviced during the main loop. May be nullptr in legacy configuration.
-    std::unique_ptr<score::lcm::watchdog::IWatchdogIf> watchdog_;
+    std::unique_ptr<score::mw::lifecycle::watchdog::IWatchdogIf> watchdog_;
 };
 
-}  // namespace score::lcm::internal
+}  // namespace score::mw::lifecycle::internal
 
 #endif  /// PROCESSGROUPMANAGER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/process_group_manager/process_state.hpp
+++ b/score/launch_manager/src/daemon/src/process_group_manager/process_state.hpp
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 /// @brief Represents the state of a modelled process.
@@ -30,6 +30,6 @@ enum class ProcessState : std::uint8_t
     kFailed = 5        ///< process failed to start.
 };
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #endif  // SCORE_LCM_PROCESS_STATE_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/recovery_client/irecovery_client.h
+++ b/score/launch_manager/src/daemon/src/recovery_client/irecovery_client.h
@@ -18,7 +18,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief The RecoveryClient allows the AliveMonitor component to report supervision failures to the
@@ -27,7 +27,7 @@ namespace lcm
 class IRecoveryClient
 {
   public:
-    using RecoveryRequestCallback = std::function<void(const score::lcm::IdentifierHash&)>;
+    using RecoveryRequestCallback = std::function<void(const score::mw::lifecycle::IdentifierHash&)>;
 
     IRecoveryClient() noexcept = default;
     virtual ~IRecoveryClient() noexcept = default;
@@ -44,9 +44,9 @@ class IRecoveryClient
     /// @details Invokes the registered callback with the provided process identifier.
     /// @param process_identifier The process that requires recovery.
     /// @return true if a callback was registered and invoked, false otherwise.
-    virtual bool sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept = 0;
+    virtual bool sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept = 0;
 };
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/recovery_client/mock_irecovery_client.h
+++ b/score/launch_manager/src/daemon/src/recovery_client/mock_irecovery_client.h
@@ -19,7 +19,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief Reusable gmock mock for IRecoveryClient, for use by tests of components that either request recovery
@@ -31,11 +31,11 @@ class MockRecoveryClient : public IRecoveryClient
     MOCK_METHOD(
         bool,
         sendRecoveryRequest,
-        (const score::lcm::IdentifierHash& process_group_identifier),
+        (const score::mw::lifecycle::IdentifierHash& process_group_identifier),
         (noexcept, override));
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif  // SCORE_LCM_IRECOVERYCLIENT_MOCK_H_

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
@@ -14,9 +14,8 @@
 
 #include <utility>
 
-namespace score
-{
-namespace lcm
+
+namespace score::lcm
 {
 
 void RecoveryClient::setRecoveryRequestCallback(RecoveryRequestCallback callback) noexcept
@@ -35,5 +34,5 @@ bool RecoveryClient::sendRecoveryRequest(const score::lcm::IdentifierHash& proce
     callback_(process_identifier);
     return true;
 }
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm
+

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client.cpp
@@ -14,8 +14,7 @@
 
 #include <utility>
 
-
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 void RecoveryClient::setRecoveryRequestCallback(RecoveryRequestCallback callback) noexcept
@@ -24,7 +23,7 @@ void RecoveryClient::setRecoveryRequestCallback(RecoveryRequestCallback callback
     callback_ = std::move(callback);
 }
 
-bool RecoveryClient::sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept
+bool RecoveryClient::sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept
 {
     std::lock_guard<std::mutex> lock(callback_mutex_);
     if (!callback_)
@@ -34,5 +33,4 @@ bool RecoveryClient::sendRecoveryRequest(const score::lcm::IdentifierHash& proce
     callback_(process_identifier);
     return true;
 }
-} // namespace score::lcm
-
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client.hpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client.hpp
@@ -19,7 +19,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 class RecoveryClient final : public IRecoveryClient
@@ -33,13 +33,13 @@ class RecoveryClient final : public IRecoveryClient
     RecoveryClient& operator=(RecoveryClient&&) = delete;
 
     void setRecoveryRequestCallback(RecoveryRequestCallback callback) noexcept override;
-    bool sendRecoveryRequest(const score::lcm::IdentifierHash& process_identifier) noexcept override;
+    bool sendRecoveryRequest(const score::mw::lifecycle::IdentifierHash& process_identifier) noexcept override;
 
   private:
     mutable std::mutex callback_mutex_;
     RecoveryRequestCallback callback_;
 };
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
@@ -16,9 +16,8 @@
 
 #include "score/mw/launch_manager/recovery_client/recovery_client.hpp"
 
-namespace score
-{
-namespace lcm
+
+namespace score::lcm
 {
 
 class RecoveryClientTest : public ::testing::Test
@@ -103,5 +102,5 @@ TEST_F(RecoveryClientTest, ReRegisteringCallbackReplacesPreviousCallback)
     EXPECT_EQ(callback2_calls, 1U);
 }
 
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm
+

--- a/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
+++ b/score/launch_manager/src/daemon/src/recovery_client/recovery_client_UT.cpp
@@ -16,8 +16,7 @@
 
 #include "score/mw/launch_manager/recovery_client/recovery_client.hpp"
 
-
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 class RecoveryClientTest : public ::testing::Test
@@ -102,5 +101,4 @@ TEST_F(RecoveryClientTest, ReRegisteringCallbackReplacesPreviousCallback)
     EXPECT_EQ(callback2_calls, 1U);
 }
 
-} // namespace score::lcm
-
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.cpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.cpp
@@ -14,9 +14,7 @@
 #include "score/mw/launch_manager/supervision_control_client/details/supervision_control_receiver.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-
-
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 SupervisionControlReceiver::SupervisionControlReceiver(BufferP ring_buffer) noexcept : ring_buffer_(ring_buffer)
 {
@@ -28,30 +26,29 @@ SupervisionControlReceiver::~SupervisionControlReceiver() noexcept
 
 score::Result<std::optional<SupervisionEvent>> SupervisionControlReceiver::getNextSupervisionEvent() noexcept
 {
-    score::lcm::SupervisionEvent event;
+    score::mw::lifecycle::SupervisionEvent event;
     if (ring_buffer_->getOverflowFlag())
     {
         LM_LOG_ERROR() << "SupervisionControlReceiver::getNextSupervisionEvent: Overflow occurred, "
                           "will be reported as kCommunicationError";
-        return score::Result<std::optional<score::lcm::SupervisionEvent>>{
+        return score::Result<std::optional<score::mw::lifecycle::SupervisionEvent>>{
             score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kCommunicationError)};
     }
 
     if (ring_buffer_->empty())
     {
-        return score::Result<std::optional<score::lcm::SupervisionEvent>>{std::nullopt};
+        return score::Result<std::optional<score::mw::lifecycle::SupervisionEvent>>{std::nullopt};
     }
 
     auto res = ring_buffer_->tryDequeue(event);
     if (res)
     {
-        return score::Result<std::optional<score::lcm::SupervisionEvent>>{event};
+        return score::Result<std::optional<score::mw::lifecycle::SupervisionEvent>>{event};
     }
     else
     {
-        return score::Result<std::optional<score::lcm::SupervisionEvent>>{
+        return score::Result<std::optional<score::mw::lifecycle::SupervisionEvent>>{
             score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kGeneralError)};
     }
 }
-} // namespace score::lcm
-
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.cpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.cpp
@@ -14,10 +14,9 @@
 #include "score/mw/launch_manager/supervision_control_client/details/supervision_control_receiver.hpp"
 #include "score/mw/launch_manager/common/log.hpp"
 
-namespace score
-{
 
-namespace lcm
+
+namespace score::lcm
 {
 SupervisionControlReceiver::SupervisionControlReceiver(BufferP ring_buffer) noexcept : ring_buffer_(ring_buffer)
 {
@@ -54,5 +53,5 @@ score::Result<std::optional<SupervisionEvent>> SupervisionControlReceiver::getNe
             score::MakeUnexpected(score::mw::lifecycle::ExecErrc::kGeneralError)};
     }
 }
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm
+

--- a/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/details/supervision_control_receiver.hpp
@@ -20,7 +20,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief SupervisionControlReceiver implementation for receiving supervision events from the Launch Manager.
@@ -28,8 +28,8 @@ class SupervisionControlReceiver final : public ISupervisionControlReceiver
 {
   public:
     using BufferP = std::shared_ptr<ipc_dropin::RingBuffer<
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>;
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>;
 
     /// @brief Constructor that creates the SupervisionControlReceiver
     /// @param ring_buffer Shared pointer to the ring buffer used to receive supervision events
@@ -61,7 +61,7 @@ class SupervisionControlReceiver final : public ISupervisionControlReceiver
     BufferP ring_buffer_{};
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_control_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_control_notifier.hpp
@@ -20,7 +20,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief ISupervisionControlNotifier interface for forwarding supervision events to the alive monitor.
@@ -34,10 +34,10 @@ class ISupervisionControlNotifier : public ISupervisionEventPublisher
 
     /// @brief Construct and return the receiver instance used to receive supervision events.
     /// @return Supervision control receiver instance
-    virtual std::unique_ptr<score::lcm::ISupervisionControlReceiver> constructReceiver() = 0;
+    virtual std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver> constructReceiver() = 0;
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_control_receiver.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_control_receiver.hpp
@@ -23,7 +23,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief ISupervisionControlReceiver interface for receiving supervision events.
@@ -39,7 +39,7 @@ class ISupervisionControlReceiver
     virtual score::Result<std::optional<SupervisionEvent>> getNextSupervisionEvent() noexcept = 0;
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_event_publisher.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/isupervision_event_publisher.hpp
@@ -19,7 +19,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief ISupervisionEventPublisher interface for forwarding supervision events to the alive monitor.
@@ -38,7 +38,7 @@ class ISupervisionEventPublisher
     virtual bool reportDeactivation(IdentifierHash id, timespec time) noexcept = 0;
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/supervision_control_client/mock_iprocess_state_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/mock_iprocess_state_notifier.hpp
@@ -22,7 +22,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief Reusable gmock mock for IProcessStateNotifier, for use by tests of components that notify PHM of process
@@ -30,11 +30,15 @@ namespace lcm
 class MockProcessStateNotifier : public IProcessStateNotifier
 {
   public:
-    MOCK_METHOD(std::unique_ptr<score::lcm::IProcessStateReceiver>, constructReceiver, (), (override));
-    MOCK_METHOD(bool, queuePosixProcess, (const score::lcm::PosixProcess& f_posixProcess), (noexcept, override));
+    MOCK_METHOD(std::unique_ptr<score::mw::lifecycle::IProcessStateReceiver>, constructReceiver, (), (override));
+    MOCK_METHOD(
+        bool,
+        queuePosixProcess,
+        (const score::mw::lifecycle::PosixProcess& f_posixProcess),
+        (noexcept, override));
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif  // IPROCESSSTATE_NOTIFIER_MOCK_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/supervision_control_client/mock_supervision_control_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/mock_supervision_control_notifier.hpp
@@ -16,7 +16,7 @@
 #include "score/mw/launch_manager/supervision_control_client/isupervision_control_notifier.hpp"
 #include <gmock/gmock.h>
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 class MockSupervisionControlNotifier : public ISupervisionControlNotifier
@@ -24,9 +24,9 @@ class MockSupervisionControlNotifier : public ISupervisionControlNotifier
   public:
     MOCK_METHOD(bool, reportActivation, (IdentifierHash id, timespec time), (override, noexcept));
     MOCK_METHOD(bool, reportDeactivation, (IdentifierHash id, timespec time), (override, noexcept));
-    MOCK_METHOD(std::unique_ptr<score::lcm::ISupervisionControlReceiver>, constructReceiver, (), (override));
+    MOCK_METHOD(std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver>, constructReceiver, (), (override));
 };
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #endif  // MOCK_SUPERVISION_CONTROL_NOTIFIER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/supervision_control_client/mock_supervision_event_publisher.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/mock_supervision_event_publisher.hpp
@@ -16,7 +16,7 @@
 #include "score/mw/launch_manager/supervision_control_client/isupervision_event_publisher.hpp"
 #include <gmock/gmock.h>
 
-namespace score::lcm
+namespace score::mw::lifecycle
 {
 
 class MockSupervisionEventPublisher : public ISupervisionEventPublisher
@@ -26,6 +26,6 @@ class MockSupervisionEventPublisher : public ISupervisionEventPublisher
     MOCK_METHOD(bool, reportDeactivation, (IdentifierHash id, timespec time), (override, noexcept));
 };
 
-}  // namespace score::lcm
+}  // namespace score::mw::lifecycle
 
 #endif  // MOCK_SUPERVISION_EVENT_PUBLISHER_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_client_ut.cpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_client_ut.cpp
@@ -16,10 +16,10 @@
 #include <memory>
 
 using namespace testing;
-using namespace score::lcm;
+using namespace score::mw::lifecycle;
 
-using score::lcm::SupervisionControlReceiver;
-using score::lcm::internal::SupervisionControlNotifier;
+using score::mw::lifecycle::SupervisionControlReceiver;
+using score::mw::lifecycle::internal::SupervisionControlNotifier;
 
 class SupervisionControlClient_UT : public ::testing::Test
 {
@@ -57,8 +57,8 @@ TEST_F(SupervisionControlClient_UT, SupervisionControlClient_QueueOneEvent_Succe
         "This test verifies that a single SupervisionEvent can be successfully queued using the "
         "SupervisionControlNotifier and retrieved using the SupervisionControlReceiver.");
     SupervisionEvent event1{
-        .id = score::lcm::IdentifierHash("Process1"),
-        .eventType = score::lcm::SupervisionEventType::kActivation,
+        .id = score::mw::lifecycle::IdentifierHash("Process1"),
+        .eventType = score::mw::lifecycle::SupervisionEventType::kActivation,
         .systemClockTimestamp = {}};
 
     clock_gettime(CLOCK_MONOTONIC, &event1.systemClockTimestamp);
@@ -88,8 +88,8 @@ TEST_F(SupervisionControlClient_UT, SupervisionControlClient_QueueMaxNumberOfEve
     for (size_t i = 0; i < static_cast<size_t>(BufferConstants::BUFFER_QUEUE_SIZE); ++i)
     {
         SupervisionEvent event{
-            .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
-            .eventType = score::lcm::SupervisionEventType::kActivation,
+            .id = score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)),
+            .eventType = score::mw::lifecycle::SupervisionEventType::kActivation,
             .systemClockTimestamp = {}};
         bool queued = notifier_->reportActivation(event.id, event.systemClockTimestamp);
         ASSERT_TRUE(queued) << "Failed to queue event at index " << i;
@@ -100,7 +100,7 @@ TEST_F(SupervisionControlClient_UT, SupervisionControlClient_QueueMaxNumberOfEve
         auto result = receiver_->getNextSupervisionEvent();
         ASSERT_TRUE(result.has_value());
         ASSERT_TRUE(result->has_value());
-        EXPECT_EQ(result->value().id, score::lcm::IdentifierHash("Process" + std::to_string(i)));
+        EXPECT_EQ(result->value().id, score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)));
     }
 
     auto no_more = receiver_->getNextSupervisionEvent();
@@ -115,15 +115,15 @@ TEST_F(SupervisionControlClient_UT, SupervisionControlClient_QueueOneEventTooMan
         "This test verifies that attempting to queue a SupervisionEvent when the buffer is already at maximum capacity "
         "results in a failure, and that no additional events can be retrieved from the receiver.");
     SupervisionEvent event1{
-        .id = score::lcm::IdentifierHash("Process1"),
-        .eventType = score::lcm::SupervisionEventType::kActivation,
+        .id = score::mw::lifecycle::IdentifierHash("Process1"),
+        .eventType = score::mw::lifecycle::SupervisionEventType::kActivation,
         .systemClockTimestamp = {}};
 
     for (size_t i = 0; i < static_cast<size_t>(BufferConstants::BUFFER_QUEUE_SIZE); ++i)
     {
         SupervisionEvent event{
-            .id = score::lcm::IdentifierHash("Process" + std::to_string(i)),
-            .eventType = score::lcm::SupervisionEventType::kActivation,
+            .id = score::mw::lifecycle::IdentifierHash("Process" + std::to_string(i)),
+            .eventType = score::mw::lifecycle::SupervisionEventType::kActivation,
             .systemClockTimestamp = {}};
         bool queued = notifier_->reportActivation(event.id, event.systemClockTimestamp);
         ASSERT_TRUE(queued) << "Failed to queue event at index " << i;

--- a/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.cpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.cpp
@@ -15,16 +15,14 @@
 #include "score/mw/launch_manager/common/log.hpp"
 #include "score/mw/launch_manager/supervision_control_client/details/supervision_control_receiver.hpp"
 
-
-
-namespace score::lcm::internal
+namespace score::mw::lifecycle::internal
 {
 
 SupervisionControlNotifier::SupervisionControlNotifier() noexcept
 {
     ring_buffer_ = std::make_shared<ipc_dropin::RingBuffer<
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>();
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>();
 
     ring_buffer_->initialize();
 }
@@ -43,7 +41,7 @@ bool SupervisionControlNotifier::reportDeactivation(IdentifierHash id, timespec 
     return queueSupervisionEvent({id, SupervisionEventType::kDeactivation, time});
 }
 
-bool SupervisionControlNotifier::queueSupervisionEvent(const score::lcm::SupervisionEvent& f_event) noexcept
+bool SupervisionControlNotifier::queueSupervisionEvent(const score::mw::lifecycle::SupervisionEvent& f_event) noexcept
 {
     bool ret = true;
     if (ring_buffer_->tryEnqueue(f_event))
@@ -58,11 +56,9 @@ bool SupervisionControlNotifier::queueSupervisionEvent(const score::lcm::Supervi
     return ret;
 }
 
-std::unique_ptr<score::lcm::ISupervisionControlReceiver> SupervisionControlNotifier::constructReceiver()
+std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver> SupervisionControlNotifier::constructReceiver()
 {
-    return std::make_unique<score::lcm::SupervisionControlReceiver>(ring_buffer_);
+    return std::make_unique<score::mw::lifecycle::SupervisionControlReceiver>(ring_buffer_);
 }
 
-} // namespace score::lcm::internal
-
-
+}  // namespace score::mw::lifecycle::internal

--- a/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.cpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.cpp
@@ -15,11 +15,9 @@
 #include "score/mw/launch_manager/common/log.hpp"
 #include "score/mw/launch_manager/supervision_control_client/details/supervision_control_receiver.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace internal
+
+
+namespace score::lcm::internal
 {
 
 SupervisionControlNotifier::SupervisionControlNotifier() noexcept
@@ -65,6 +63,6 @@ std::unique_ptr<score::lcm::ISupervisionControlReceiver> SupervisionControlNotif
     return std::make_unique<score::lcm::SupervisionControlReceiver>(ring_buffer_);
 }
 
-}  // namespace internal
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::internal
+
+

--- a/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/supervision_control_notifier.hpp
@@ -21,7 +21,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace internal
@@ -53,7 +53,7 @@ class SupervisionControlNotifier final : public ISupervisionControlNotifier
 
     /// @brief Construct and return the receiver instance used to receive supervision events.
     /// @return Supervision control receiver instance
-    std::unique_ptr<score::lcm::ISupervisionControlReceiver> constructReceiver() override;
+    std::unique_ptr<score::mw::lifecycle::ISupervisionControlReceiver> constructReceiver() override;
 
     /// @brief Report that process with @param id has reached the active state at @param time
     bool reportActivation(IdentifierHash id, timespec time) noexcept override;
@@ -65,18 +65,18 @@ class SupervisionControlNotifier final : public ISupervisionControlNotifier
     /// @brief Writes via IPC the latest supervision event, so that the alive monitor can be informed about it.
     /// @param[in]   f_event   The SupervisionEvent to be queued
     /// @returns True on success, false for failure
-    bool queueSupervisionEvent(const score::lcm::SupervisionEvent& f_event) noexcept;
+    bool queueSupervisionEvent(const score::mw::lifecycle::SupervisionEvent& f_event) noexcept;
 
     /// @brief Ring buffer through which supervision events are forwarded to the alive monitor
     std::shared_ptr<ipc_dropin::RingBuffer<
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_QUEUE_SIZE),
-        static_cast<size_t>(score::lcm::BufferConstants::BUFFER_MAXPAYLOAD)>>
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_QUEUE_SIZE),
+        static_cast<size_t>(score::mw::lifecycle::BufferConstants::BUFFER_MAXPAYLOAD)>>
         ring_buffer_{};
 };
 
 }  // namespace internal
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 #endif

--- a/score/launch_manager/src/daemon/src/supervision_control_client/supervision_event.hpp
+++ b/score/launch_manager/src/daemon/src/supervision_control_client/supervision_event.hpp
@@ -21,7 +21,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief Type of supervision event sent from the launch manager to the alive monitor.
@@ -36,7 +36,7 @@ enum class SupervisionEventType : std::uint8_t
 struct SupervisionEvent
 {
     /// @brief Stores the Modelled Process ID as IdentifierHash.
-    score::lcm::IdentifierHash id;
+    score::mw::lifecycle::IdentifierHash id;
 
     /// @brief The type of supervision event.
     SupervisionEventType eventType;
@@ -55,7 +55,7 @@ constexpr std::size_t BUFFER_QUEUE_SIZE = 4096UL;
 
 }  // namespace BufferConstants
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -25,7 +25,7 @@ struct WatchdogConfig;
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace watchdog
 {
@@ -56,7 +56,7 @@ class IWatchdogIf
     /// The main loop cycle time must be strictly less than the minimum watchdog timeout to ensure that
     /// the watchdog timeout cannot expire during an unblocked run of the main loop.
     static_assert(
-        score::lcm::internal::kMainLoopCycleTimeMs < kTimeoutMinMillis,
+        score::mw::lifecycle::internal::kMainLoopCycleTimeMs < kTimeoutMinMillis,
         "Main loop cycle time must be less than the minimum watchdog timeout");
 
     /// @brief Destructor.
@@ -137,7 +137,7 @@ class IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -18,14 +18,14 @@
 
 #include <cstdint>
 
-namespace score::mw::lifecycle::configuration
+namespace score::mw::lifecycle::internal::configuration
 {
 struct WatchdogConfig;
 }
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace watchdog
 {
@@ -79,7 +79,7 @@ class IWatchdogIf
     /// @return Status of configuration. True if watchdog configuration is valid and has been successfully taken over
     /// by the Watchdog Interface library, false otherwise.
     virtual bool init(
-        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::internal::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept = 0;
 
     /// @brief Activate the watchdog.
@@ -137,7 +137,7 @@ class IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/IWatchdogIf.hpp
@@ -18,7 +18,7 @@
 
 #include <cstdint>
 
-namespace score::mw::launch_manager::configuration
+namespace score::mw::lifecycle::configuration
 {
 struct WatchdogConfig;
 }
@@ -79,7 +79,7 @@ class IWatchdogIf
     /// @return Status of configuration. True if watchdog configuration is valid and has been successfully taken over
     /// by the Watchdog Interface library, false otherwise.
     virtual bool init(
-        const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept = 0;
 
     /// @brief Activate the watchdog.

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
@@ -15,7 +15,7 @@
 
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-namespace score::mw::lifecycle::watchdog
+namespace score::mw::lifecycle::internal::watchdog
 {
 
 std::unique_ptr<IWatchdogIf> createWatchdog()
@@ -23,4 +23,4 @@ std::unique_ptr<IWatchdogIf> createWatchdog()
     return std::make_unique<WatchdogImpl>();
 }
 
-}  // namespace score::mw::lifecycle::watchdog
+}  // namespace score::mw::lifecycle::internal::watchdog

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
@@ -15,11 +15,9 @@
 
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace watchdog
+
+
+namespace score::lcm::watchdog
 {
 
 std::unique_ptr<IWatchdogIf> createWatchdog()
@@ -27,6 +25,6 @@ std::unique_ptr<IWatchdogIf> createWatchdog()
     return std::make_unique<WatchdogImpl>();
 }
 
-}  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::watchdog
+
+

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.cpp
@@ -15,9 +15,7 @@
 
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-
-
-namespace score::lcm::watchdog
+namespace score::mw::lifecycle::watchdog
 {
 
 std::unique_ptr<IWatchdogIf> createWatchdog()
@@ -25,6 +23,4 @@ std::unique_ptr<IWatchdogIf> createWatchdog()
     return std::make_unique<WatchdogImpl>();
 }
 
-} // namespace score::lcm::watchdog
-
-
+}  // namespace score::mw::lifecycle::watchdog

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace watchdog
 {
@@ -30,7 +30,7 @@ namespace watchdog
 std::unique_ptr<IWatchdogIf> createWatchdog();
 
 }  // namespace watchdog
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace watchdog
 {
@@ -30,7 +30,7 @@ namespace watchdog
 std::unique_ptr<IWatchdogIf> createWatchdog();
 
 }  // namespace watchdog
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
@@ -18,9 +18,9 @@
 #include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-using score::lcm::watchdog::createWatchdog;
-using score::lcm::watchdog::IWatchdogIf;
-using score::lcm::watchdog::WatchdogImpl;
+using score::mw::lifecycle::watchdog::createWatchdog;
+using score::mw::lifecycle::watchdog::IWatchdogIf;
+using score::mw::lifecycle::watchdog::WatchdogImpl;
 
 class WatchdogFactoryTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/WatchdogFactory_UT.cpp
@@ -18,9 +18,9 @@
 #include "score/mw/launch_manager/watchdog/WatchdogFactory.hpp"
 #include "score/mw/launch_manager/watchdog/details/WatchdogImpl.hpp"
 
-using score::mw::lifecycle::watchdog::createWatchdog;
-using score::mw::lifecycle::watchdog::IWatchdogIf;
-using score::mw::lifecycle::watchdog::WatchdogImpl;
+using score::mw::lifecycle::internal::watchdog::createWatchdog;
+using score::mw::lifecycle::internal::watchdog::IWatchdogIf;
+using score::mw::lifecycle::internal::watchdog::WatchdogImpl;
 
 class WatchdogFactoryTest : public ::testing::Test
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -51,7 +51,7 @@ WatchdogImpl::WatchdogImpl(score::os::Ioctl& ioctl, score::os::Fcntl& fcntl, sco
 }
 
 bool WatchdogImpl::init(
-    const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+    const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
     std::int64_t cycle_time_ns) noexcept
 {
     bool isSuccess{true};

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -19,11 +19,9 @@
 #include "score/mw/launch_manager/configuration/config.hpp"
 #include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
 
-namespace score
-{
-namespace lcm
-{
-namespace watchdog
+
+
+namespace score::lcm::watchdog
 {
 
 namespace
@@ -467,6 +465,6 @@ void WatchdogImpl::waitForever() const noexcept
 #pragma CTC ENDSKIP
 #endif
 
-}  // namespace watchdog
-}  // namespace lcm
-}  // namespace score
+} // namespace score::lcm::watchdog
+
+

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -19,9 +19,7 @@
 #include "score/mw/launch_manager/configuration/config.hpp"
 #include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
 
-
-
-namespace score::lcm::watchdog
+namespace score::mw::lifecycle::watchdog
 {
 
 namespace
@@ -451,7 +449,7 @@ bool WatchdogImpl::validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, co
 void WatchdogImpl::waitForever() const noexcept
 {
     // This code cannot be covered in tests, as it blocks execution forever
-    const score::lcm::saf::timers::OsClockInterface clock{};
+    const score::mw::lifecycle::saf::timers::OsClockInterface clock{};
     struct timespec sleeptime = {};
     sleeptime.tv_sec = 1;
     sleeptime.tv_nsec = 0;
@@ -465,6 +463,4 @@ void WatchdogImpl::waitForever() const noexcept
 #pragma CTC ENDSKIP
 #endif
 
-} // namespace score::lcm::watchdog
-
-
+}  // namespace score::mw::lifecycle::watchdog

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.cpp
@@ -19,7 +19,7 @@
 #include "score/mw/launch_manager/configuration/config.hpp"
 #include "score/mw/launch_manager/watchdog/details/Watchdog.hpp"
 
-namespace score::mw::lifecycle::watchdog
+namespace score::mw::lifecycle::internal::watchdog
 {
 
 namespace
@@ -51,7 +51,7 @@ WatchdogImpl::WatchdogImpl(score::os::Ioctl& ioctl, score::os::Fcntl& fcntl, sco
 }
 
 bool WatchdogImpl::init(
-    const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
+    const score::mw::lifecycle::internal::configuration::WatchdogConfig& watchdog_config,
     std::int64_t cycle_time_ns) noexcept
 {
     bool isSuccess{true};
@@ -449,7 +449,7 @@ bool WatchdogImpl::validateTimeoutWithCycleTime(std::int64_t f_cycleTimeInNs, co
 void WatchdogImpl::waitForever() const noexcept
 {
     // This code cannot be covered in tests, as it blocks execution forever
-    const score::mw::lifecycle::saf::timers::OsClockInterface clock{};
+    const score::mw::lifecycle::internal::saf::timers::OsClockInterface clock{};
     struct timespec sleeptime = {};
     sleeptime.tv_sec = 1;
     sleeptime.tv_nsec = 0;
@@ -463,4 +463,4 @@ void WatchdogImpl::waitForever() const noexcept
 #pragma CTC ENDSKIP
 #endif
 
-}  // namespace score::mw::lifecycle::watchdog
+}  // namespace score::mw::lifecycle::internal::watchdog

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -29,6 +29,9 @@ namespace score
 namespace mw::lifecycle
 {
 
+namespace internal
+{
+
 namespace watchdog
 {
 
@@ -70,7 +73,7 @@ class WatchdogImpl : public IWatchdogIf
 
     /// @copydoc IWatchdogIf::init()
     bool init(
-        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::internal::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept override;
 
     /// @copydoc IWatchdogIf::enable()
@@ -235,6 +238,7 @@ class WatchdogImpl : public IWatchdogIf
 };
 
 }  // namespace watchdog
+}  // namespace internal
 }  // namespace mw::lifecycle
 }  // namespace score
 

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -26,7 +26,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 
 namespace watchdog
@@ -235,7 +235,7 @@ class WatchdogImpl : public IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl.hpp
@@ -70,7 +70,7 @@ class WatchdogImpl : public IWatchdogIf
 
     /// @copydoc IWatchdogIf::init()
     bool init(
-        const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config,
+        const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config,
         std::int64_t cycle_time_ns) noexcept override;
 
     /// @copydoc IWatchdogIf::enable()

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -32,9 +32,9 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::StrEq;
 
-using score::mw::lifecycle::configuration::WatchdogConfig;
-using score::mw::lifecycle::watchdog::IWatchdogIf;
-using score::mw::lifecycle::watchdog::WatchdogImpl;
+using score::mw::lifecycle::internal::configuration::WatchdogConfig;
+using score::mw::lifecycle::internal::watchdog::IWatchdogIf;
+using score::mw::lifecycle::internal::watchdog::WatchdogImpl;
 
 namespace
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -32,9 +32,9 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::StrEq;
 
-using score::lcm::watchdog::IWatchdogIf;
-using score::lcm::watchdog::WatchdogImpl;
 using score::mw::launch_manager::configuration::WatchdogConfig;
+using score::mw::lifecycle::watchdog::IWatchdogIf;
+using score::mw::lifecycle::watchdog::WatchdogImpl;
 
 namespace
 {

--- a/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
+++ b/score/launch_manager/src/daemon/src/watchdog/details/WatchdogImpl_UT.cpp
@@ -32,7 +32,7 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::StrEq;
 
-using score::mw::launch_manager::configuration::WatchdogConfig;
+using score::mw::lifecycle::configuration::WatchdogConfig;
 using score::mw::lifecycle::watchdog::IWatchdogIf;
 using score::mw::lifecycle::watchdog::WatchdogImpl;
 

--- a/score/launch_manager/src/daemon/src/watchdog/mock_IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/mock_IWatchdogIf.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace mw::lifecycle
+namespace mw::lifecycle::internal
 {
 namespace watchdog
 {
@@ -34,7 +34,8 @@ class MockWatchdogIf : public IWatchdogIf
     MOCK_METHOD(
         bool,
         init,
-        (const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config, std::int64_t cycle_time_ns),
+        (const score::mw::lifecycle::internal::configuration::WatchdogConfig& watchdog_config,
+         std::int64_t cycle_time_ns),
         (noexcept, override));
     MOCK_METHOD(bool, enable, (), (noexcept, override));
     MOCK_METHOD(void, disable, (), (noexcept, override));
@@ -43,7 +44,7 @@ class MockWatchdogIf : public IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace mw::lifecycle
+}  // namespace mw::lifecycle::internal
 }  // namespace score
 
 #endif  // IWATCHDOGIFMOCK_HPP_INCLUDED

--- a/score/launch_manager/src/daemon/src/watchdog/mock_IWatchdogIf.hpp
+++ b/score/launch_manager/src/daemon/src/watchdog/mock_IWatchdogIf.hpp
@@ -20,7 +20,7 @@
 
 namespace score
 {
-namespace lcm
+namespace mw::lifecycle
 {
 namespace watchdog
 {
@@ -34,7 +34,7 @@ class MockWatchdogIf : public IWatchdogIf
     MOCK_METHOD(
         bool,
         init,
-        (const score::mw::launch_manager::configuration::WatchdogConfig& watchdog_config, std::int64_t cycle_time_ns),
+        (const score::mw::lifecycle::configuration::WatchdogConfig& watchdog_config, std::int64_t cycle_time_ns),
         (noexcept, override));
     MOCK_METHOD(bool, enable, (), (noexcept, override));
     MOCK_METHOD(void, disable, (), (noexcept, override));
@@ -43,7 +43,7 @@ class MockWatchdogIf : public IWatchdogIf
 };
 
 }  // namespace watchdog
-}  // namespace lcm
+}  // namespace mw::lifecycle
 }  // namespace score
 
 #endif  // IWATCHDOGIFMOCK_HPP_INCLUDED

--- a/score/launch_manager/src/execution_error_event.h
+++ b/score/launch_manager/src/execution_error_event.h
@@ -21,7 +21,7 @@
 namespace score
 {
 
-namespace lcm
+namespace mw::lifecycle
 {
 
 /// @brief Represents the execution error.
@@ -41,7 +41,7 @@ struct ExecutionErrorEvent final
     IdentifierHash processGroup;
 };
 
-}  // namespace lcm
+}  // namespace mw::lifecycle
 
 }  // namespace score
 

--- a/score/launch_manager/src/lifecycle_client/src/aasapplicationcontainer.cpp
+++ b/score/launch_manager/src/lifecycle_client/src/aasapplicationcontainer.cpp
@@ -16,8 +16,6 @@
 #include "score/mw/lifecycle/lifecyclemanager.h"
 #include <score/jthread.hpp>
 
-
-
 namespace score::mw::lifecycle
 {
 
@@ -130,6 +128,4 @@ std::int32_t AasApplicationContainer::Launch()
     return lifecycle_manager.run(*this, context_);
 }
 
-} // namespace score::mw::lifecycle
-
-
+}  // namespace score::mw::lifecycle

--- a/score/launch_manager/src/lifecycle_client/src/aasapplicationcontainer.cpp
+++ b/score/launch_manager/src/lifecycle_client/src/aasapplicationcontainer.cpp
@@ -16,11 +16,9 @@
 #include "score/mw/lifecycle/lifecyclemanager.h"
 #include <score/jthread.hpp>
 
-namespace score
-{
-namespace mw
-{
-namespace lifecycle
+
+
+namespace score::mw::lifecycle
 {
 
 AasApplicationContainer::AasApplicationContainer(
@@ -132,6 +130,6 @@ std::int32_t AasApplicationContainer::Launch()
     return lifecycle_manager.run(*this, context_);
 }
 
-}  // namespace lifecycle
-}  // namespace mw
-}  // namespace score
+} // namespace score::mw::lifecycle
+
+

--- a/score/launch_manager/src/lifecycle_client/src/details/report_running_impl.cpp
+++ b/score/launch_manager/src/lifecycle_client/src/details/report_running_impl.cpp
@@ -25,7 +25,7 @@
 #include "score/mw/lifecycle/execution_error.h"
 #include "score/mw/lifecycle/lifecycle_client/details/report_running_impl.hpp"
 
-using namespace score::lcm::internal::osal;
+using namespace score::mw::lifecycle::internal::osal;
 
 namespace score::mw::lifecycle
 {
@@ -103,7 +103,7 @@ score::Result<std::monostate> ReportRunningImpl::reportKRunningtoDaemon() const 
         return comms_error;
     }
 
-    if (sync->reply_sync_.timedWait(score::lcm::internal::kMaxRunningDelay) == OsalReturnType::kFail)
+    if (sync->reply_sync_.timedWait(score::mw::lifecycle::internal::kMaxRunningDelay) == OsalReturnType::kFail)
     {
         LM_LOG_ERROR() << "[Lifecycle Client] Launch Manager failed to acknowledge kRunning report.";
 

--- a/tests/integration/incorrect_config_non_reporting/non_reporting_process.cpp
+++ b/tests/integration/incorrect_config_non_reporting/non_reporting_process.cpp
@@ -24,7 +24,7 @@
 
 TEST(NonReporting, Process)
 {
-    using ipc = score::lcm::internal::osal::IpcCommsSync;
+    using ipc = score::mw::lifecycle::internal::osal::IpcCommsSync;
 
     // Map the sync_fd to some shared memory of size 0. With sync_fd=111, this is likely to happen by default
     // As there is no comms channel, using sync_fd in this process should not cause a crash.


### PR DESCRIPTION
- `score::lcm` replaced with `score::mw::lifecycle`
- `score::mw::launch_manager` replaced with `score::mw::lifecycle`
- Remove `using namespaces`s from headers
- `.clang-tidy` had a syntax error, this has been fixed

Resolves #411 